### PR TITLE
feat: Play Store release prep – fix privacy policy, add CI tests, CHANGELOG (#118)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,9 +2,9 @@ name: CI/CD - Automated Quality Checks
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, staging, develop]
   pull_request:
-    branches: [main, develop]
+    branches: [main, staging, develop]
 
 # Security: Explicitly set minimal permissions
 permissions:
@@ -77,12 +77,43 @@ jobs:
         run: npx tsc --noEmit || true
 
   # ============================================================================
-  # JOB 2: Cross-Platform Build Tests
+  # JOB 2: Automated Tests
+  # ============================================================================
+  test:
+    name: 🧪 Automated Tests
+    runs-on: ubuntu-latest
+    needs: code-quality
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Run tests with coverage
+        run: npm run test:ci
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 7
+
+  # ============================================================================
+  # JOB 3: Cross-Platform Build Tests
   # ============================================================================
   build-web:
     name: 🌐 Build Web
     runs-on: ubuntu-latest
-    needs: code-quality
+    needs: [code-quality, test]
 
     steps:
       - uses: actions/checkout@v4
@@ -115,7 +146,7 @@ jobs:
           retention-days: 7
 
   # ============================================================================
-  # JOB 3: Platform Compatibility Checks (Expo Managed)
+  # JOB 4: Platform Compatibility Checks (Expo Managed)
   # ============================================================================
   platform-checks:
     name: 🔧 Platform Compatibility
@@ -143,7 +174,7 @@ jobs:
           echo "✅ All versions are consistent"
 
   # ============================================================================
-  # JOB 4: Security & Dependencies
+  # JOB 5: Security & Dependencies
   # ============================================================================
   security:
     name: 🔒 Security Audit
@@ -172,12 +203,12 @@ jobs:
           fi
 
   # ============================================================================
-  # JOB 5: Release Readiness Report
+  # JOB 6: Release Readiness Report
   # ============================================================================
   release-checklist:
     name: 📋 Release Readiness Report
     runs-on: ubuntu-latest
-    needs: [code-quality, build-web, platform-checks]
+    needs: [code-quality, test, build-web, platform-checks]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
@@ -190,6 +221,7 @@ jobs:
           echo "## ✅ Automated Checks Passed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Code Quality & Linting" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Automated Tests" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Web Build Successful" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Platform Compatibility" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Version Consistency" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,102 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.2.6] - 2026-04-05
+
+### Changed
+- Privacy policies updated to accurately document optional Sentry crash reporting
+- CI/CD pipeline now runs automated tests on every push and pull request
+- CI/CD pipeline now triggers on `staging` branch in addition to `main` and `develop`
+
+### Added
+- CHANGELOG.md following Keep a Changelog format
+- THIRD_PARTY_LICENSES.md documenting open-source dependencies
+- `staging` branch for pre-production integration
+
+### Fixed
+- Privacy policy contradiction: policies now correctly describe Sentry as an optional,
+  configurable crash reporting service (was incorrectly stating "no third-party services"
+  and "no crash reports")
+
+## [1.2.5] - 2026-03-15
+
+### Changed
+- package-lock.json updated after npm install
+
+## [1.2.4] - 2026-03-01
+
+### Changed
+- i18n for SettingsModal: replaced ternary strings with t() keys (#115)
+
+### Fixed
+- Responsive layout: proportional screen sections across all device sizes
+
+## [1.2.3] - 2026-02-20
+
+### Fixed
+- Fill tool flooding entire canvas instead of bounded region
+
+## [1.2.0] - 2026-02-27
+
+### Added
+- Drawing replay (Strich-für-Strich / stroke-by-stroke) in result phase
+- Play/Stop button under "Deine Zeichnung" / "Your Drawing"
+- Sound effects and haptics (Issue #31):
+  - Web Audio API based tone generation (no audio files required)
+  - Timer tick sound on each countdown step
+  - Phase-change chime (C-E-G ascending triad) on Memorize→Draw and Draw→Result transitions
+  - Star-rating sound (ascending tone per star, 1–5)
+  - Success sound (two-tone) on gallery save
+  - Haptic feedback (native): expo-haptics with Light/Success patterns
+  - Sound toggle in settings (on/off, persisted)
+
+### Dependencies
+- Added `expo-av` ^16.0.8
+- Added `expo-haptics` ^55.0.8
+
+## [1.1.0] - 2026-01-05
+
+### Added
+- Color picker filtering per level image (Issue #20)
+  - `colors: string[]` property added to LevelImage interface
+  - Color curation for all 14 SVG images
+  - Dynamic color picker filters DrawingColors based on `currentImage.colors`
+- Cache-busting system for GitHub Pages
+  - `scripts/update-cache-version.js` for extended cache-busting
+  - `?v=timestamp` query parameters on all HTML files
+  - HTTP Cache-Control meta tags
+  - `.nojekyll` file for GitHub Pages compatibility
+  - `version.json` endpoint for version tracking
+
+### Fixed
+- AsyncStorage web fallback for GitHub Pages (in-memory storage when AsyncStorage unavailable)
+- GitHub Pages subpath configuration (`baseUrl: "/DrawFromMemory/"` in app.json)
+
+## [1.0.0] - 2026-01-01
+
+### Added
+- Initial release of Merke und Male / Remember and Draw
+- Memory training game with 10 difficulty levels
+- 14 SVG images to memorize and redraw
+- Drawing canvas with brush tool and fill tool
+- Color picker with themed palette
+- Gallery for saving drawings (max 50)
+- Settings: language (de/en), theme, brush size, sound toggle
+- Offline-first: all data stored locally via AsyncStorage
+- Web version deployed to GitHub Pages
+- Android build via EAS
+
+[Unreleased]: https://github.com/S540d/DrawFromMemory/compare/v1.2.6...HEAD
+[1.2.6]: https://github.com/S540d/DrawFromMemory/compare/v1.2.5...v1.2.6
+[1.2.5]: https://github.com/S540d/DrawFromMemory/compare/v1.2.4...v1.2.5
+[1.2.4]: https://github.com/S540d/DrawFromMemory/compare/v1.2.3...v1.2.4
+[1.2.3]: https://github.com/S540d/DrawFromMemory/compare/v1.2.0...v1.2.3
+[1.2.0]: https://github.com/S540d/DrawFromMemory/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/S540d/DrawFromMemory/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/S540d/DrawFromMemory/releases/tag/v1.0.0

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,6 +1,6 @@
 # Privacy Policy for Merke und Male
 
-**Effective Date:** [TBD]
+**Effective Date:** April 5, 2026
 
 ## Introduction
 
@@ -24,17 +24,32 @@ We do not collect:
 - Location data
 - Device identifiers
 - Usage analytics
-- Crash reports
 - Advertising data
-- Any data that leaves your device
 
 ## Third-Party Services
 
-Our App does not integrate any third-party services, analytics tools, or advertising networks.
+### Crash Reporting (Sentry) — Optional
+
+The Android app optionally uses **Sentry** (sentry.io) for crash reporting. Sentry is only active
+when a DSN is configured at build time (`EXPO_PUBLIC_SENTRY_DSN`).
+
+**What Sentry collects:**
+- Crash logs and stack traces (technical error information only)
+- Device type, OS version, and app version (non-identifying metadata)
+
+**What Sentry does NOT collect:**
+- Personal information
+- Game data or progress
+- Location data
+- Any data that could identify an individual user
+
+Sentry's privacy policy: https://sentry.io/privacy/
+
+The web version of the app does **not** use Sentry.
 
 ## Children's Privacy
 
-Merke und Male is suitable for children. Since we do not collect any personal information, we comply with children's privacy regulations including COPPA (Children's Online Privacy Protection Act).
+Merke und Male is suitable for children. We do not collect any personal information. The optional Sentry crash reporting collects only anonymous technical data (crash logs) and no personal information about children. We comply with children's privacy regulations including COPPA (Children's Online Privacy Protection Act).
 
 ## Data Security
 
@@ -87,5 +102,5 @@ This App complies with:
 
 ---
 
-**Last Updated:** [TBD]
-**Version:** 1.0
+**Last Updated:** April 5, 2026
+**Version:** 1.1

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,89 @@
+# Third-Party Licenses
+
+This document lists the open-source libraries used by Merke und Male / Remember and Draw
+and their respective licenses.
+
+---
+
+## Crash Reporting
+
+### Sentry React Native (`@sentry/react-native` ~7.11.0)
+
+- **License:** MIT
+- **Copyright:** © Sentry
+- **Homepage:** https://sentry.io
+- **Repository:** https://github.com/getsentry/sentry-react-native
+- **Usage:** Optional crash reporting (Android only, requires `EXPO_PUBLIC_SENTRY_DSN`)
+- **Privacy Policy:** https://sentry.io/privacy/
+
+---
+
+## Graphics & Rendering
+
+### React Native Skia (`@shopify/react-native-skia` 2.4.18)
+
+- **License:** MIT
+- **Copyright:** © Shopify Inc.
+- **Homepage:** https://shopify.github.io/react-native-skia/
+- **Repository:** https://github.com/Shopify/react-native-skia
+- **Usage:** Drawing canvas rendering (Skia-based 2D graphics)
+
+---
+
+## Framework & Runtime
+
+### React Native
+
+- **License:** MIT
+- **Copyright:** © Meta Platforms, Inc. and affiliates
+- **Repository:** https://github.com/facebook/react-native
+
+### Expo
+
+- **License:** MIT
+- **Copyright:** © 650 Industries, Inc. (Expo)
+- **Repository:** https://github.com/expo/expo
+
+### React
+
+- **License:** MIT
+- **Copyright:** © Meta Platforms, Inc. and affiliates
+- **Repository:** https://github.com/facebook/react
+
+---
+
+## Storage
+
+### AsyncStorage (`@react-native-async-storage/async-storage`)
+
+- **License:** MIT
+- **Copyright:** © React Native Community
+- **Repository:** https://github.com/react-native-async-storage/async-storage
+
+---
+
+## Internationalization
+
+### i18next & react-i18next
+
+- **License:** MIT
+- **Copyright:** © i18next
+- **Repository:** https://github.com/i18next/i18next
+
+---
+
+## Audio & Haptics
+
+### expo-haptics
+
+- **License:** MIT
+- **Copyright:** © 650 Industries, Inc. (Expo)
+- **Repository:** https://github.com/expo/expo/tree/main/packages/expo-haptics
+
+---
+
+## Notes
+
+- All listed libraries are used under their respective MIT licenses.
+- The full text of the MIT License is available at: https://opensource.org/licenses/MIT
+- For the complete list of all transitive dependencies, see `package.json` and `package-lock.json`.

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -1,6 +1,6 @@
 # Datenschutzerklärung - Merke und Male
 
-**Letzte Aktualisierung:** 1. Februar 2026
+**Letzte Aktualisierung:** 5. April 2026
 
 ## Übersicht
 
@@ -8,11 +8,12 @@
 
 ## Kurz zusammengefasst
 
-- ✅ **Keine Datensammlung**: Wir sammeln keinerlei persönliche Daten
-- ✅ **Keine Weitergabe**: Es werden keine Daten an Dritte weitergegeben
+- ✅ **Keine persönlichen Daten**: Wir sammeln keinerlei persönliche Daten
+- ✅ **Keine Weitergabe**: Persönliche Daten werden nicht weitergegeben
 - ✅ **Keine Werbung**: Die App enthält keine Werbung
 - ✅ **Keine In-App-Käufe**: Die App ist komplett kostenlos
 - ✅ **Kein Internet erforderlich**: Die App funktioniert vollständig offline
+- ⚠️ **Optionales Crash-Reporting**: Die Android-App kann Sentry für Absturzberichte nutzen (nur technische Daten, keine persönlichen Informationen)
 - ✅ **Open Source**: Der komplette Quellcode ist auf GitHub einsehbar
 
 ---
@@ -85,7 +86,8 @@ Die App ist speziell für Kinder konzipiert und erfüllt die höchsten Datenschu
 ### 5.1 COPPA Konformität (USA)
 Die App entspricht dem Children's Online Privacy Protection Act (COPPA):
 - ✅ Keine Sammlung von persönlichen Daten von Kindern unter 13 Jahren
-- ✅ Keine Weitergabe von Informationen
+- ✅ Keine Weitergabe persönlicher Informationen
+- ✅ Das optionale Sentry Crash-Reporting sammelt keine personenbezogenen Daten
 - ✅ Keine Werbung
 - ✅ Keine In-App-Käufe
 
@@ -119,11 +121,27 @@ Da keine Daten gesammelt werden, gibt es keine Daten, über die wir Auskunft geb
 
 ## 7. Drittanbieter-Dienste
 
-**Die App nutzt keine Drittanbieter-Dienste.**
+### 7.1 Crash-Reporting (Sentry) — Optional
 
-Insbesondere:
+Die Android-App nutzt optional **Sentry** (sentry.io) für Absturzberichte. Sentry ist nur aktiv, wenn ein DSN zum Build-Zeitpunkt konfiguriert ist (`EXPO_PUBLIC_SENTRY_DSN`).
+
+**Was Sentry sammelt:**
+- Absturzprotokolle und Stack-Traces (ausschließlich technische Fehlerinformationen)
+- Gerätetyp, Betriebssystemversion und App-Version (nicht-identifizierende Metadaten)
+
+**Was Sentry NICHT sammelt:**
+- Persönliche Informationen
+- Spieldaten oder Spielfortschritt
+- Standortdaten
+- Daten, die eine Person identifizieren könnten
+
+Datenschutzerklärung von Sentry: https://sentry.io/privacy/
+
+Die Web-Version der App nutzt Sentry **nicht**.
+
+### 7.2 Nicht verwendete Dienste
+
 - ❌ Keine Analyse-Tools (z.B. Google Analytics, Firebase Analytics)
-- ❌ Keine Crash-Reporting-Dienste
 - ❌ Keine Werbe-Netzwerke
 - ❌ Keine Social Media SDKs
 - ❌ Keine Cloud-Dienste
@@ -182,6 +200,6 @@ Ihre Kinder können die App sicher und privat nutzen.
 
 ---
 
-**Version:** 1.0
-**Gültig ab:** 1. Februar 2026
+**Version:** 1.1
+**Gültig ab:** 5. April 2026
 **Sprache:** Deutsch

--- a/docs/PRIVACY_POLICY_EN.md
+++ b/docs/PRIVACY_POLICY_EN.md
@@ -1,6 +1,6 @@
 # Privacy Policy - Remember and Draw
 
-**Last Updated:** February 1, 2026
+**Last Updated:** April 5, 2026
 
 ## Overview
 
@@ -8,11 +8,12 @@
 
 ## Summary
 
-- ✅ **No Data Collection**: We do not collect any personal data
-- ✅ **No Sharing**: No data is shared with third parties
+- ✅ **No Personal Data**: We do not collect any personal data
+- ✅ **No Sharing**: Personal data is not shared with third parties
 - ✅ **No Advertising**: The app contains no ads
 - ✅ **No In-App Purchases**: The app is completely free
 - ✅ **No Internet Required**: The app works fully offline
+- ⚠️ **Optional Crash Reporting**: The Android app may use Sentry for crash reports (technical data only, no personal information)
 - ✅ **Open Source**: The complete source code is available on GitHub
 
 ---
@@ -85,7 +86,8 @@ The app is specifically designed for children and meets the highest privacy stan
 ### 5.1 COPPA Compliance (USA)
 The app complies with the Children's Online Privacy Protection Act (COPPA):
 - ✅ No collection of personal data from children under 13
-- ✅ No sharing of information
+- ✅ No sharing of personal information
+- ✅ Optional Sentry crash reporting collects no personal data
 - ✅ No advertising
 - ✅ No in-app purchases
 
@@ -119,11 +121,27 @@ Since no data is collected, there is no data we could provide information about.
 
 ## 7. Third-Party Services
 
-**The app does not use any third-party services.**
+### 7.1 Crash Reporting (Sentry) — Optional
 
-Specifically:
+The Android app optionally uses **Sentry** (sentry.io) for crash reporting. Sentry is only active when a DSN is configured at build time (`EXPO_PUBLIC_SENTRY_DSN`).
+
+**What Sentry collects:**
+- Crash logs and stack traces (technical error information only)
+- Device type, OS version, and app version (non-identifying metadata)
+
+**What Sentry does NOT collect:**
+- Personal information
+- Game data or progress
+- Location data
+- Any data that could identify an individual user
+
+Sentry's privacy policy: https://sentry.io/privacy/
+
+The web version of the app does **not** use Sentry.
+
+### 7.2 Services Not Used
+
 - ❌ No analytics tools (e.g., Google Analytics, Firebase Analytics)
-- ❌ No crash reporting services
 - ❌ No advertising networks
 - ❌ No social media SDKs
 - ❌ No cloud services
@@ -182,6 +200,6 @@ Your children can use the app safely and privately.
 
 ---
 
-**Version:** 1.0
-**Effective Date:** February 1, 2026
+**Version:** 1.1
+**Effective Date:** April 5, 2026
 **Language:** English

--- a/public/privacy-policy-en.html
+++ b/public/privacy-policy-en.html
@@ -120,16 +120,17 @@
 <body>
     <div class="container">
         <h1>Privacy Policy</h1>
-        <p class="meta"><strong>Last Updated:</strong> February 1, 2026</p>
+        <p class="meta"><strong>Last Updated:</strong> April 5, 2026</p>
 
         <div class="summary">
             <div class="summary-title">Summary</div>
             <ul>
-                <li><span class="checkmark">✅</span> <strong>No Data Collection</strong>: We do not collect any personal data</li>
-                <li><span class="checkmark">✅</span> <strong>No Sharing</strong>: No data is shared with third parties</li>
+                <li><span class="checkmark">✅</span> <strong>No Personal Data</strong>: We do not collect any personal data</li>
+                <li><span class="checkmark">✅</span> <strong>No Sharing</strong>: Personal data is not shared with third parties</li>
                 <li><span class="checkmark">✅</span> <strong>No Advertising</strong>: The app contains no ads</li>
                 <li><span class="checkmark">✅</span> <strong>No In-App Purchases</strong>: The app is completely free</li>
                 <li><span class="checkmark">✅</span> <strong>No Internet Required</strong>: The app works fully offline</li>
+                <li>⚠️ <strong>Optional Crash Reporting</strong>: The Android app may use Sentry for crash reports (technical data only, no personal information)</li>
                 <li><span class="checkmark">✅</span> <strong>Open Source</strong>: The complete source code is available on GitHub</li>
             </ul>
         </div>
@@ -176,29 +177,55 @@
             <li><span class="cross">❌</span> No phone permission</li>
         </ul>
 
-        <h2>3. Data Sharing</h2>
-        <p><strong>No data is shared.</strong></p>
-        <p>Since the app does not collect data, no data can be shared with third parties.</p>
+        <h2>3. Third-Party Services</h2>
+
+        <h3>3.1 Crash Reporting (Sentry) — Optional</h3>
+        <p>The Android app optionally uses <strong>Sentry</strong> (sentry.io) for crash reporting. Sentry is only active when a DSN is configured at build time.</p>
+        <p><strong>What Sentry collects:</strong></p>
+        <ul>
+            <li>Crash logs and stack traces (technical error information only)</li>
+            <li>Device type, OS version, and app version (non-identifying metadata)</li>
+        </ul>
+        <p><strong>What Sentry does NOT collect:</strong></p>
+        <ul>
+            <li><span class="cross">❌</span> No personal information</li>
+            <li><span class="cross">❌</span> No game data or progress</li>
+            <li><span class="cross">❌</span> No location data</li>
+        </ul>
+        <p>Sentry's privacy policy: <a href="https://sentry.io/privacy/">https://sentry.io/privacy/</a></p>
+        <p>The web version of the app does <strong>not</strong> use Sentry.</p>
+
+        <h3>3.2 Services Not Used</h3>
+        <ul>
+            <li><span class="cross">❌</span> No analytics tools (e.g., Google Analytics, Firebase Analytics)</li>
+            <li><span class="cross">❌</span> No advertising networks</li>
+            <li><span class="cross">❌</span> No social media SDKs</li>
+            <li><span class="cross">❌</span> No cloud services</li>
+        </ul>
+
+        <h2>4. Data Sharing</h2>
+        <p><strong>No personal data is shared.</strong></p>
+        <p>Since the app does not collect personal data, no personal data can be shared with third parties.</p>
         <ul>
             <li><span class="cross">❌</span> No sharing with advertising networks</li>
             <li><span class="cross">❌</span> No sharing with analytics services</li>
             <li><span class="cross">❌</span> No sharing with social media platforms</li>
-            <li><span class="cross">❌</span> No sharing with the developer</li>
         </ul>
 
-        <h2>4. Children's Privacy</h2>
+        <h2>5. Children's Privacy</h2>
         <p>The app is specifically designed for children and meets the highest privacy standards:</p>
 
-        <h3>4.1 COPPA Compliance (USA)</h3>
+        <h3>5.1 COPPA Compliance (USA)</h3>
         <p>The app complies with the Children's Online Privacy Protection Act (COPPA):</p>
         <ul>
             <li><span class="checkmark">✅</span> No collection of personal data from children under 13</li>
-            <li><span class="checkmark">✅</span> No sharing of information</li>
+            <li><span class="checkmark">✅</span> No sharing of personal information</li>
+            <li><span class="checkmark">✅</span> Optional Sentry crash reporting collects no personal data</li>
             <li><span class="checkmark">✅</span> No advertising</li>
             <li><span class="checkmark">✅</span> No in-app purchases</li>
         </ul>
 
-        <h3>4.2 GDPR Compliance (EU)</h3>
+        <h3>5.2 GDPR Compliance (EU)</h3>
         <p>The app complies with the EU General Data Protection Regulation (GDPR):</p>
         <ul>
             <li><span class="checkmark">✅</span> No processing of personal data</li>
@@ -207,9 +234,9 @@
             <li><span class="checkmark">✅</span> Transparent privacy policy</li>
         </ul>
 
-        <h2>5. Your Rights</h2>
+        <h2>6. Your Rights</h2>
 
-        <h3>5.1 Right to Deletion</h3>
+        <h3>6.1 Right to Deletion</h3>
         <p><strong>How to delete all app data:</strong></p>
         <ol>
             <li><strong>Android:</strong> Settings → Apps → Remember and Draw → Storage → Clear Data</li>
@@ -217,18 +244,18 @@
         </ol>
         <p>Uninstalling the app completely removes all locally stored data from the device.</p>
 
-        <h2>6. Open Source</h2>
+        <h2>7. Open Source</h2>
         <p>The complete source code of the app is available on GitHub:</p>
         <p><strong>Repository:</strong> <a href="https://github.com/S540d/DrawFromMemory">https://github.com/S540d/DrawFromMemory</a></p>
         <p>You can review the code and verify that no data is actually collected.</p>
 
-        <h2>7. Contact</h2>
+        <h2>8. Contact</h2>
         <p>For questions about this privacy policy, you can contact us:</p>
         <p><strong>GitHub Issues:</strong> <a href="https://github.com/S540d/DrawFromMemory/issues">https://github.com/S540d/DrawFromMemory/issues</a><br>
         <strong>Website:</strong> <a href="https://s540d.github.io/DrawFromMemory/">https://s540d.github.io/DrawFromMemory/</a></p>
 
         <div class="footer">
-            <p><strong>Version:</strong> 1.0 | <strong>Effective Date:</strong> February 1, 2026 | <strong>Language:</strong> English</p>
+            <p><strong>Version:</strong> 1.1 | <strong>Effective Date:</strong> April 5, 2026 | <strong>Language:</strong> English</p>
             <p><a href="privacy-policy.html">Deutsche Version</a></p>
         </div>
     </div>

--- a/public/privacy-policy.html
+++ b/public/privacy-policy.html
@@ -120,16 +120,17 @@
 <body>
     <div class="container">
         <h1>Datenschutzerklärung</h1>
-        <p class="meta"><strong>Letzte Aktualisierung:</strong> 1. Februar 2026</p>
+        <p class="meta"><strong>Letzte Aktualisierung:</strong> 5. April 2026</p>
 
         <div class="summary">
             <div class="summary-title">Kurz zusammengefasst</div>
             <ul>
-                <li><span class="checkmark">✅</span> <strong>Keine Datensammlung</strong>: Wir sammeln keinerlei persönliche Daten</li>
-                <li><span class="checkmark">✅</span> <strong>Keine Weitergabe</strong>: Es werden keine Daten an Dritte weitergegeben</li>
+                <li><span class="checkmark">✅</span> <strong>Keine persönlichen Daten</strong>: Wir sammeln keinerlei persönliche Daten</li>
+                <li><span class="checkmark">✅</span> <strong>Keine Weitergabe</strong>: Persönliche Daten werden nicht weitergegeben</li>
                 <li><span class="checkmark">✅</span> <strong>Keine Werbung</strong>: Die App enthält keine Werbung</li>
                 <li><span class="checkmark">✅</span> <strong>Keine In-App-Käufe</strong>: Die App ist komplett kostenlos</li>
                 <li><span class="checkmark">✅</span> <strong>Kein Internet erforderlich</strong>: Die App funktioniert vollständig offline</li>
+                <li>⚠️ <strong>Optionales Crash-Reporting</strong>: Die Android-App kann Sentry für Absturzberichte nutzen (nur technische Daten, keine persönlichen Informationen)</li>
                 <li><span class="checkmark">✅</span> <strong>Open Source</strong>: Der komplette Quellcode ist auf GitHub einsehbar</li>
             </ul>
         </div>
@@ -176,29 +177,55 @@
             <li><span class="cross">❌</span> Keine Telefon-Berechtigung</li>
         </ul>
 
-        <h2>3. Datenweitergabe</h2>
-        <p><strong>Es werden keine Daten weitergegeben.</strong></p>
-        <p>Da die App keine Daten sammelt, können auch keine Daten an Dritte weitergegeben werden.</p>
+        <h2>3. Drittanbieter-Dienste</h2>
+
+        <h3>3.1 Crash-Reporting (Sentry) — Optional</h3>
+        <p>Die Android-App nutzt optional <strong>Sentry</strong> (sentry.io) für Absturzberichte. Sentry ist nur aktiv, wenn ein DSN zum Build-Zeitpunkt konfiguriert ist.</p>
+        <p><strong>Was Sentry sammelt:</strong></p>
+        <ul>
+            <li>Absturzprotokolle und Stack-Traces (ausschließlich technische Fehlerinformationen)</li>
+            <li>Gerätetyp, Betriebssystemversion und App-Version (nicht-identifizierende Metadaten)</li>
+        </ul>
+        <p><strong>Was Sentry NICHT sammelt:</strong></p>
+        <ul>
+            <li><span class="cross">❌</span> Keine persönlichen Informationen</li>
+            <li><span class="cross">❌</span> Keine Spieldaten</li>
+            <li><span class="cross">❌</span> Keine Standortdaten</li>
+        </ul>
+        <p>Datenschutzerklärung von Sentry: <a href="https://sentry.io/privacy/">https://sentry.io/privacy/</a></p>
+        <p>Die Web-Version der App nutzt Sentry <strong>nicht</strong>.</p>
+
+        <h3>3.2 Nicht verwendete Dienste</h3>
+        <ul>
+            <li><span class="cross">❌</span> Keine Analyse-Tools (z.B. Google Analytics, Firebase Analytics)</li>
+            <li><span class="cross">❌</span> Keine Werbe-Netzwerke</li>
+            <li><span class="cross">❌</span> Keine Social Media SDKs</li>
+            <li><span class="cross">❌</span> Keine Cloud-Dienste</li>
+        </ul>
+
+        <h2>4. Datenweitergabe</h2>
+        <p><strong>Persönliche Daten werden nicht weitergegeben.</strong></p>
+        <p>Da die App keine persönlichen Daten sammelt, können auch keine persönlichen Daten weitergegeben werden.</p>
         <ul>
             <li><span class="cross">❌</span> Keine Weitergabe an Werbenetzwerke</li>
             <li><span class="cross">❌</span> Keine Weitergabe an Analyse-Dienste</li>
             <li><span class="cross">❌</span> Keine Weitergabe an Social Media Plattformen</li>
-            <li><span class="cross">❌</span> Keine Weitergabe an den Entwickler</li>
         </ul>
 
-        <h2>4. Kinder-Datenschutz</h2>
+        <h2>5. Kinder-Datenschutz</h2>
         <p>Die App ist speziell für Kinder konzipiert und erfüllt die höchsten Datenschutzstandards:</p>
 
-        <h3>4.1 COPPA Konformität (USA)</h3>
+        <h3>5.1 COPPA Konformität (USA)</h3>
         <p>Die App entspricht dem Children's Online Privacy Protection Act (COPPA):</p>
         <ul>
             <li><span class="checkmark">✅</span> Keine Sammlung von persönlichen Daten von Kindern unter 13 Jahren</li>
-            <li><span class="checkmark">✅</span> Keine Weitergabe von Informationen</li>
+            <li><span class="checkmark">✅</span> Keine Weitergabe persönlicher Informationen</li>
+            <li><span class="checkmark">✅</span> Das optionale Sentry Crash-Reporting sammelt keine personenbezogenen Daten</li>
             <li><span class="checkmark">✅</span> Keine Werbung</li>
             <li><span class="checkmark">✅</span> Keine In-App-Käufe</li>
         </ul>
 
-        <h3>4.2 DSGVO/GDPR Konformität (EU)</h3>
+        <h3>5.2 DSGVO/GDPR Konformität (EU)</h3>
         <p>Die App entspricht der EU-Datenschutz-Grundverordnung (DSGVO):</p>
         <ul>
             <li><span class="checkmark">✅</span> Keine Verarbeitung personenbezogener Daten</li>
@@ -207,9 +234,9 @@
             <li><span class="checkmark">✅</span> Transparente Datenschutzerklärung</li>
         </ul>
 
-        <h2>5. Ihre Rechte</h2>
+        <h2>6. Ihre Rechte</h2>
 
-        <h3>5.1 Recht auf Löschung</h3>
+        <h3>6.1 Recht auf Löschung</h3>
         <p><strong>So löschen Sie alle App-Daten:</strong></p>
         <ol>
             <li><strong>Android:</strong> Einstellungen → Apps → Merke und Male → Speicher → Daten löschen</li>
@@ -217,18 +244,18 @@
         </ol>
         <p>Durch Deinstallation der App werden alle lokal gespeicherten Daten vollständig vom Gerät entfernt.</p>
 
-        <h2>6. Open Source</h2>
+        <h2>7. Open Source</h2>
         <p>Der komplette Quellcode der App ist auf GitHub verfügbar:</p>
         <p><strong>Repository:</strong> <a href="https://github.com/S540d/DrawFromMemory">https://github.com/S540d/DrawFromMemory</a></p>
         <p>Sie können den Code einsehen und überprüfen, dass tatsächlich keine Daten gesammelt werden.</p>
 
-        <h2>7. Kontakt</h2>
+        <h2>8. Kontakt</h2>
         <p>Bei Fragen zu dieser Datenschutzerklärung können Sie uns kontaktieren:</p>
         <p><strong>GitHub Issues:</strong> <a href="https://github.com/S540d/DrawFromMemory/issues">https://github.com/S540d/DrawFromMemory/issues</a><br>
         <strong>Website:</strong> <a href="https://s540d.github.io/DrawFromMemory/">https://s540d.github.io/DrawFromMemory/</a></p>
 
         <div class="footer">
-            <p><strong>Version:</strong> 1.0 | <strong>Gültig ab:</strong> 1. Februar 2026 | <strong>Sprache:</strong> Deutsch</p>
+            <p><strong>Version:</strong> 1.1 | <strong>Gültig ab:</strong> 5. April 2026 | <strong>Sprache:</strong> Deutsch</p>
             <p><a href="privacy-policy-en.html">English version</a></p>
         </div>
     </div>


### PR DESCRIPTION
P0 – fix privacy policy contradiction (Sentry):
- Update all 5 policy files (PRIVACY_POLICY.md, docs/PRIVACY_POLICY.md,
  docs/PRIVACY_POLICY_EN.md, public/privacy-policy.html,
  public/privacy-policy-en.html) to accurately describe Sentry as an
  optional, configurable crash-reporting service (Android only, no
  personal data collected)
- Replace [TBD] placeholder dates with actual publication date (2026-04-05)

P1 – CI/CD & changelog:
- Add automated test job (npm run test:ci + coverage upload) to ci-cd.yml
- Trigger CI on staging branch in addition to main/develop
- Create CHANGELOG.md following Keep a Changelog format (v1.0.0–v1.2.6)

P2 – third-party licenses:
- Create THIRD_PARTY_LICENSES.md documenting Sentry, React Native Skia,
  Expo, React Native and other key dependencies

https://claude.ai/code/session_015vXHsnWU6oS17UXVmkxbWL