### PR TITLE
Simplify result screen: compact buttons, canvas icons for play/save

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,7 +220,16 @@ CI triggert bei Push auf `main`, `staging`, `testing` und bei PRs auf `main`.
 - **#122** – Play Store Vorbereitung: Privacy Policies aktualisiert, ParentalGate, CHANGELOG.md, THIRD_PARTY_LICENSES.md, CI Test-Job, Data Safety Docs
 - **#121** – CI: `docs-privacy` + `keystore-secrets` Jobs, Husky Pre-Commit Hooks
 
+### Offene PRs
+- **#125** – Ergebnis-Screen vereinfacht: Canvas-Icon-Overlays für Replay/Save, kompakte 3-Button-Reihe, kürzere Labels
+
+### Bekannte CI-Probleme
+- **`docs-privacy`-Job schlägt auf `main` und in PRs fehl**, weil `docs/DEPLOYMENT_GUIDE.md`, `docs/PLAY_STORE_METADATA.md`, `docs/PLAY_STORE_METADATA_EN.md` und `docs/STORE_ASSETS_TODO.md` committed sind, aber vom CI als sensitiv eingestuft werden. Fix-Optionen:
+  - Diese Dateien aus der Sensitive-Liste in `ci-cd.yml` entfernen (falls sie public bleiben sollen), **oder**
+  - In `docs/private/` verschieben + dort gitignoren (empfohlen laut ursprünglichem Intent)
+
 ### Nächste Schritte (offen)
+- **`docs-privacy` CI-Bug fixen** (siehe oben)
 - Data Safety Section in Play Console ausfüllen (Anleitung: `docs/PLAY_STORE_DATA_SAFETY.md`)
 - Variabler Timer (Schwierigkeits-abhängig)
 - Weitere Level (perspektivische Bilder, Schwierigkeit 4–5)
@@ -244,3 +253,4 @@ App ist technisch bereit. Noch ausstehend (manuell):
 - **i18next ist NICHT installiert** – kein `import i18next from 'i18next'`. Immer `t()` aus `services/i18n.ts`.
 - **ThemeContext** ist der einzige Weg auf das aktuelle Theme zuzugreifen – kein direktes Lesen von AsyncStorage für Theme.
 - **`develop`-Branch existiert auf GitHub**, wird aber nicht aktiv für Feature-Branches genutzt (Claude-Branches direkt von `main`).
+- **`docs-privacy` CI-Job schlägt fehl**, wenn `DEPLOYMENT_GUIDE.md`, `PLAY_STORE_METADATA.md` o.ä. in `docs/` committed sind – diese Dateien gelten als sensitiv laut CI, sind aber noch nicht nach `docs/private/` verschoben.

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -320,17 +320,28 @@ export default function GameScreen() {
                 strokeColor={Colors.drawing.black}
                 strokeWidth={2}
               />
+              {drawing.paths.length > 0 && (
+                <View style={styles.canvasIconRow}>
+                  <TouchableOpacity
+                    style={[styles.canvasIconButton, isReplaying && styles.canvasIconButtonActive]}
+                    onPress={isReplaying ? () => setIsReplaying(false) : startReplay}
+                  >
+                    <Text style={[styles.canvasIconText, isReplaying && styles.canvasIconTextActive]}>
+                      {isReplaying ? '⏹' : '▶'}
+                    </Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[styles.canvasIconButton, savedToGallery && styles.canvasIconButtonSaved]}
+                    onPress={saveToGallery}
+                    disabled={savedToGallery}
+                  >
+                    <Text style={[styles.canvasIconText, savedToGallery && styles.canvasIconTextSaved]}>
+                      {savedToGallery ? '✓' : '💾'}
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              )}
             </View>
-            {drawing.paths.length > 0 && (
-              <TouchableOpacity
-                style={[styles.replayButton, isReplaying && styles.replayButtonActive]}
-                onPress={isReplaying ? () => setIsReplaying(false) : startReplay}
-              >
-                <Text style={[styles.replayButtonText, isReplaying && styles.replayButtonTextActive]}>
-                  {isReplaying ? t('game.result.replayStop') : t('game.result.replay')}
-                </Text>
-              </TouchableOpacity>
-            )}
           </View>
         </View>
 
@@ -342,59 +353,22 @@ export default function GameScreen() {
           </View>
         )}
 
-        {/* Save to Gallery */}
-        {drawing.paths.length > 0 && (
-          <TouchableOpacity
-            style={[styles.galleryButton, savedToGallery && styles.galleryButtonSaved]}
-            onPress={saveToGallery}
-            disabled={savedToGallery}
-          >
-            <Text style={[styles.galleryButtonText, savedToGallery && styles.galleryButtonTextSaved]}>
-              {savedToGallery ? t('gallery.saved') : t('gallery.save')}
-            </Text>
-          </TouchableOpacity>
-        )}
-
-        {/* Level Navigation */}
-        <View style={styles.levelNavigation}>
-          <TouchableOpacity
-            style={[styles.navButton, levelNumber <= 1 && styles.navButtonDisabled]}
-            onPress={startPreviousLevel}
-            disabled={levelNumber <= 1}
-          >
-            <Text style={[styles.navButtonText, levelNumber <= 1 && styles.navButtonTextDisabled]}>← {t('common.back')}</Text>
+        {/* Action Buttons */}
+        <View style={styles.actionRow}>
+          <TouchableOpacity style={styles.actionButton} onPress={restartCurrentLevel}>
+            <Text style={styles.actionButtonText}>{t('game.result.retry')}</Text>
           </TouchableOpacity>
           {levelNumber < getTotalLevels() ? (
-            <TouchableOpacity
-              style={styles.navButton}
-              onPress={startNextLevel}
-            >
-              <Text style={styles.navButtonText}>{t('game.result.nextLevel')} →</Text>
+            <TouchableOpacity style={[styles.actionButton, styles.actionButtonPrimary]} onPress={startNextLevel}>
+              <Text style={[styles.actionButtonText, styles.actionButtonPrimaryText]}>{t('game.result.nextLevel')} →</Text>
             </TouchableOpacity>
           ) : (
-            <TouchableOpacity
-              style={styles.navButton}
-              onPress={restartFromLevel1}
-            >
-              <Text style={styles.navButtonText}>{t('game.result.playAgain')}</Text>
+            <TouchableOpacity style={[styles.actionButton, styles.actionButtonPrimary]} onPress={restartFromLevel1}>
+              <Text style={[styles.actionButtonText, styles.actionButtonPrimaryText]}>{t('game.result.playAgain')}</Text>
             </TouchableOpacity>
           )}
-        </View>
-
-        {/* Buttons */}
-        <View style={styles.buttonColumn}>
-          <TouchableOpacity
-            style={styles.primaryButton}
-            onPress={restartCurrentLevel}
-          >
-            <Text style={styles.primaryButtonText}>{t('game.result.retry')}</Text>
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            style={styles.secondaryButton}
-            onPress={() => router.back()}
-          >
-            <Text style={styles.secondaryButtonText}>Zum Menü</Text>
+          <TouchableOpacity style={styles.actionButton} onPress={() => router.back()}>
+            <Text style={styles.actionButtonText}>{t('game.result.backToMenu')}</Text>
           </TouchableOpacity>
         </View>
       </ScrollView>
@@ -828,8 +802,35 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     gap: Spacing.sm,
   },
-  buttonColumn: {
-    gap: Spacing.md,
+  actionRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    marginTop: Spacing.sm,
+  },
+  actionButton: {
+    flex: 1,
+    backgroundColor: Colors.surface,
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.xs,
+    borderRadius: BorderRadius.lg,
+    alignItems: 'center',
+    borderWidth: 2,
+    borderColor: Colors.primary,
+    minHeight: 48,
+    justifyContent: 'center',
+    ...Colors.shadow.small,
+  },
+  actionButtonPrimary: {
+    backgroundColor: Colors.primary,
+  },
+  actionButtonText: {
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.semibold,
+    color: Colors.primary,
+    textAlign: 'center',
+  },
+  actionButtonPrimaryText: {
+    color: Colors.background,
   },
   primaryButton: {
     flex: 1,
@@ -964,38 +965,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     padding: Spacing.lg,
   },
-  levelNavigation: {
-    flexDirection: 'row',
-    gap: Spacing.md,
-    marginBottom: Spacing.lg,
-    justifyContent: 'center',
-  },
-  navButton: {
-    flex: 1,
-    backgroundColor: Colors.surface,
-    paddingVertical: Spacing.md,
-    paddingHorizontal: Spacing.lg,
-    borderRadius: BorderRadius.lg,
-    alignItems: 'center',
-    borderWidth: 2,
-    borderColor: Colors.primary,
-    minHeight: 48,
-    justifyContent: 'center',
-    ...Colors.shadow.small, // Soft & Modern: Subtile Schatten für Navigation
-  },
-  navButtonDisabled: {
-    backgroundColor: Colors.surface,
-    borderColor: Colors.text.light,
-    opacity: 0.5,
-  },
-  navButtonText: {
-    fontSize: FontSize.sm,
-    fontWeight: FontWeight.semibold,
-    color: Colors.primary,
-  },
-  navButtonTextDisabled: {
-    color: Colors.text.light,
-  },
   completionBanner: {
     backgroundColor: Colors.success + '15',
     borderWidth: 2,
@@ -1017,48 +986,41 @@ const styles = StyleSheet.create({
     color: Colors.text.secondary,
     textAlign: 'center',
   },
-  galleryButton: {
-    alignSelf: 'center',
-    backgroundColor: Colors.surface,
-    paddingVertical: Spacing.sm,
-    paddingHorizontal: Spacing.lg,
-    borderRadius: BorderRadius.lg,
-    borderWidth: 2,
-    borderColor: Colors.secondary,
-    marginBottom: Spacing.md,
+  canvasIconRow: {
+    position: 'absolute',
+    bottom: Spacing.xs,
+    right: Spacing.xs,
+    flexDirection: 'row',
+    gap: Spacing.xs,
   },
-  galleryButtonSaved: {
-    borderColor: Colors.success,
-    backgroundColor: Colors.success + '15',
-  },
-  galleryButtonText: {
-    fontSize: FontSize.sm,
-    fontWeight: FontWeight.semibold,
-    color: Colors.secondary,
-  },
-  galleryButtonTextSaved: {
-    color: Colors.success,
-  },
-  replayButton: {
-    marginTop: Spacing.sm,
-    paddingVertical: Spacing.xs,
-    paddingHorizontal: Spacing.md,
-    borderRadius: BorderRadius.md,
+  canvasIconButton: {
+    width: 32,
+    height: 32,
+    borderRadius: BorderRadius.sm,
     backgroundColor: Colors.surface,
     borderWidth: 1,
     borderColor: Colors.primary,
+    justifyContent: 'center',
+    alignItems: 'center',
+    ...Colors.shadow.small,
   },
-  replayButtonActive: {
+  canvasIconButtonActive: {
     backgroundColor: Colors.primary,
+    borderColor: Colors.primary,
   },
-  replayButtonText: {
+  canvasIconButtonSaved: {
+    backgroundColor: Colors.success + '20',
+    borderColor: Colors.success,
+  },
+  canvasIconText: {
     fontSize: FontSize.xs,
-    fontWeight: FontWeight.semibold,
     color: Colors.primary,
-    textAlign: 'center',
   },
-  replayButtonTextActive: {
+  canvasIconTextActive: {
     color: Colors.background,
+  },
+  canvasIconTextSaved: {
+    color: Colors.success,
   },
   toolContainer: {
     marginBottom: Spacing.md,

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -67,7 +67,6 @@ export default function GameScreen() {
     startReplay,
     restartCurrentLevel,
     startNextLevel,
-    startPreviousLevel,
     restartFromLevel1,
   } = useGamePhase({
     initialLevel,
@@ -325,6 +324,8 @@ export default function GameScreen() {
                   <TouchableOpacity
                     style={[styles.canvasIconButton, isReplaying && styles.canvasIconButtonActive]}
                     onPress={isReplaying ? () => setIsReplaying(false) : startReplay}
+                    accessibilityRole="button"
+                    accessibilityLabel={isReplaying ? t('game.result.replayStop') : t('game.result.replay')}
                   >
                     <Text style={[styles.canvasIconText, isReplaying && styles.canvasIconTextActive]}>
                       {isReplaying ? '⏹' : '▶'}
@@ -334,6 +335,9 @@ export default function GameScreen() {
                     style={[styles.canvasIconButton, savedToGallery && styles.canvasIconButtonSaved]}
                     onPress={saveToGallery}
                     disabled={savedToGallery}
+                    accessibilityRole="button"
+                    accessibilityLabel={savedToGallery ? t('gallery.saved') : t('gallery.save')}
+                    accessibilityState={{ disabled: savedToGallery }}
                   >
                     <Text style={[styles.canvasIconText, savedToGallery && styles.canvasIconTextSaved]}>
                       {savedToGallery ? '✓' : '💾'}
@@ -994,8 +998,8 @@ const styles = StyleSheet.create({
     gap: Spacing.xs,
   },
   canvasIconButton: {
-    width: 32,
-    height: 32,
+    width: 44,
+    height: 44,
     borderRadius: BorderRadius.sm,
     backgroundColor: Colors.surface,
     borderWidth: 1,

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -47,12 +47,12 @@
       "yourDrawing": "Deine Zeichnung",
       "original": "Original",
       "rating": "Deine Bewertung",
-      "retry": "Nochmal versuchen",
-      "nextLevel": "Nächstes Level",
-      "backToMenu": "Zum Menü",
+      "retry": "Nochmal",
+      "nextLevel": "Weiter",
+      "backToMenu": "Menü",
       "allLevelsComplete": "Alle Level geschafft!",
       "allLevelsCompleteMessage": "Du hast alle 10 Level gemeistert. Du bist ein echtes Gedächtnis-Ass!",
-      "playAgain": "Nochmal von vorne",
+      "playAgain": "Von vorne",
       "replay": "▶ Abspielen",
       "replayStop": "⏹ Stopp"
     }

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -47,12 +47,12 @@
       "yourDrawing": "Your Drawing",
       "original": "Original",
       "rating": "Your Rating",
-      "retry": "Try again",
-      "nextLevel": "Next Level",
-      "backToMenu": "Back to Menu",
+      "retry": "Again",
+      "nextLevel": "Next",
+      "backToMenu": "Menu",
       "allLevelsComplete": "All levels complete!",
       "allLevelsCompleteMessage": "You have mastered all 10 levels. You are a true memory champion!",
-      "playAgain": "Start over",
+      "playAgain": "Restart",
       "replay": "▶ Replay",
       "replayStop": "⏹ Stop"
     }


### PR DESCRIPTION
- Replace standalone replay and save buttons with small icon overlays (▶/⏹ and 💾/✓) inside the drawing canvas box
- Remove bottom back button (duplicate of header), remove previous-level nav button
- Combine retry/next/menu into a single three-button row
- Shorten button labels: "Nochmal versuchen" → "Nochmal", "Nächstes Level" → "Weiter", "Zum Menü" → "Menü", "Nochmal von vorne" → "Von vorne"

https://claude.ai/code/session_017BCHfmNJpFfuaKJCwuHMbB