### PR TITLE
fix: prevent OOM crash during flood-fill on low-memory Android devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-04-11
+
+### Fixed
+- Flood-fill OOM crash on low-memory Android devices: replaced `Set<number>` visited structure with `Uint8Array` bitmap (~8× smaller), check neighbours before push to prevent stack blowup (#126)
+
+### Changed
+- Result screen: compact 3-button row, canvas icon overlays for Replay/Save, shorter labels (#125)
+- Standardized typography hierarchy and reduced button sizes (#116)
+- `docs/private/` pattern introduced for internal docs (gitignored) (#120)
+
+### Security
+- CI: fixed `docs-privacy` false positives; tightened sensitive-filename list to real credential files (#124)
+- Removed stale branches: `develop`, `testing`, all `claude/*` and `copilot/*` branches (#124)
+
 ## [1.2.6] - 2026-04-05
 
 ### Changed

--- a/components/ParentalGate.tsx
+++ b/components/ParentalGate.tsx
@@ -86,7 +86,7 @@ export default function ParentalGate({ visible, onSuccess, onCancel }: ParentalG
               styles.input,
               {
                 color: colors.text.primary,
-                borderColor: showError ? '#e53e3e' : colors.border,
+                borderColor: showError ? colors.error : colors.border,
                 backgroundColor: colors.background,
               },
             ]}
@@ -104,7 +104,7 @@ export default function ParentalGate({ visible, onSuccess, onCancel }: ParentalG
           />
 
           {showError && (
-            <Text style={styles.errorText}>
+            <Text style={[styles.errorText, { color: colors.error }]}>
               {t('parentalGate.wrongAnswer')}
             </Text>
           )}
@@ -176,8 +176,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   errorText: {
-    color: '#e53e3e',
-    fontSize: FontSize.xs ?? 12,
+    fontSize: FontSize.xs,
     textAlign: 'center',
   },
   buttons: {

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -83,15 +83,18 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
     if (!pendingUrl) return;
     const url = pendingUrl;
     setPendingUrl(null);
+    const errorMsg = url.includes('ko-fi.com')
+      ? t('settings.browserError')
+      : t('settings.browserErrorGeneric');
     try {
       const supported = await Linking.canOpenURL(url);
       if (supported) {
         await Linking.openURL(url);
       } else {
-        Alert.alert(t('settings.error'), t('settings.browserError'));
+        Alert.alert(t('settings.error'), errorMsg);
       }
     } catch {
-      Alert.alert(t('settings.error'), t('settings.browserError'));
+      Alert.alert(t('settings.error'), errorMsg);
     }
   };
 

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -81,6 +81,7 @@
     "feedbackEmailBody": "Hallo,\n\nIch habe Feedback zu Merke und Male:\n\n",
     "feedbackEmailError": "E-Mail-Client konnte nicht geöffnet werden. Bitte sende dein Feedback an: devsven@posteo.de",
     "browserError": "Browser konnte nicht geöffnet werden. Bitte besuche: https://ko-fi.com/s540d",
+    "browserErrorGeneric": "Browser konnte nicht geöffnet werden.",
     "shareMessage": "Schau dir diese coole Gedächtnistraining-App an: Merke und Male! https://github.com/S540d/DrawFromMemory",
     "aboutSupport": "Über & Support",
     "feedback": "Feedback",

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -81,6 +81,7 @@
     "feedbackEmailBody": "Hello,\n\nI have feedback about Remember & Draw:\n\n",
     "feedbackEmailError": "Could not open email client. Please send your feedback to: devsven@posteo.de",
     "browserError": "Could not open browser. Please visit: https://ko-fi.com/s540d",
+    "browserErrorGeneric": "Could not open browser.",
     "shareMessage": "Check out this cool memory training app: Remember & Draw! https://github.com/S540d/DrawFromMemory",
     "aboutSupport": "About & Support",
     "feedback": "Feedback",

--- a/services/FloodFillService.ts
+++ b/services/FloodFillService.ts
@@ -1,6 +1,7 @@
 // Maximum pixels for flood-fill to limit runtime/memory usage and guard against
-// runaway fills (the fill may stop early when this limit is hit)
-export const MAX_FLOOD_FILL_PIXELS = 500000;
+// runaway fills (the fill may stop early when this limit is hit).
+// Reduced from 500 000 to 200 000 to prevent OOM on low-memory Android devices.
+export const MAX_FLOOD_FILL_PIXELS = 200000;
 
 export interface RGBAColor {
   r: number;
@@ -62,17 +63,22 @@ export function floodFillPixels(
     return false;
   }
 
-  const stack: { x: number; y: number }[] = [{ x: x0, y: y0 }];
-  const visited = new Set<number>();
+  // Use a flat Uint8Array as a visited bitmap – one byte per pixel index.
+  // This is ~8× smaller than a Set<number> and avoids GC pressure on old Android devices.
+  const totalPixels = width * height;
+  const visited = new Uint8Array(totalPixels);
 
-  while (stack.length > 0 && visited.size < MAX_FLOOD_FILL_PIXELS) {
-    const { x, y } = stack.pop()!;
+  // Use flat pixel indices (not byte offsets) throughout to keep the bitmap compact.
+  const stack: number[] = [y0 * width + x0];
+  visited[y0 * width + x0] = 1;
+  let filledCount = 0;
 
-    if (x < 0 || x >= width || y < 0 || y >= height) continue;
+  while (stack.length > 0 && filledCount < MAX_FLOOD_FILL_PIXELS) {
+    const idx = stack.pop()!;
+    const x = idx % width;
+    const y = (idx - x) / width;
 
-    const pos = (y * width + x) * 4;
-    if (visited.has(pos)) continue;
-
+    const pos = idx * 4;
     const r = pixels[pos];
     const g = pixels[pos + 1];
     const b = pixels[pos + 2];
@@ -88,17 +94,19 @@ export function floodFillPixels(
       continue;
     }
 
-    visited.add(pos);
     pixels[pos] = targetColor.r;
     pixels[pos + 1] = targetColor.g;
     pixels[pos + 2] = targetColor.b;
     pixels[pos + 3] = targetColor.a;
+    filledCount++;
 
-    stack.push({ x: x + 1, y });
-    stack.push({ x: x - 1, y });
-    stack.push({ x, y: y + 1 });
-    stack.push({ x, y: y - 1 });
+    // Push neighbours only if in-bounds and not yet visited.
+    // Checking before pushing keeps the stack small (avoids quadratic blowup).
+    if (x + 1 < width  && !visited[idx + 1])     { visited[idx + 1] = 1;     stack.push(idx + 1); }
+    if (x - 1 >= 0     && !visited[idx - 1])     { visited[idx - 1] = 1;     stack.push(idx - 1); }
+    if (y + 1 < height && !visited[idx + width]) { visited[idx + width] = 1; stack.push(idx + width); }
+    if (y - 1 >= 0     && !visited[idx - width]) { visited[idx - width] = 1; stack.push(idx - width); }
   }
 
-  return visited.size > 0;
+  return filledCount > 0;
 }

--- a/services/__tests__/FloodFillService.test.ts
+++ b/services/__tests__/FloodFillService.test.ts
@@ -116,6 +116,6 @@ describe('floodFillPixels', () => {
   });
 
   it('exports MAX_FLOOD_FILL_PIXELS constant', () => {
-    expect(MAX_FLOOD_FILL_PIXELS).toBe(500000);
+    expect(MAX_FLOOD_FILL_PIXELS).toBe(200000);
   });
 });


### PR DESCRIPTION
## Summary

- Replace `Set<number>` visited structure with a `Uint8Array` bitmap (~8× smaller in memory) to prevent OOM on low-memory Android devices
- Check neighbours before pushing to the stack (not only on pop) to prevent quadratic stack growth
- Reduce `MAX_FLOOD_FILL_PIXELS` from 500 000 to 200 000 as an additional safety guard

Fixes #126

## Root cause

Two issues combined caused the "Ups! etwas ist schief gelaufen" error on old Android devices when using the fill tool:

1. `Set<number>` with up to 500 000 entries → excessive heap pressure on devices with < 512 MB RAM → OOM → ErrorBoundary triggered
2. Each pixel pushed 4 neighbours unconditionally → stack could grow to millions of entries before duplicates were caught on pop

## Test plan

- [ ] All existing `FloodFillService` tests pass (9/9)
- [ ] Fill tool works on low-memory Android device (e.g. Android 8 / 1 GB RAM)
- [ ] Large circles fill completely without the app freezing or crashing
- [ ] Fill stops gracefully at colour boundaries (no bleed-through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)