### PR TITLE
feat: Add fill tool for drawing canvas

### DIFF
--- a/app/game.tsx
+++ b/app/game.tsx
@@ -124,6 +124,7 @@ export default function GameScreen() {
         <DrawingCanvas
           strokeColor={drawing.color}
           strokeWidth={drawing.strokeWidth}
+          tool={drawing.tool}
           paths={drawing.paths}
           onDrawingChange={drawing.setPaths}
         />
@@ -153,33 +154,54 @@ export default function GameScreen() {
         })()}
       </View>
 
-      {/* Linienstärke-Auswahl */}
-      <View style={styles.strokeWidthContainer}>
-        <Text style={styles.strokeWidthLabel}>Strichstärke:</Text>
-        <View style={styles.strokeWidthButtons}>
+      {/* Tool-Auswahl: Pinsel / Füllen */}
+      <View style={styles.toolContainer}>
+        <Text style={styles.toolLabel}>{t('game.draw.tool')}:</Text>
+        <View style={styles.toolButtons}>
           <TouchableOpacity
-            style={[styles.strokeWidthButton, drawing.strokeWidth === 2 && styles.strokeWidthButtonActive]}
-            onPress={() => drawing.setStrokeWidth(2)}
+            style={[styles.toolButton, drawing.tool === 'brush' && styles.toolButtonActive]}
+            onPress={() => drawing.setTool('brush')}
           >
-            <View style={[styles.strokeWidthPreview, { height: 2 }]} />
-            <Text style={[styles.strokeWidthButtonText, drawing.strokeWidth === 2 && styles.strokeWidthButtonTextActive]}>Dünn</Text>
+            <Text style={[styles.toolButtonText, drawing.tool === 'brush' && styles.toolButtonTextActive]}>{t('game.draw.toolBrush')}</Text>
           </TouchableOpacity>
           <TouchableOpacity
-            style={[styles.strokeWidthButton, drawing.strokeWidth === 3 && styles.strokeWidthButtonActive]}
-            onPress={() => drawing.setStrokeWidth(3)}
+            style={[styles.toolButton, drawing.tool === 'fill' && styles.toolButtonActive]}
+            onPress={() => drawing.setTool('fill')}
           >
-            <View style={[styles.strokeWidthPreview, { height: 3 }]} />
-            <Text style={[styles.strokeWidthButtonText, drawing.strokeWidth === 3 && styles.strokeWidthButtonTextActive]}>Normal</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={[styles.strokeWidthButton, drawing.strokeWidth === 5 && styles.strokeWidthButtonActive]}
-            onPress={() => drawing.setStrokeWidth(5)}
-          >
-            <View style={[styles.strokeWidthPreview, { height: 5 }]} />
-            <Text style={[styles.strokeWidthButtonText, drawing.strokeWidth === 5 && styles.strokeWidthButtonTextActive]}>Dick</Text>
+            <Text style={[styles.toolButtonText, drawing.tool === 'fill' && styles.toolButtonTextActive]}>{t('game.draw.toolFill')}</Text>
           </TouchableOpacity>
         </View>
       </View>
+
+      {/* Linienstärke-Auswahl (nur bei Pinsel-Werkzeug) */}
+      {drawing.tool === 'brush' && (
+        <View style={styles.strokeWidthContainer}>
+          <Text style={styles.strokeWidthLabel}>{t('game.draw.strokeWidth')}:</Text>
+          <View style={styles.strokeWidthButtons}>
+            <TouchableOpacity
+              style={[styles.strokeWidthButton, drawing.strokeWidth === 2 && styles.strokeWidthButtonActive]}
+              onPress={() => drawing.setStrokeWidth(2)}
+            >
+              <View style={[styles.strokeWidthPreview, { height: 2 }]} />
+              <Text style={[styles.strokeWidthButtonText, drawing.strokeWidth === 2 && styles.strokeWidthButtonTextActive]}>{t('game.draw.strokeWidthThin')}</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.strokeWidthButton, drawing.strokeWidth === 3 && styles.strokeWidthButtonActive]}
+              onPress={() => drawing.setStrokeWidth(3)}
+            >
+              <View style={[styles.strokeWidthPreview, { height: 3 }]} />
+              <Text style={[styles.strokeWidthButtonText, drawing.strokeWidth === 3 && styles.strokeWidthButtonTextActive]}>{t('game.draw.strokeWidthNormal')}</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.strokeWidthButton, drawing.strokeWidth === 5 && styles.strokeWidthButtonActive]}
+              onPress={() => drawing.setStrokeWidth(5)}
+            >
+              <View style={[styles.strokeWidthPreview, { height: 5 }]} />
+              <Text style={[styles.strokeWidthButtonText, drawing.strokeWidth === 5 && styles.strokeWidthButtonTextActive]}>{t('game.draw.strokeWidthThick')}</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      )}
 
       {/* Buttons */}
       <View style={styles.buttonRow}>
@@ -805,6 +827,42 @@ const styles = StyleSheet.create({
   },
   navButtonTextDisabled: {
     color: Colors.text.light,
+  },
+  toolContainer: {
+    marginBottom: Spacing.md,
+    alignItems: 'center',
+  },
+  toolLabel: {
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.semibold,
+    color: Colors.text.secondary,
+    marginBottom: Spacing.sm,
+  },
+  toolButtons: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+  },
+  toolButton: {
+    backgroundColor: Colors.surface,
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.lg,
+    borderRadius: BorderRadius.md,
+    alignItems: 'center',
+    borderWidth: 2,
+    borderColor: Colors.surface,
+    minWidth: 80,
+  },
+  toolButtonActive: {
+    backgroundColor: Colors.primary,
+    borderColor: Colors.primary,
+  },
+  toolButtonText: {
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.semibold,
+    color: Colors.text.primary,
+  },
+  toolButtonTextActive: {
+    color: Colors.background,
   },
   strokeWidthContainer: {
     marginBottom: Spacing.lg,

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -27,6 +27,13 @@
     "draw": {
       "title": "Male das Bild nach!",
       "hint": "Benutze die Farben und male was du dir gemerkt hast",
+      "tool": "Werkzeug",
+      "toolBrush": "Pinsel",
+      "toolFill": "Füllen",
+      "strokeWidth": "Strichstärke",
+      "strokeWidthThin": "Dünn",
+      "strokeWidthNormal": "Normal",
+      "strokeWidthThick": "Dick",
       "undo": "Rückgängig",
       "clear": "Alles löschen",
       "clearConfirm": "Wirklich alles löschen?",

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -27,6 +27,13 @@
     "draw": {
       "title": "Draw the picture!",
       "hint": "Use the colors and draw what you remember",
+      "tool": "Tool",
+      "toolBrush": "Brush",
+      "toolFill": "Fill",
+      "strokeWidth": "Stroke Width",
+      "strokeWidthThin": "Thin",
+      "strokeWidthNormal": "Normal",
+      "strokeWidthThick": "Thick",
       "undo": "Undo",
       "clear": "Clear all",
       "clearConfirm": "Really clear everything?",


### PR DESCRIPTION
## Summary
Adds a fill tool to the drawing canvas, allowing users to fill enclosed areas with color instead of just drawing strokes.

## Changes
- ✨ **New Feature:** Fill tool with brush/fill selector UI
- 🌐 **Web Implementation:** Stack-based flood-fill algorithm with color tolerance
- 📱 **Native Implementation:** Simplified circle-fill for react-native-skia
- 🌍 **Internationalization:** Added DE/EN translations for tool labels
- 🎨 **UI Improvements:** Tool selector buttons with active states
- ♻️ **Undo Support:** Fill operations are fully undoable

## Technical Details

### Web (HTML5 Canvas)
- Stack-based flood-fill algorithm (non-recursive for performance)
- Color tolerance of ±2 RGB values for better boundary detection
- Canvas pre-filled with white background for consistent behavior

### Native (react-native-skia)
- Simplified implementation using filled circles at tap position
- Radius: 30px (adjustable)
- Future enhancement: Full flood-fill for native platform

### Data Structure
```typescript
DrawingPath {
  points: Point[];
  color: string;
  strokeWidth: number;
  type?: 'stroke' | 'fill'; // New field
}
```

## UI Changes
- Tool selector above color palette (Brush/Fill buttons)
- Stroke width selector only visible when brush tool is active
- Buttons follow Material Design 3 style from settings

## Testing
- ✅ Web: Flood-fill works correctly with undo/redo
- ⏳ Native: Needs testing on mobile device (Expo Go)
- ✅ Translations: Both DE and EN labels display correctly
- ✅ Backward compatibility: Existing drawings load without issues

## Screenshots
_Testing on localhost:8081 shows functional fill tool_

## Related Issues
Addresses part of #29 (Fill tool feature request)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)