### PR TITLE
ci: add docs-privacy and keystore security checks

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -172,7 +172,107 @@ jobs:
           fi
 
   # ============================================================================
-  # JOB 5: Release Readiness Report
+  # JOB 5: Docs Privacy Check
+  # ============================================================================
+  docs-privacy:
+    name: 🔐 Docs Privacy Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check .gitignore covers docs/private/
+        run: |
+          if ! grep -q "docs/private/" .gitignore; then
+            echo "❌ ERROR: docs/private/ is not in .gitignore!"
+            exit 1
+          fi
+          echo "✅ docs/private/ is gitignored"
+
+      - name: Check no private docs are committed
+        run: |
+          PRIVATE_FILES=$(git ls-files docs/private/ 2>/dev/null)
+          if [ -n "$PRIVATE_FILES" ]; then
+            echo "❌ ERROR: Private docs found in repository:"
+            echo "$PRIVATE_FILES"
+            exit 1
+          fi
+          echo "✅ No private docs committed"
+
+      - name: Check known sensitive filenames not in repo
+        run: |
+          SENSITIVE=(
+            "DEPLOYMENT_GUIDE.md"
+            "PLAY_STORE_METADATA.md"
+            "PLAY_STORE_METADATA_EN.md"
+            "STORE_ASSETS_TODO.md"
+            "BILDERPOOL.md"
+            "IMAGE_GUIDELINES.md"
+          )
+          FOUND=0
+          for f in "${SENSITIVE[@]}"; do
+            if git ls-files | grep -q "$f"; then
+              echo "❌ WARNING: Sensitive file committed: $f"
+              FOUND=1
+            fi
+          done
+          if [ $FOUND -eq 0 ]; then
+            echo "✅ No sensitive filenames found"
+          else
+            exit 1
+          fi
+
+  # ============================================================================
+  # JOB 6: Keystore & Credential Scan
+  # ============================================================================
+  keystore-secrets:
+    name: 🔑 Keystore & Credential Scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check no keystore files are committed
+        run: |
+          FOUND=$(git ls-files | grep -E "\.(keystore|jks)$" || true)
+          if [ -n "$FOUND" ]; then
+            echo "❌ ERROR: Keystore file committed to repository!"
+            echo "$FOUND"
+            exit 1
+          fi
+          echo "✅ No keystore files found"
+
+      - name: Check .gitignore covers keystore patterns
+        run: |
+          if ! grep -q "\.keystore" .gitignore || ! grep -q "\.jks" .gitignore; then
+            echo "❌ ERROR: .gitignore does not cover *.keystore / *.jks!"
+            exit 1
+          fi
+          echo "✅ Keystore patterns are gitignored"
+
+      - name: Scan for hardcoded keystore passwords
+        run: |
+          if grep -rEi "keystorePassword\s*=\s*\S|keyPassword\s*=\s*\S|storePassword\s*=\s*\S" . \
+              --exclude-dir=node_modules --exclude-dir=.git \
+              --exclude="*.md" --exclude="*.example" 2>/dev/null; then
+            echo "❌ ERROR: Hardcoded keystore password found!"
+            echo "Use environment variables or EAS Secrets instead."
+            exit 1
+          fi
+          echo "✅ No hardcoded keystore passwords found"
+
+      - name: Scan for base64-encoded keystore
+        run: |
+          if grep -rE "MIIF[A-Za-z0-9+/]{50,}" . \
+              --exclude-dir=node_modules --exclude-dir=.git \
+              --exclude="*.md" 2>/dev/null; then
+            echo "❌ WARNING: Possible base64-encoded keystore content found!"
+            exit 1
+          fi
+          echo "✅ No encoded keystore content found"
+
+  # ============================================================================
+  # JOB 7: Release Readiness Report
   # ============================================================================
   release-checklist:
     name: 📋 Release Readiness Report

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -47,4 +47,26 @@ if git diff --cached --name-only | grep -E "(package\.json|app\.json|App\.tsx|bu
   fi
 fi
 
+# Check: keine privaten Docs committen
+echo "Checking for private docs..."
+STAGED=$(git diff --cached --name-only)
+if echo "$STAGED" | grep -q "^docs/private/"; then
+  echo "❌ Commit blocked: Files from docs/private/ cannot be committed."
+  exit 1
+fi
+
+# Check: keine Keystore-Dateien committen
+echo "Checking for keystore files..."
+if echo "$STAGED" | grep -qE "\.(keystore|jks)$"; then
+  echo "❌ Commit blocked: Keystore file detected in staged changes!"
+  exit 1
+fi
+
+# Check: keine Keystore-Passwörter in staged files
+echo "Checking for hardcoded keystore passwords..."
+if git diff --cached | grep -Ei "keystorePassword\s*=\s*\S|keyPassword\s*=\s*\S|storePassword\s*=\s*\S"; then
+  echo "❌ Commit blocked: Hardcoded keystore password detected!"
+  exit 1
+fi
+
 echo "✅ Pre-commit checks passed!"


### PR DESCRIPTION
## Summary

Automatische Absicherung für das `docs/private/` Konvention und Android Keystore-Schutz.

- **`docs-privacy` CI-Job**: Prüft bei jedem Push/PR, dass `docs/private/` korrekt gitignoriert ist und keine sensiblen Dateien (Deployment-Guide, Play-Store-Texte etc.) ins Repository gelangen
- **`keystore-secrets` CI-Job**: Scannt auf committed `.keystore`/`.jks` Dateien, hardcodierte Keystore-Passwörter und base64-encodierte Keystore-Inhalte
- **Husky Pre-Commit Hook**: Dieselben Checks lokal vor dem Commit – schnelles Feedback ohne CI-Wartezeit

## Kontext

Diese CI-Checks sind die serverseitige Absicherung für das `docs/private/` Pattern, das lokal auf dem Entwicklerrechner eingerichtet wird (siehe verlinktes Issue). Die eigentlichen Dateibewegungen (`mv docs/DEPLOYMENT_GUIDE.md docs/private/` etc.) und die `.gitignore`-Anpassung werden lokal ausgeführt und sind **nicht** Teil dieses PRs.

## Test plan

- [ ] CI-Jobs `docs-privacy` und `keystore-secrets` laufen grün durch (keine sensiblen Dateien im Repo)
- [ ] Husky Pre-Commit Hook blockiert bei versuchtem `git add docs/private/*`
- [ ] Husky Pre-Commit Hook blockiert bei `.keystore`-Datei in staged changes
- [ ] Bestehende CI-Jobs weiterhin funktionsfähig

https://claude.ai/code/session_016L5vh6echPtgne4upP1YXb