### PR TITLE
fix: correct home screen language and result screen title (#145)

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Merke und Male",
     "slug": "merke-und-male",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "platforms": [
       "ios",
       "android",
@@ -43,7 +43,7 @@
       },
       "package": "com.s540d.merkeundmale",
       "permissions": [],
-      "versionCode": 50,
+      "versionCode": 51,
       "newArchEnabled": false,
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.s540d.merkeundmale",
       "privacyPolicy": "https://s540d.github.io/DrawFromMemory/PRIVACY_POLICY.html"

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,8 +5,8 @@ import { ThemeProvider, useTheme } from '@services/ThemeContext';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { ErrorBoundary } from '@components/ErrorBoundary';
 import AnimatedSplashScreen from '@components/AnimatedSplashScreen';
-import { useCallback, useEffect, useState } from 'react';
-import { initLanguage } from '@services/i18n';
+import { useCallback, useEffect, useState, useReducer } from 'react';
+import { initLanguage, addLanguageChangeListener } from '@services/i18n';
 import { initSentry } from '@services/SentryService';
 
 // Initialize Sentry as early as possible (no-op on web or without DSN)
@@ -19,12 +19,15 @@ function RootLayoutContent() {
   const { theme, colors } = useTheme();
   const [showSplash, setShowSplash] = useState(true);
   const handleSplashFinish = useCallback(() => setShowSplash(false), []);
+  const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
 
-  // Initialize language from storage
+  // Initialize language from storage, then re-render so all screens show the correct language
   useEffect(() => {
+    const unsubscribe = addLanguageChangeListener(() => forceUpdate());
     initLanguage().catch((error) => {
       console.error('Failed to initialize language:', error);
     });
+    return unsubscribe;
   }, []);
 
   return (

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -117,7 +117,7 @@ export default function GameScreen() {
             <ErrorBoundary>
               <LevelImageDisplay image={currentImage} size={layout.memorizeImageSize} revealStep={revealStep} />
             </ErrorBoundary>
-            <Text style={styles.imageName}>{currentImage.displayName}</Text>
+            <Text style={styles.imageName}>{currentLang === 'en' ? currentImage.displayNameEn : currentImage.displayName}</Text>
             <Text style={styles.imageInfo}>
               Level {levelNumber} • {currentImage.strokeCount} Striche
             </Text>

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -271,11 +271,11 @@ export default function GameScreen() {
   // Render Result Phase
   const renderResultPhase = () => {
     const getFeedbackText = (rating: number) => {
-      if (rating === 5) return 'Perfekt! Du bist ein Gedächtnis-Meister!';
-      if (rating === 4) return 'Sehr gut! Fast perfekt!';
-      if (rating === 3) return 'Gut gemacht! Weiter so!';
-      if (rating >= 1) return 'Das war schon besser als vorhin, willst du es trotzdem nochmal versuchen?';
-      return 'Wie viele Sterne gibst du dir?';
+      if (rating === 5) return t('game.result.feedback5');
+      if (rating === 4) return t('game.result.feedback4');
+      if (rating === 3) return t('game.result.feedback3');
+      if (rating >= 1) return t('game.result.feedback1');
+      return t('game.result.tapStars');
     };
 
     // Berechne responsive Bildgröße: 40% der Bildschirmbreite, min 150px, max 250px
@@ -297,7 +297,7 @@ export default function GameScreen() {
             <Text style={styles.feedbackText}>{getFeedbackText(userRating)}</Text>
           </AnimatedFeedback>
           {userRating === 0 && (
-            <Text style={styles.feedbackText}>Tippe auf die Sterne, um dich zu bewerten!</Text>
+            <Text style={styles.feedbackText}>{t('game.result.tapStars')}</Text>
           )}
         </View>
 
@@ -388,7 +388,7 @@ export default function GameScreen() {
           accessibilityLabel={t('common.back')}
           accessibilityRole="button"
         >
-          <Text style={styles.backButton}>← Zurück</Text>
+          <Text style={styles.backButton}>← {t('common.back')}</Text>
         </TouchableOpacity>
         <View style={styles.headerCenter}>
           <Text style={styles.levelBadge}>Level {levelNumber}</Text>

--- a/app/levels.tsx
+++ b/app/levels.tsx
@@ -59,7 +59,7 @@ export default function LevelsScreen() {
       {/* Header */}
       <View style={[styles.header, { borderBottomColor: colors.surface }]}>
         <TouchableOpacity onPress={() => router.back()}>
-          <Text style={[styles.backButton, { color: colors.primary }]}>← Zurück</Text>
+          <Text style={[styles.backButton, { color: colors.primary }]}>← {t('common.back')}</Text>
         </TouchableOpacity>
         <Text style={[styles.title, { color: colors.text.primary }]}>{t('levels.title')}</Text>
       </View>

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -44,6 +44,11 @@
     },
     "result": {
       "title": "Bewerte selbst:",
+      "tapStars": "Tippe auf die Sterne, um dich zu bewerten!",
+      "feedback5": "Perfekt! Du bist ein Gedächtnis-Meister!",
+      "feedback4": "Sehr gut! Fast perfekt!",
+      "feedback3": "Gut gemacht! Weiter so!",
+      "feedback1": "Das war schon besser als vorhin, willst du es trotzdem nochmal versuchen?",
       "yourDrawing": "Deine Zeichnung",
       "original": "Original",
       "rating": "Deine Bewertung",

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -43,7 +43,7 @@
       "done": "Fertig"
     },
     "result": {
-      "title": "Ergebnis",
+      "title": "Bewerte selbst:",
       "yourDrawing": "Deine Zeichnung",
       "original": "Original",
       "rating": "Deine Bewertung",

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -43,7 +43,7 @@
       "done": "Done"
     },
     "result": {
-      "title": "Result",
+      "title": "Rate yourself:",
       "yourDrawing": "Your Drawing",
       "original": "Original",
       "rating": "Your Rating",

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -44,6 +44,11 @@
     },
     "result": {
       "title": "Rate yourself:",
+      "tapStars": "Tap the stars to rate yourself!",
+      "feedback5": "Perfect! You are a memory master!",
+      "feedback4": "Very good! Almost perfect!",
+      "feedback3": "Well done! Keep it up!",
+      "feedback1": "That was already better than before, do you still want to try again?",
       "yourDrawing": "Your Drawing",
       "original": "Original",
       "rating": "Your Rating",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merke-und-male",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "main": "expo-router/entry",
   "homepage": "https://s540d.github.io/DrawFromMemory/",
   "repository": {

--- a/services/__tests__/i18n.test.ts
+++ b/services/__tests__/i18n.test.ts
@@ -21,13 +21,14 @@ describe('i18n Service', () => {
   let getLanguage: any;
   let initLanguage: any;
   let getDeviceLanguage: any;
+  let addLanguageChangeListener: any;
   let storageManager: any;
   let Localization: any;
 
   beforeEach(() => {
     // Reset the module to clear isInitialized flag
     jest.resetModules();
-    
+
     // Re-import modules
     storageManager = require('../StorageManager').default;
     Localization = require('expo-localization');
@@ -36,7 +37,8 @@ describe('i18n Service', () => {
     getLanguage = i18n.getLanguage;
     initLanguage = i18n.initLanguage;
     getDeviceLanguage = i18n.getDeviceLanguage;
-    
+    addLanguageChangeListener = i18n.addLanguageChangeListener;
+
     // Clear mock history
     jest.clearAllMocks();
   });
@@ -132,6 +134,47 @@ describe('i18n Service', () => {
       await initLanguage();
       
       expect(consoleWarnSpy).toHaveBeenCalledWith('Failed to load language from storage:', expect.any(Error));
+      expect(getLanguage()).toBe('en');
+      consoleWarnSpy.mockRestore();
+    });
+  });
+
+  describe('addLanguageChangeListener', () => {
+    it('should call listener after initLanguage resolves', async () => {
+      storageManager.getSetting.mockResolvedValueOnce('de');
+      const listener = jest.fn();
+      addLanguageChangeListener(listener);
+
+      await initLanguage();
+
+      expect(listener).toHaveBeenCalledWith('de');
+    });
+
+    it('should call listener after setLanguage', async () => {
+      const listener = jest.fn();
+      addLanguageChangeListener(listener);
+
+      await setLanguage('en');
+
+      expect(listener).toHaveBeenCalledWith('en');
+    });
+
+    it('should not call listener after unsubscribing', async () => {
+      const listener = jest.fn();
+      const unsubscribe = addLanguageChangeListener(listener);
+      unsubscribe();
+
+      await setLanguage('en');
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('should not break language init if a listener throws', async () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      storageManager.getSetting.mockResolvedValueOnce('en');
+      addLanguageChangeListener(() => { throw new Error('listener error'); });
+
+      await expect(initLanguage()).resolves.toBeUndefined();
       expect(getLanguage()).toBe('en');
       consoleWarnSpy.mockRestore();
     });

--- a/services/i18n.ts
+++ b/services/i18n.ts
@@ -18,7 +18,15 @@ let isInitialized = false;
 const listeners: Set<LanguageChangeListener> = new Set();
 
 function notifyListeners(lang: Language): void {
-  listeners.forEach((fn) => fn(lang));
+  listeners.forEach((fn) => {
+    try {
+      fn(lang);
+    } catch (error) {
+      if (__DEV__) {
+        console.warn('Language change listener failed:', error);
+      }
+    }
+  });
 }
 
 export function addLanguageChangeListener(fn: LanguageChangeListener): () => void {

--- a/services/i18n.ts
+++ b/services/i18n.ts
@@ -10,10 +10,21 @@ import * as Localization from 'expo-localization';
 
 type Language = 'de' | 'en';
 type TranslationKey = string;
+type LanguageChangeListener = (lang: Language) => void;
 
 const translations = { de, en };
 let currentLanguage: Language = 'en';
 let isInitialized = false;
+const listeners: Set<LanguageChangeListener> = new Set();
+
+function notifyListeners(lang: Language): void {
+  listeners.forEach((fn) => fn(lang));
+}
+
+export function addLanguageChangeListener(fn: LanguageChangeListener): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
 
 /**
  * Detects the device's locale and returns a supported language
@@ -68,6 +79,7 @@ export async function initLanguage(): Promise<void> {
       await storageManager.setSetting('language', currentLanguage);
     }
     isInitialized = true;
+    notifyListeners(currentLanguage);
   } catch (error) {
     if (__DEV__) {
       console.warn('Failed to load language from storage:', error);
@@ -83,6 +95,7 @@ export async function initLanguage(): Promise<void> {
       }
     }
     isInitialized = true; // Mark as initialized even on error to avoid repeated attempts
+    notifyListeners(currentLanguage);
   }
 }
 
@@ -91,6 +104,7 @@ export async function initLanguage(): Promise<void> {
  */
 export async function setLanguage(lang: Language): Promise<void> {
   currentLanguage = lang;
+  notifyListeners(lang);
   try {
     await storageManager.setSetting('language', lang);
   } catch (error) {
@@ -156,4 +170,4 @@ export function useTranslation() {
   };
 }
 
-export default { t, setLanguage, getLanguage, useTranslation, initLanguage, getDeviceLanguage };
+export default { t, setLanguage, getLanguage, useTranslation, initLanguage, getDeviceLanguage, addLanguageChangeListener };


### PR DESCRIPTION
## Summary

- **Home screen englisch**: `currentLanguage` startet als `'en'`, `initLanguage()` läuft async — beim ersten Render war die Sprache noch nicht geladen. Fix: `addLanguageChangeListener` in `i18n.ts`, `_layout.tsx` registriert sich und erzwingt nach dem Init einen Re-Render.
- **Ergebnis-Screen Titel**: `game.result.title` von `"Ergebnis"` → `"Bewerte selbst:"` (DE) und `"Result"` → `"Rate yourself:"` (EN).

## Test plan

- [ ] App auf Deutsch-Gerät starten → Startseite zeigt "Merke und Male" (nicht "Remember & Draw")
- [ ] Level spielen → Ergebnis-Screen zeigt "Bewerte selbst:" statt "Ergebnis"
- [ ] Sprache in Einstellungen wechseln → sofortige Wirkung dank Listener
- [ ] 241 Tests grün ✅
- [ ] TypeScript fehlerfrei ✅

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)