### PR TITLE
fix: Android nav bar overlap + TypeScript errors (#133)

### DIFF
--- a/app/game.tsx
+++ b/app/game.tsx
@@ -284,7 +284,7 @@ export default function GameScreen() {
     return (
       <ScrollView
         style={[styles.phaseContainer, { padding: 0 }]}
-        contentContainerStyle={[styles.resultContent, { paddingBottom: Math.max(insets.bottom, Spacing.md) }]}
+        contentContainerStyle={[styles.resultContent, { paddingBottom: Spacing.md }]}
         showsVerticalScrollIndicator={false}
       >
         <Text style={styles.phaseTitle}>{t('game.result.title')}</Text>
@@ -380,7 +380,7 @@ export default function GameScreen() {
   };
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { paddingBottom: insets.bottom }]}>
       {/* Header */}
       <View style={[styles.header, { paddingVertical: layout.headerPaddingVertical, paddingHorizontal: layout.headerPaddingHorizontal }]}>
         <TouchableOpacity

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -284,7 +284,7 @@ export default function GameScreen() {
     return (
       <ScrollView
         style={[styles.phaseContainer, { padding: 0 }]}
-        contentContainerStyle={[styles.resultContent, { paddingBottom: Spacing.md }]}
+        contentContainerStyle={styles.resultContent}
         showsVerticalScrollIndicator={false}
       >
         <Text style={styles.phaseTitle}>{t('game.result.title')}</Text>

--- a/components/LevelImageDisplay.tsx
+++ b/components/LevelImageDisplay.tsx
@@ -598,7 +598,7 @@ export default function LevelImageDisplay({ image, size = 300, revealStep }: Pro
 
   // Progressive reveal: only show children up to revealStep
   if (revealStep !== undefined) {
-    const children = React.Children.toArray(svgElement.props.children);
+    const children = React.Children.toArray((svgElement.props as { children?: React.ReactNode }).children);
     const visibleChildren = children.slice(0, revealStep + 1);
     const cloned = React.cloneElement(svgElement, {}, ...visibleChildren);
     return (

--- a/components/LevelImageDisplay.tsx
+++ b/components/LevelImageDisplay.tsx
@@ -598,7 +598,7 @@ export default function LevelImageDisplay({ image, size = 300, revealStep }: Pro
 
   // Progressive reveal: only show children up to revealStep
   if (revealStep !== undefined) {
-    const children = React.Children.toArray((svgElement.props as { children?: React.ReactNode }).children);
+    const children = React.Children.toArray((svgElement.props as React.ComponentProps<typeof Svg>).children);
     const visibleChildren = children.slice(0, revealStep + 1);
     const cloned = React.cloneElement(svgElement, {}, ...visibleChildren);
     return (

--- a/services/ThemeContext.tsx
+++ b/services/ThemeContext.tsx
@@ -187,7 +187,8 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
     let isMounted = true;
 
     // Set initial system theme after mount (client-side only)
-    setSystemTheme(Appearance.getColorScheme() || 'light');
+    const initialScheme = Appearance.getColorScheme();
+    setSystemTheme(initialScheme === 'dark' ? 'dark' : 'light');
 
     const initTheme = async () => {
       try {
@@ -204,7 +205,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
     // Listen to system theme changes
     const subscription = Appearance.addChangeListener(({ colorScheme }) => {
       if (isMounted) {
-        setSystemTheme(colorScheme || 'light');
+        setSystemTheme(colorScheme === 'dark' ? 'dark' : 'light');
       }
     });
 

--- a/services/ThemeContext.tsx
+++ b/services/ThemeContext.tsx
@@ -9,6 +9,11 @@ import storageManager from './StorageManager';
 
 export type Theme = 'light' | 'dark' | 'system';
 
+/** Maps ColorSchemeName (which can be null or "unspecified") to a concrete light/dark value. */
+function normalizeColorScheme(scheme: ReturnType<typeof Appearance.getColorScheme>): 'light' | 'dark' {
+  return scheme === 'dark' ? 'dark' : 'light';
+}
+
 export interface ThemeColors {
   // Primary
   primary: string;
@@ -187,8 +192,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
     let isMounted = true;
 
     // Set initial system theme after mount (client-side only)
-    const initialScheme = Appearance.getColorScheme();
-    setSystemTheme(initialScheme === 'dark' ? 'dark' : 'light');
+    setSystemTheme(normalizeColorScheme(Appearance.getColorScheme()));
 
     const initTheme = async () => {
       try {
@@ -205,7 +209,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
     // Listen to system theme changes
     const subscription = Appearance.addChangeListener(({ colorScheme }) => {
       if (isMounted) {
-        setSystemTheme(colorScheme === 'dark' ? 'dark' : 'light');
+        setSystemTheme(normalizeColorScheme(colorScheme));
       }
     });
 


### PR DESCRIPTION
## Problem

Auf Android-Geräten mit Software-Navigationsleiste (Home, Zurück, Recents) wurden die App-Buttons in der Zeichen- und Merke-Phase von den System-Tasten überlagert. Nur die Ergebnis-Phase hatte bereits einen korrekten `paddingBottom` für den Safe-Area-Bereich.

Zusätzlich: 3 TypeScript-Fehler aus Issue #133 (pre-existing).

## Änderungen

### Layout-Fix (Android nav bar)
- `app/game.tsx`: `paddingBottom: insets.bottom` auf den äußersten Container gesetzt
- Gilt jetzt für **alle 3 Phasen** (Merken, Zeichnen, Ergebnis) gleichzeitig
- `useScreenLayout` zieht `insets.bottom` bereits von `safeHeight` ab → Canvas-Größenberechnung war schon korrekt, der physische Abstand fehlte nur im Rendering
- Ergebnis-Phase: doppeltes `insets.bottom` entfernt (war jetzt redundant)

### TypeScript-Fixes (Issue #133)
- `services/ThemeContext.tsx` Z.190+208: `ColorSchemeName` kann `"unspecified"` sein → explizites ternäres Mapping statt `|| 'light'` Fallback (TS2345)
- `components/LevelImageDisplay.tsx` Z.601: `svgElement.props` als `{ children?: React.ReactNode }` gecastet (TS18046)

## Test

- [x] 241 Tests, alle grün
- [x] `npx tsc --noEmit` fehlerfrei

Closes #133