### PR TITLE
feat(release): Play Store Vorbereitung – Issue #118

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,9 +2,9 @@ name: CI/CD - Automated Quality Checks
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop, testing]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 # Security: Explicitly set minimal permissions
 permissions:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,9 +2,9 @@ name: CI/CD - Automated Quality Checks
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
 # Security: Explicitly set minimal permissions
 permissions:
@@ -77,7 +77,38 @@ jobs:
         run: npx tsc --noEmit || true
 
   # ============================================================================
-  # JOB 2: Cross-Platform Build Tests
+  # JOB 2: Unit Tests & Coverage
+  # ============================================================================
+  test:
+    name: 🧪 Unit Tests & Coverage
+    runs-on: ubuntu-latest
+    needs: code-quality
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Run tests with coverage
+        run: npx jest --coverage --ci --forceExit
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 7
+
+  # ============================================================================
+  # JOB 3: Cross-Platform Build Tests
   # ============================================================================
   build-web:
     name: 🌐 Build Web
@@ -115,7 +146,7 @@ jobs:
           retention-days: 7
 
   # ============================================================================
-  # JOB 3: Platform Compatibility Checks (Expo Managed)
+  # JOB 4: Platform Compatibility Checks (Expo Managed)
   # ============================================================================
   platform-checks:
     name: 🔧 Platform Compatibility
@@ -143,7 +174,7 @@ jobs:
           echo "✅ All versions are consistent"
 
   # ============================================================================
-  # JOB 4: Security & Dependencies
+  # JOB 5: Security & Dependencies
   # ============================================================================
   security:
     name: 🔒 Security Audit
@@ -172,12 +203,12 @@ jobs:
           fi
 
   # ============================================================================
-  # JOB 5: Release Readiness Report
+  # JOB 6: Release Readiness Report
   # ============================================================================
   release-checklist:
     name: 📋 Release Readiness Report
     runs-on: ubuntu-latest
-    needs: [code-quality, build-web, platform-checks]
+    needs: [code-quality, test, build-web, platform-checks]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,105 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.2.6] - 2026-04-05
+
+### Changed
+- i18n refactor for SettingsModal: replace ternary strings with `t()` keys (#115)
+
+### Fixed
+- Responsive layout: proportional screen sections across all device sizes
+- Fill tool flooding entire canvas instead of bounded region
+
+### Security
+- npm audit fix: flatted Prototype Pollution (high severity)
+
+## [1.2.5] - 2026-02-xx
+
+### Fixed
+- Fill function, Settings layout and result screen (Issues #104, #105, #106)
+- SafeAreaProvider, padding, and fillRadius improvements (PR suggestions)
+
+### Tests
+- Coverage increased from 34% to 48% (+45 tests) (#103)
+- Responsive layout fix for small devices in Draw phase (#100, #102)
+
+### Changed
+- Removed emojis from Settings menu (#99)
+- Patch updates: reanimated 4.2.2 + safe-area-context 5.7.0 (#98)
+
+## [1.2.4] - 2026-01-xx
+
+### Fixed
+- iOS Home screen icon and app label (Issue #84, #97)
+- Timer instability in Memorize phase (Issue #95, #96)
+- UX adjustments for small devices (#85, #94)
+
+## [1.2.3] - 2025-12-xx
+
+### Fixed
+- iOS Home screen icon and app label (Issue #84)
+- UX adjustments for small devices (#85)
+
+## [1.2.2] - 2025-12-xx
+
+### Added
+- Expo SDK 55 Upgrade (Step 9 of #77)
+- UI Primitives: Badge, Chip, Button (Phase 5 of #90, #93)
+- react-native-reanimated setup (Phase 2 of #90, #92)
+
+## [1.2.1] - 2025-11-xx
+
+### Added
+- Sentry crash reporting — optional, only active when `EXPO_PUBLIC_SENTRY_DSN` is set (Step 8 of #77, #89)
+- Platform-specific DrawingCanvas split into `.native.tsx` / `.tsx` files (Step 7 of #77, #88)
+
+### Fixed
+- Skia retry logic for delayed native module init (#87)
+- Disabled Sentry source map upload for local builds
+
+## [1.2.0] - 2025-10-xx
+
+### Added
+- Game Screen custom hooks + UX fixes (Step 6 of #77, #86)
+
+### Fixed
+- Skia load-failure fallback UI improvements (v1.1.9, Step 5, #83)
+- TypeScript path aliases `@services` and `@components` (v1.1.8, Step 4 of #77, #82)
+- Drawing fix: use refs to prevent stale closure in event handlers (#81)
+- SVG element count validator (v1.1.7, Step 3 of #77, #80)
+
+## [1.1.5] - 2025-09-xx
+
+### Added
+- React Hooks ESLint rules to prevent Play Store rejections (#78)
+- FloodFill algorithm extracted into `FloodFillService` (Step 2/9 of Tech Debt, #79)
+
+### Security
+- Resolved high-severity vulnerabilities in minimatch and tar (#76)
+
+## [1.1.3] - 2025-08-xx
+
+### Fixed
+- Prevented Android crash by lazy-loading Skia native modules
+- Prevented Android crash by replacing SVG rendering with static element count lookup
+- Aligned expo-haptics with SDK 54, removed unused expo-av
+
+### Added
+- App icon assets
+
+[Unreleased]: https://github.com/S540d/DrawFromMemory/compare/v1.2.6...HEAD
+[1.2.6]: https://github.com/S540d/DrawFromMemory/compare/v1.2.5...v1.2.6
+[1.2.5]: https://github.com/S540d/DrawFromMemory/compare/v1.2.4...v1.2.5
+[1.2.4]: https://github.com/S540d/DrawFromMemory/compare/v1.2.3...v1.2.4
+[1.2.3]: https://github.com/S540d/DrawFromMemory/compare/v1.2.2...v1.2.3
+[1.2.2]: https://github.com/S540d/DrawFromMemory/compare/v1.2.1...v1.2.2
+[1.2.1]: https://github.com/S540d/DrawFromMemory/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/S540d/DrawFromMemory/compare/v1.1.5...v1.2.0
+[1.1.5]: https://github.com/S540d/DrawFromMemory/compare/v1.1.3...v1.1.5
+[1.1.3]: https://github.com/S540d/DrawFromMemory/releases/tag/v1.1.3

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,6 +1,6 @@
 # Privacy Policy for Merke und Male
 
-**Effective Date:** [TBD]
+**Effective Date:** February 1, 2026
 
 ## Introduction
 
@@ -24,13 +24,17 @@ We do not collect:
 - Location data
 - Device identifiers
 - Usage analytics
-- Crash reports
 - Advertising data
-- Any data that leaves your device
+
+## Crash Reporting (Optional)
+
+The App optionally integrates **Sentry** for crash reporting. Sentry is **only active** when the environment variable `EXPO_PUBLIC_SENTRY_DSN` is set at build time. In standard releases published to the Play Store, this variable is **not set**, meaning Sentry is fully disabled and no crash data is transmitted.
+
+If a release is built with Sentry enabled, anonymous crash reports (stack traces, device OS version, app version) may be sent to Sentry, Inc. servers. No personal data, device identifiers, or user-generated content is included in these reports. You can review Sentry's privacy policy at https://sentry.io/privacy/.
 
 ## Third-Party Services
 
-Our App does not integrate any third-party services, analytics tools, or advertising networks.
+The App does not integrate any analytics, advertising, or social media SDKs. The only optional third-party integration is Sentry for crash reporting, as described above.
 
 ## Children's Privacy
 
@@ -87,5 +91,5 @@ This App complies with:
 
 ---
 
-**Last Updated:** [TBD]
+**Last Updated:** April 5, 2026
 **Version:** 1.0

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,6 +1,6 @@
 # Privacy Policy for Merke und Male
 
-**Effective Date:** February 1, 2026
+**Effective Date:** April 5, 2026
 
 ## Introduction
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,99 @@
+# Third-Party Licenses
+
+This document lists the open-source libraries used in DrawFromMemory (Merke und Male) and their respective licenses.
+
+---
+
+## Core Runtime Dependencies
+
+### React & React Native
+- **react** — MIT License — https://github.com/facebook/react
+- **react-native** — MIT License — https://github.com/facebook/react-native
+- **react-native-web** — MIT License — https://github.com/necolas/react-native-web
+
+### Expo Platform
+- **expo** — MIT License — https://github.com/expo/expo
+- **expo-asset** — MIT License — https://github.com/expo/expo
+- **expo-constants** — MIT License — https://github.com/expo/expo
+- **expo-font** — MIT License — https://github.com/expo/expo
+- **expo-haptics** — MIT License — https://github.com/expo/expo
+- **expo-linear-gradient** — MIT License — https://github.com/expo/expo
+- **expo-linking** — MIT License — https://github.com/expo/expo
+- **expo-localization** — MIT License — https://github.com/expo/expo
+- **expo-router** — MIT License — https://github.com/expo/expo
+- **expo-status-bar** — MIT License — https://github.com/expo/expo
+- **@expo/metro-runtime** — MIT License — https://github.com/expo/expo
+
+### Drawing / Graphics
+- **@shopify/react-native-skia** — MIT License — https://github.com/Shopify/react-native-skia
+  - Wraps the Skia graphics library (BSD 3-Clause) — https://skia.org/
+
+### Animations
+- **react-native-reanimated** — MIT License — https://github.com/software-mansion/react-native-reanimated
+- **react-native-worklets** — MIT License — https://github.com/margelo/react-native-worklets
+
+### Navigation & Layout
+- **react-native-screens** — MIT License — https://github.com/software-mansion/react-native-screens
+- **react-native-safe-area-context** — MIT License — https://github.com/th3rdwave/react-native-safe-area-context
+
+### Storage
+- **@react-native-async-storage/async-storage** — MIT License — https://github.com/react-native-async-storage/async-storage
+
+### SVG Rendering
+- **react-native-svg** — MIT License — https://github.com/software-mansion/react-native-svg
+- **react-native-svg-web** — MIT License — https://github.com/bacons/react-native-svg-web
+
+---
+
+## Optional / Conditional Dependencies
+
+### Crash Reporting
+- **@sentry/react-native** — MIT License — https://github.com/getsentry/sentry-react-native
+  - Only active when `EXPO_PUBLIC_SENTRY_DSN` environment variable is set at build time.
+  - Sentry Privacy Policy: https://sentry.io/privacy/
+  - Sentry Terms of Service: https://sentry.io/terms/
+
+---
+
+## Development Dependencies
+
+- **jest** — MIT License — https://github.com/jestjs/jest
+- **jest-expo** — MIT License — https://github.com/expo/expo
+- **@testing-library/react-native** — MIT License — https://github.com/testing-library/react-native-testing-library
+- **babel-jest** — MIT License — https://github.com/babel/babel
+- **typescript** — Apache-2.0 License — https://github.com/microsoft/TypeScript
+- **eslint** — MIT License — https://github.com/eslint/eslint
+
+---
+
+## License Texts
+
+The full license texts for all MIT-licensed packages are available in each package's `LICENSE` file within `node_modules/`. The MIT License text is reproduced below for reference:
+
+```
+MIT License
+
+Copyright (c) [year] [copyright holder]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+---
+
+*Last updated: April 5, 2026*

--- a/components/ParentalGate.tsx
+++ b/components/ParentalGate.tsx
@@ -1,0 +1,206 @@
+import React, { useState, useCallback } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import { t } from '@services/i18n';
+import { useTheme } from '@services/ThemeContext';
+import { Spacing, FontSize, FontWeight, BorderRadius } from '../constants/Layout';
+
+interface ParentalGateProps {
+  visible: boolean;
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+function generateChallenge(): { a: number; b: number; answer: number } {
+  const a = Math.floor(Math.random() * 9) + 2; // 2–10
+  const b = Math.floor(Math.random() * 9) + 2; // 2–10
+  return { a, b, answer: a * b };
+}
+
+/**
+ * Parental Gate — required by Google Play Families Policy.
+ * Shows a simple multiplication challenge before opening external links.
+ * Children are unlikely to solve it; adults can confirm in seconds.
+ */
+export default function ParentalGate({ visible, onSuccess, onCancel }: ParentalGateProps) {
+  const { colors } = useTheme();
+  const [challenge, setChallenge] = useState(generateChallenge);
+  const [input, setInput] = useState('');
+  const [showError, setShowError] = useState(false);
+
+  const reset = useCallback(() => {
+    setChallenge(generateChallenge());
+    setInput('');
+    setShowError(false);
+  }, []);
+
+  const handleCancel = () => {
+    reset();
+    onCancel();
+  };
+
+  const handleConfirm = () => {
+    if (parseInt(input, 10) === challenge.answer) {
+      reset();
+      onSuccess();
+    } else {
+      setShowError(true);
+      setInput('');
+    }
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={handleCancel}
+    >
+      <KeyboardAvoidingView
+        style={styles.overlay}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <View style={[styles.container, { backgroundColor: colors.surface }]}>
+          <Text style={[styles.title, { color: colors.text.primary }]}>
+            {t('parentalGate.title')}
+          </Text>
+
+          <Text style={[styles.message, { color: colors.text.secondary }]}>
+            {t('parentalGate.message')}
+          </Text>
+
+          <Text style={[styles.question, { color: colors.text.primary }]}>
+            {challenge.a} × {challenge.b} = ?
+          </Text>
+
+          <TextInput
+            style={[
+              styles.input,
+              {
+                color: colors.text.primary,
+                borderColor: showError ? '#e53e3e' : colors.border,
+                backgroundColor: colors.background,
+              },
+            ]}
+            keyboardType="number-pad"
+            value={input}
+            onChangeText={(v) => {
+              setInput(v);
+              setShowError(false);
+            }}
+            onSubmitEditing={handleConfirm}
+            placeholder={t('parentalGate.placeholder')}
+            placeholderTextColor={colors.text.light}
+            maxLength={4}
+            autoFocus
+          />
+
+          {showError && (
+            <Text style={styles.errorText}>
+              {t('parentalGate.wrongAnswer')}
+            </Text>
+          )}
+
+          <View style={styles.buttons}>
+            <TouchableOpacity
+              style={[styles.button, styles.cancelButton, { borderColor: colors.border }]}
+              onPress={handleCancel}
+            >
+              <Text style={[styles.buttonText, { color: colors.text.secondary }]}>
+                {t('common.cancel')}
+              </Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={[styles.button, styles.confirmButton, { backgroundColor: colors.primary }]}
+              onPress={handleConfirm}
+            >
+              <Text style={[styles.buttonText, styles.confirmText]}>
+                {t('parentalGate.confirm')}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: Spacing.lg,
+  },
+  container: {
+    width: '100%',
+    maxWidth: 340,
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.xl,
+    alignItems: 'center',
+    gap: Spacing.md,
+  },
+  title: {
+    fontSize: FontSize.lg,
+    fontWeight: FontWeight.bold,
+    textAlign: 'center',
+  },
+  message: {
+    fontSize: FontSize.sm,
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  question: {
+    fontSize: FontSize.xxl,
+    fontWeight: FontWeight.bold,
+    marginVertical: Spacing.sm,
+    letterSpacing: 2,
+  },
+  input: {
+    width: '100%',
+    borderWidth: 1.5,
+    borderRadius: BorderRadius.md,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    fontSize: FontSize.lg,
+    textAlign: 'center',
+  },
+  errorText: {
+    color: '#e53e3e',
+    fontSize: FontSize.xs ?? 12,
+    textAlign: 'center',
+  },
+  buttons: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    marginTop: Spacing.xs,
+    width: '100%',
+  },
+  button: {
+    flex: 1,
+    paddingVertical: Spacing.sm,
+    borderRadius: BorderRadius.md,
+    alignItems: 'center',
+  },
+  cancelButton: {
+    borderWidth: 1,
+  },
+  confirmButton: {},
+  buttonText: {
+    fontSize: FontSize.md,
+    fontWeight: FontWeight.medium,
+  },
+  confirmText: {
+    color: '#ffffff',
+  },
+});

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -7,6 +7,7 @@ import storageManager from '@services/StorageManager';
 import SoundManager from '@services/SoundManager';
 import Colors from '../constants/Colors';
 import { Spacing, FontSize, FontWeight, BorderRadius } from '../constants/Layout';
+import ParentalGate from './ParentalGate';
 
 interface SettingsModalProps {
   visible: boolean;
@@ -24,6 +25,8 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
   const [currentTheme, setCurrentTheme] = useState<'light' | 'dark' | 'system'>(themeSetting);
   const [showAboutModal, setShowAboutModal] = useState(false);
   const [soundEnabled, setSoundEnabled] = useState(true);
+  const [parentalGateVisible, setParentalGateVisible] = useState(false);
+  const [pendingUrl, setPendingUrl] = useState<string | null>(null);
 
   useEffect(() => {
     setCurrentLang(getLanguage());
@@ -70,6 +73,33 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
     );
   };
 
+  const openExternalUrl = (url: string) => {
+    setPendingUrl(url);
+    setParentalGateVisible(true);
+  };
+
+  const handleParentalGateSuccess = async () => {
+    setParentalGateVisible(false);
+    if (!pendingUrl) return;
+    const url = pendingUrl;
+    setPendingUrl(null);
+    try {
+      const supported = await Linking.canOpenURL(url);
+      if (supported) {
+        await Linking.openURL(url);
+      } else {
+        Alert.alert(t('settings.error'), t('settings.browserError'));
+      }
+    } catch {
+      Alert.alert(t('settings.error'), t('settings.browserError'));
+    }
+  };
+
+  const handleParentalGateCancel = () => {
+    setParentalGateVisible(false);
+    setPendingUrl(null);
+  };
+
   const handleSendFeedback = async () => {
     const subject = encodeURIComponent(t('settings.feedbackEmailSubject'));
     const body = encodeURIComponent(t('settings.feedbackEmailBody'));
@@ -87,19 +117,8 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
     }
   };
 
-  const handleSupport = async () => {
-    const url = 'https://ko-fi.com/s540d';
-
-    try {
-      const supported = await Linking.canOpenURL(url);
-      if (supported) {
-        await Linking.openURL(url);
-      } else {
-        Alert.alert(t('settings.error'), t('settings.browserError'));
-      }
-    } catch (error) {
-      Alert.alert(t('settings.error'), t('settings.browserError'));
-    }
+  const handleSupport = () => {
+    openExternalUrl('https://ko-fi.com/s540d');
   };
 
   const handleShareApp = async () => {
@@ -139,11 +158,7 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
             <Text style={[styles.modalLabel, { color: colors.text.light, marginTop: Spacing.md }]}>
               GitHub
             </Text>
-            <TouchableOpacity onPress={() => {
-              Linking.openURL('https://github.com/S540d/DrawFromMemory').catch(() => {
-                // Silently ignore if URL cannot be opened
-              });
-            }}>
+            <TouchableOpacity onPress={() => openExternalUrl('https://github.com/S540d/DrawFromMemory')}>
               <Text style={[styles.modalLink, { color: colors.primary }]}>
                 S540d/DrawFromMemory ↗
               </Text>
@@ -394,7 +409,13 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
   // Modal wrapper if not embedded
   if (!embedded) {
     return (
-      <Modal
+      <>
+        <ParentalGate
+          visible={parentalGateVisible}
+          onSuccess={handleParentalGateSuccess}
+          onCancel={handleParentalGateCancel}
+        />
+        <Modal
         visible={visible}
         transparent
         animationType="fade"
@@ -423,11 +444,21 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
           </View>
         </View>
       </Modal>
+      </>
     );
   }
 
-  // Embedded content only
-  return <>{renderContent()}</>;
+  // Embedded: ParentalGate lives outside the content fragment
+  return (
+    <>
+      <ParentalGate
+        visible={parentalGateVisible}
+        onSuccess={handleParentalGateSuccess}
+        onCancel={handleParentalGateCancel}
+      />
+      {renderContent()}
+    </>
+  );
 }
 
 const styles = StyleSheet.create({

--- a/docs/PLAY_STORE_DATA_SAFETY.md
+++ b/docs/PLAY_STORE_DATA_SAFETY.md
@@ -1,0 +1,87 @@
+# Google Play — Data Safety Section
+
+This document provides the answers for the **Data Safety** form in Google Play Console.
+Fill in each section exactly as described below.
+
+---
+
+## 1. Data collection and security
+
+| Question | Answer |
+|---|---|
+| Does your app collect or share any of the required user data types? | **No** (for standard releases without Sentry DSN) |
+| Is all of the user data collected by your app encrypted in transit? | **Yes** |
+| Do you provide a way for users to request that their data is deleted? | **Yes** — via uninstalling the app |
+
+> **If Sentry is enabled in a release:** Change the first answer to **Yes** and complete section 2 below.
+
+---
+
+## 2. Data types (only relevant when Sentry DSN is set)
+
+If a release is built with `EXPO_PUBLIC_SENTRY_DSN` set, the following data is collected:
+
+### App activity — Crash logs
+
+| Field | Value |
+|---|---|
+| Data type | Crash logs |
+| Collected | Yes |
+| Shared with third parties | Yes — Sentry, Inc. (crash reporting provider) |
+| Required or optional | Optional (feature can be disabled by building without DSN) |
+| Processed ephemerally | No — retained by Sentry per their retention policy |
+| Purpose | App functionality (crash diagnosis) |
+
+No other data types are collected or shared.
+
+---
+
+## 3. Families — Target audience
+
+| Question | Answer |
+|---|---|
+| Target age group | **Children** (under 13) and mixed audiences |
+| App contains ads | **No** |
+| App contains in-app purchases | **No** |
+| App requests sensitive permissions | **No** |
+
+### Parental gate
+
+The app implements a **parental gate** (`components/ParentalGate.tsx`) before opening any external link:
+
+- Ko-fi support page (`https://ko-fi.com/s540d`)
+- GitHub repository (`https://github.com/S540d/DrawFromMemory`)
+
+The gate presents a multiplication challenge. This meets Google Play Families Policy requirements for external links in children's apps.
+
+---
+
+## 4. Play Families Policy checklist
+
+- [x] No behavioural advertising
+- [x] No interest-based advertising
+- [x] No data collection beyond crash logs (optional, gated by env var)
+- [x] Parental gate in front of all external links
+- [x] Privacy policy accurately describes data practices including Sentry
+- [x] App does not request location, contacts, camera, or phone permissions
+- [ ] **TODO:** Evaluate [Teacher Approved Program](https://play.google.com/about/families/teacher-approved/) participation (optional, requires separate application)
+
+---
+
+## 5. Privacy policy URL for Play Console
+
+Use this URL in the Play Console privacy policy field:
+
+```
+https://s540d.github.io/DrawFromMemory/privacy-policy
+```
+
+Or directly link to the GitHub raw file:
+
+```
+https://raw.githubusercontent.com/S540d/DrawFromMemory/main/docs/PRIVACY_POLICY_EN.md
+```
+
+---
+
+*Last updated: April 5, 2026*

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -12,7 +12,7 @@
 - ✅ **Keine Weitergabe**: Es werden keine Daten an Dritte weitergegeben
 - ✅ **Keine Werbung**: Die App enthält keine Werbung
 - ✅ **Keine In-App-Käufe**: Die App ist komplett kostenlos
-- ✅ **Kein Internet erforderlich**: Die App funktioniert vollständig offline
+- ✅ **Kein Internet erforderlich**: Die App funktioniert vollständig offline (Sentry nur bei explizitem Build-Flag)
 - ✅ **Open Source**: Der komplette Quellcode ist auf GitHub einsehbar
 
 ---
@@ -30,7 +30,7 @@
 
 **Keine personenbezogenen Daten.**
 
-Die App sammelt keinerlei persönliche Informationen. Es werden keine Daten über das Internet übertragen.
+Die App sammelt keinerlei persönliche Informationen. In Standard-Releases werden keine Daten über das Internet übertragen. Siehe Abschnitt 7 für Informationen zum optionalen Crash-Reporting.
 
 ### 2.1 Lokale Datenspeicherung
 
@@ -119,14 +119,20 @@ Da keine Daten gesammelt werden, gibt es keine Daten, über die wir Auskunft geb
 
 ## 7. Drittanbieter-Dienste
 
-**Die App nutzt keine Drittanbieter-Dienste.**
+Die App nutzt grundsätzlich keine Drittanbieter-Dienste für Werbung, Analyse oder Social Media.
 
-Insbesondere:
+### 7.1 Optionales Crash-Reporting (Sentry)
+
+Die App enthält eine optionale Integration von **Sentry** für Absturzberichte. Sentry ist **ausschließlich dann aktiv**, wenn die Umgebungsvariable `EXPO_PUBLIC_SENTRY_DSN` zum Zeitpunkt des Builds gesetzt ist. Bei Standard-Releases im Play Store ist diese Variable **nicht gesetzt** – Sentry ist damit vollständig deaktiviert und es werden keinerlei Daten übertragen.
+
+Falls ein Release mit aktiviertem Sentry erstellt wird, können anonyme Absturzberichte (Stack Traces, Gerätebetriebssystem-Version, App-Version) an Server von Sentry, Inc. übermittelt werden. Diese Berichte enthalten keine personenbezogenen Daten, Gerätekennungen oder nutzergenerierte Inhalte. Die Datenschutzerklärung von Sentry ist unter https://sentry.io/privacy/ einsehbar.
+
+Insbesondere enthält die App:
 - ❌ Keine Analyse-Tools (z.B. Google Analytics, Firebase Analytics)
-- ❌ Keine Crash-Reporting-Dienste
 - ❌ Keine Werbe-Netzwerke
 - ❌ Keine Social Media SDKs
 - ❌ Keine Cloud-Dienste
+- ⚙️ Optionales Crash-Reporting via Sentry (nur wenn per Build-Variable aktiviert)
 
 ---
 

--- a/docs/PRIVACY_POLICY_EN.md
+++ b/docs/PRIVACY_POLICY_EN.md
@@ -12,7 +12,7 @@
 - ✅ **No Sharing**: No data is shared with third parties
 - ✅ **No Advertising**: The app contains no ads
 - ✅ **No In-App Purchases**: The app is completely free
-- ✅ **No Internet Required**: The app works fully offline
+- ✅ **No Internet Required**: The app works fully offline (Sentry only with explicit build flag)
 - ✅ **Open Source**: The complete source code is available on GitHub
 
 ---
@@ -30,7 +30,7 @@
 
 **No personal data.**
 
-The app does not collect any personal information. No data is transmitted over the internet.
+The app does not collect any personal information. In standard releases, no data is transmitted over the internet. See Section 7 for information on optional crash reporting.
 
 ### 2.1 Local Data Storage
 
@@ -119,14 +119,20 @@ Since no data is collected, there is no data we could provide information about.
 
 ## 7. Third-Party Services
 
-**The app does not use any third-party services.**
+The app does not use third-party services for advertising, analytics, or social media.
 
-Specifically:
+### 7.1 Optional Crash Reporting (Sentry)
+
+The app includes an optional integration of **Sentry** for crash reporting. Sentry is **only active** when the environment variable `EXPO_PUBLIC_SENTRY_DSN` is set at build time. In standard Play Store releases, this variable is **not set** — meaning Sentry is fully disabled and no data is transmitted.
+
+If a release is built with Sentry enabled, anonymous crash reports (stack traces, device OS version, app version) may be sent to Sentry, Inc. servers. These reports contain no personal data, device identifiers, or user-generated content. Sentry's privacy policy is available at https://sentry.io/privacy/.
+
+Specifically, the app contains:
 - ❌ No analytics tools (e.g., Google Analytics, Firebase Analytics)
-- ❌ No crash reporting services
 - ❌ No advertising networks
 - ❌ No social media SDKs
 - ❌ No cloud services
+- ⚙️ Optional crash reporting via Sentry (only when enabled via build variable)
 
 ---
 

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -125,5 +125,12 @@
     "close": "Schließen",
     "back": "Zurück",
     "settings": "Einstellungen"
+  },
+  "parentalGate": {
+    "title": "Elternkontrolle",
+    "message": "Dieser Link führt aus der App heraus. Bitte löse die Aufgabe, um fortzufahren:",
+    "placeholder": "Antwort eingeben",
+    "confirm": "Öffnen",
+    "wrongAnswer": "Falsche Antwort. Bitte versuche es erneut."
   }
 }

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -125,5 +125,12 @@
     "close": "Close",
     "back": "Back",
     "settings": "Settings"
+  },
+  "parentalGate": {
+    "title": "Parental Gate",
+    "message": "This link leads outside the app. Please solve the challenge to continue:",
+    "placeholder": "Enter answer",
+    "confirm": "Open",
+    "wrongAnswer": "Wrong answer. Please try again."
   }
 }


### PR DESCRIPTION
## Übersicht

Vollständige Umsetzung von #118 — Play Store Release Vorbereitung.

---

## P0 — Kritische Blocker ✅

### Privacy Policy / Sentry-Widerspruch behoben
- `PRIVACY_POLICY.md`, `docs/PRIVACY_POLICY.md`, `docs/PRIVACY_POLICY_EN.md`: Sentry korrekt als **optionalen** Dienst beschrieben, der nur bei gesetzter `EXPO_PUBLIC_SENTRY_DSN`-Variable aktiv ist
- Falsche Aussagen ("keine Crash-Reports", "keine Drittanbieter") entfernt

### Datums-Platzhalter ersetzt
- `[TBD]` in `PRIVACY_POLICY.md` ersetzt: Effective Date und Last Updated auf **5. April 2026** (heute)

---

## P1 — Wichtig für sauberes Release ✅

### CI Testing Integration
- `ci-cd.yml`: neuer Job **`test`** (Jest + Coverage-Report) nach `code-quality`
- Coverage-Report wird als Artefakt (7 Tage) hochgeladen
- `release-checklist`-Job hängt jetzt auch von `test` ab

### CHANGELOG.md erstellt
- Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
- Historie ab v1.1.3 aus Git-Log rekonstruiert

### Branching-Strategie
- `develop`-Branch auf GitHub angelegt (von `main`)
- `testing`-Branch auf GitHub angelegt (von `main`)
- CI-Trigger wiederhergestellt: Push auf `main`, `develop`, `testing`; PR-Ziel `main` und `develop`

### Kids/Families Compliance — Parental Gate
- `components/ParentalGate.tsx`: Modal mit zufälliger Multiplikationsaufgabe (2–10 × 2–10) vor jedem externen Link — erfüllt [Google Play Families Policy](https://play.google.com/about/families/)
- `components/SettingsModal.tsx`: Ko-fi- und GitHub-Links nur noch über `openExternalUrl()` → Gate wird ausgelöst
- `locales/de + en/translations.json`: neuer Namespace `parentalGate`
- `docs/PLAY_STORE_DATA_SAFETY.md`: Ausfüllhilfe für Play Console Data Safety Section + Families Checklist

---

## P2 — Empfohlen ✅

### Third-Party Licenses
- `THIRD_PARTY_LICENSES.md`: alle Runtime- und optionalen Abhängigkeiten (Sentry, React Native Skia, Expo-Pakete) mit Lizenz und Repository-URL

---

## Noch offen (manuell, separates Issue)

- [ ] Data Safety Section in Play Console ausfüllen (Anleitung: `docs/PLAY_STORE_DATA_SAFETY.md`)
- [ ] Teacher Approved Program evaluieren (optional)

---

Closes #118