### PR TITLE
feat: Redesign Phase 4 — Result Screen Redesign

### DIFF
--- a/app/game.tsx
+++ b/app/game.tsx
@@ -33,6 +33,8 @@ export default function GameScreen() {
   const { screenWidth, isSmall } = layout;
   const [showSettings, setShowSettings] = useState(false);
   const [showColorPicker, setShowColorPicker] = useState(false);
+  const [showHintModal, setShowHintModal] = useState(false);
+  const [hasUsedHint, setHasUsedHint] = useState(false);
 
   // Drawing Canvas Hook
   const drawing = useDrawingCanvas();
@@ -71,6 +73,22 @@ export default function GameScreen() {
     drawingPaths: drawing.paths,
     clearCanvas: drawing.clearCanvas,
   });
+
+  // Reset hint joker when level changes
+  const handleRestartCurrentLevel = () => {
+    setHasUsedHint(false);
+    restartCurrentLevel();
+  };
+
+  const handleStartNextLevel = () => {
+    setHasUsedHint(false);
+    startNextLevel();
+  };
+
+  const handleRestartFromLevel1 = () => {
+    setHasUsedHint(false);
+    restartFromLevel1();
+  };
 
   // Initialize sound manager
   useEffect(() => {
@@ -127,8 +145,37 @@ export default function GameScreen() {
 
   // Render Draw Phase
   const renderDrawPhase = () => {
+    const levelName = currentLang === 'en' ? currentImage?.displayNameEn : currentImage?.displayName;
     return (
     <View style={styles.phaseContainer}>
+      {/* Info-Streifen: Thumbnail + Aufgabe + Hint-Joker */}
+      <View style={styles.infoStrip}>
+        {currentImage && (
+          <View style={styles.infoThumbnail}>
+            <LevelImageDisplay image={currentImage} size={44} />
+          </View>
+        )}
+        <Text style={styles.infoStripText} numberOfLines={2}>
+          {t('game.draw.drawFromMemory')}{levelName ? ` — ${levelName}` : ''}
+        </Text>
+        <TouchableOpacity
+          style={[styles.hintButton, hasUsedHint && styles.hintButtonUsed]}
+          onPress={() => {
+            if (!hasUsedHint) {
+              setHasUsedHint(true);
+              setShowHintModal(true);
+            }
+          }}
+          disabled={hasUsedHint}
+          accessibilityLabel={hasUsedHint ? t('game.draw.hintUsed') : t('game.draw.hintButton')}
+          accessibilityRole="button"
+        >
+          <Text style={[styles.hintButtonText, hasUsedHint && styles.hintButtonTextUsed]}>
+            {hasUsedHint ? '👁 ✓' : t('game.draw.hintButton')}
+          </Text>
+        </TouchableOpacity>
+      </View>
+
       {/* Zeichenfläche mit react-native-skia */}
       <View style={[styles.canvasContainer, dynCanvasContainer]}>
         <ErrorBoundary>
@@ -382,15 +429,15 @@ export default function GameScreen() {
 
         {/* Action Buttons */}
         <View style={styles.actionRow}>
-          <TouchableOpacity style={styles.actionButton} onPress={restartCurrentLevel}>
+          <TouchableOpacity style={styles.actionButton} onPress={handleRestartCurrentLevel}>
             <Text style={styles.actionButtonText}>{t('game.result.retry')}</Text>
           </TouchableOpacity>
           {levelNumber < getTotalLevels() ? (
-            <TouchableOpacity style={[styles.actionButton, styles.actionButtonPrimary]} onPress={startNextLevel}>
+            <TouchableOpacity style={[styles.actionButton, styles.actionButtonPrimary]} onPress={handleStartNextLevel}>
               <Text style={[styles.actionButtonText, styles.actionButtonPrimaryText]}>{t('game.result.nextLevel')} →</Text>
             </TouchableOpacity>
           ) : (
-            <TouchableOpacity style={[styles.actionButton, styles.actionButtonPrimary]} onPress={restartFromLevel1}>
+            <TouchableOpacity style={[styles.actionButton, styles.actionButtonPrimary]} onPress={handleRestartFromLevel1}>
               <Text style={[styles.actionButtonText, styles.actionButtonPrimaryText]}>{t('game.result.playAgain')}</Text>
             </TouchableOpacity>
           )}
@@ -472,6 +519,36 @@ export default function GameScreen() {
             </View>
           </View>
         </View>
+      </Modal>
+
+      {/* Hint Modal — Vorlage einmal ansehen */}
+      <Modal
+        visible={showHintModal}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setShowHintModal(false)}
+      >
+        <TouchableOpacity
+          style={styles.modalOverlay}
+          activeOpacity={1}
+          onPress={() => setShowHintModal(false)}
+          accessibilityRole="button"
+          accessibilityLabel={t('common.close')}
+        >
+          <View style={styles.hintModal}>
+            <View style={styles.hintModalHeader}>
+              <Text style={styles.hintModalTitle}>{t('game.draw.hintModalTitle')}</Text>
+              <TouchableOpacity onPress={() => setShowHintModal(false)} style={styles.closeButton}>
+                <Text style={styles.closeText}>✕</Text>
+              </TouchableOpacity>
+            </View>
+            {currentImage && (
+              <ErrorBoundary>
+                <LevelImageDisplay image={currentImage} size={Math.min(screenWidth - 80, 300)} />
+              </ErrorBoundary>
+            )}
+          </View>
+        </TouchableOpacity>
       </Modal>
 
       {/* Phase Content */}
@@ -1032,6 +1109,76 @@ const styles = StyleSheet.create({
   },
   strokeWidthButtonTextActive: {
     color: Colors.background,
+  },
+  // Info-Streifen (Draw Phase)
+  infoStrip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    backgroundColor: Colors.surface,
+    borderRadius: BorderRadius.xl,
+    padding: Spacing.sm,
+    marginBottom: Spacing.xs,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    ...Colors.shadow.small,
+  },
+  infoThumbnail: {
+    width: 52,
+    height: 44,
+    borderRadius: BorderRadius.md,
+    overflow: 'hidden',
+    flexShrink: 0,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  infoStripText: {
+    flex: 1,
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.semibold,
+    color: Colors.text.primary,
+  },
+  hintButton: {
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: Spacing.xs,
+    borderRadius: BorderRadius.md,
+    backgroundColor: Colors.primary,
+    flexShrink: 0,
+    ...Colors.shadow.small,
+  },
+  hintButtonUsed: {
+    backgroundColor: Colors.border,
+    opacity: 0.5,
+  },
+  hintButtonText: {
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.bold,
+    color: Colors.surface,
+  },
+  hintButtonTextUsed: {
+    color: Colors.text.secondary,
+  },
+  // Hint Modal
+  hintModal: {
+    backgroundColor: Colors.background,
+    borderRadius: BorderRadius.xxl,
+    padding: Spacing.lg,
+    width: '90%',
+    maxWidth: 380,
+    alignItems: 'center',
+    ...Colors.shadow.large,
+  },
+  hintModalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    width: '100%',
+    marginBottom: Spacing.md,
+  },
+  hintModalTitle: {
+    fontSize: FontSize.lg,
+    fontWeight: FontWeight.semibold,
+    color: Colors.text.primary,
   },
   closeButton: {
     width: 44,

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -310,34 +310,6 @@ export default function GameScreen() {
     );
   };
 
-  // Render Star Rating (Interactive)
-  const renderStars = (rating: number, interactive: boolean = false) => {
-    return (
-      <View style={styles.starsRow}>
-        {[1, 2, 3, 4, 5].map((star) => {
-          const StarComponent = interactive ? TouchableOpacity : View;
-          return (
-            <StarComponent
-              key={star}
-              style={[
-                styles.starBox,
-                star <= rating && styles.starBoxFilled,
-              ]}
-              onPress={interactive ? () => handleRatingSubmit(star) : undefined}
-            >
-              <Text style={[
-                styles.starText,
-                star <= rating && styles.starTextFilled,
-              ]}>
-                ★
-              </Text>
-            </StarComponent>
-          );
-        })}
-      </View>
-    );
-  };
-
   // Render Result Phase
   const renderResultPhase = () => {
     const getFeedbackText = (rating: number) => {
@@ -348,8 +320,8 @@ export default function GameScreen() {
       return t('game.result.tapStars');
     };
 
-    // Berechne responsive Bildgröße: 40% der Bildschirmbreite, min 150px, max 250px
-    const imageSize = Math.min(Math.max(screenWidth * 0.4, 150), 250);
+    // Bildgröße: 44% der Bildschirmbreite, min 140px, max 220px
+    const imageSize = Math.min(Math.max(screenWidth * 0.44, 140), 220);
 
     return (
       <ScrollView
@@ -357,30 +329,29 @@ export default function GameScreen() {
         contentContainerStyle={styles.resultContent}
         showsVerticalScrollIndicator={false}
       >
-        <Text style={styles.phaseTitle}>{t('game.result.title')}</Text>
-
-        {/* Sterne-Bewertung Interaktiv */}
-        <View style={[styles.starsContainer, isSmall && styles.starsContainerSmall]}>
-          {renderStars(userRating, true)}
-          <AnimatedFeedback visible={userRating > 0}>
-            <Text style={styles.ratingText}>{userRating} Stern{userRating !== 1 ? 'e' : ''}!</Text>
-            <Text style={styles.feedbackText}>{getFeedbackText(userRating)}</Text>
-          </AnimatedFeedback>
-          {userRating === 0 && (
-            <Text style={styles.feedbackText}>{t('game.result.tapStars')}</Text>
-          )}
-        </View>
-
-        {/* Vergleich */}
+        {/* 1. Side-by-side Vergleich */}
         <View style={styles.comparisonContainer}>
-          <View style={styles.comparisonBox}>
+          {/* Vorlage */}
+          <View style={[styles.comparisonCard, { width: imageSize }]}>
+            <View style={[styles.comparisonCardHeader, styles.comparisonCardHeaderTemplate]}>
+              <Text style={[styles.comparisonCardLabel, { color: Colors.primary }]}>
+                {t('game.result.original').toUpperCase()}
+              </Text>
+            </View>
             <View style={[styles.comparisonImage, { width: imageSize, height: imageSize }]}>
               {currentImage && (
                 <LevelImageDisplay image={currentImage} size={imageSize} />
               )}
             </View>
           </View>
-          <View style={styles.comparisonBox}>
+
+          {/* Deine Zeichnung */}
+          <View style={[styles.comparisonCard, { width: imageSize }]}>
+            <View style={[styles.comparisonCardHeader, styles.comparisonCardHeaderDrawing]}>
+              <Text style={[styles.comparisonCardLabel, { color: Colors.secondary }]}>
+                {t('game.result.yourDrawing').toUpperCase()}
+              </Text>
+            </View>
             <View style={[styles.comparisonImage, { width: imageSize, height: imageSize }]}>
               <DrawingCanvas
                 width={imageSize}
@@ -401,22 +372,36 @@ export default function GameScreen() {
                       {isReplaying ? '⏹' : '▶'}
                     </Text>
                   </TouchableOpacity>
-                  <TouchableOpacity
-                    style={[styles.canvasIconButton, savedToGallery && styles.canvasIconButtonSaved]}
-                    onPress={saveToGallery}
-                    disabled={savedToGallery}
-                    accessibilityRole="button"
-                    accessibilityLabel={savedToGallery ? t('gallery.saved') : t('gallery.save')}
-                    accessibilityState={{ disabled: savedToGallery }}
-                  >
-                    <Text style={[styles.canvasIconText, savedToGallery && styles.canvasIconTextSaved]}>
-                      {savedToGallery ? '✓' : '💾'}
-                    </Text>
-                  </TouchableOpacity>
                 </View>
               )}
             </View>
           </View>
+        </View>
+
+        {/* 2. Sterne-Bewertung */}
+        <View style={[styles.starsContainer, isSmall && styles.starsContainerSmall]}>
+          <Text style={styles.phaseTitle}>{t('game.result.title')}</Text>
+          <View style={styles.starsRow}>
+            {[1, 2, 3, 4, 5].map((star) => (
+              <TouchableOpacity
+                key={star}
+                onPress={() => handleRatingSubmit(star)}
+                accessibilityRole="button"
+                accessibilityLabel={`${star} Stern${star !== 1 ? 'e' : ''}`}
+              >
+                <Text style={[styles.starEmoji, star <= userRating && styles.starEmojiActive]}>
+                  ⭐
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+          <AnimatedFeedback visible={userRating > 0}>
+            <Text style={styles.ratingText}>{userRating} Stern{userRating !== 1 ? 'e' : ''}!</Text>
+            <Text style={styles.feedbackText}>{getFeedbackText(userRating)}</Text>
+          </AnimatedFeedback>
+          {userRating === 0 && (
+            <Text style={styles.feedbackText}>{t('game.result.tapStars')}</Text>
+          )}
         </View>
 
         {/* Completion banner for Level 10 */}
@@ -427,7 +412,7 @@ export default function GameScreen() {
           </View>
         )}
 
-        {/* Action Buttons */}
+        {/* 3. Aktions-Buttons */}
         <View style={styles.actionRow}>
           <TouchableOpacity style={styles.actionButton} onPress={handleRestartCurrentLevel}>
             <Text style={styles.actionButtonText}>{t('game.result.retry')}</Text>
@@ -445,6 +430,20 @@ export default function GameScreen() {
             <Text style={styles.actionButtonText}>{t('game.result.backToMenu')}</Text>
           </TouchableOpacity>
         </View>
+
+        {/* 4. Galerie speichern */}
+        <TouchableOpacity
+          style={[styles.galleryButton, savedToGallery && styles.galleryButtonSaved]}
+          onPress={saveToGallery}
+          disabled={savedToGallery}
+          accessibilityRole="button"
+          accessibilityLabel={savedToGallery ? t('gallery.saved') : t('gallery.save')}
+          accessibilityState={{ disabled: savedToGallery }}
+        >
+          <Text style={[styles.galleryButtonText, savedToGallery && styles.galleryButtonTextSaved]}>
+            {savedToGallery ? `✓ ${t('gallery.saved')}` : `🖼 ${t('gallery.save')}`}
+          </Text>
+        </TouchableOpacity>
       </ScrollView>
     );
   };
@@ -895,28 +894,12 @@ const styles = StyleSheet.create({
     gap: Spacing.sm,
     marginBottom: Spacing.md,
   },
-  starBox: {
-    width: 48,
-    height: 48,
-    borderRadius: BorderRadius.md,
-    backgroundColor: Colors.surface,
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderWidth: 2,
-    borderColor: Colors.stars.empty,
-    ...Colors.shadow.small, // Soft & Modern: Subtile Schatten für Sterne
+  starEmoji: {
+    fontSize: 36,
+    opacity: 0.3,
   },
-  starBoxFilled: {
-    backgroundColor: Colors.stars.filled,
-    borderColor: Colors.stars.filled,
-    ...Colors.shadow.medium, // Gefüllte Sterne mit stärkerem Schatten
-  },
-  starText: {
-    fontSize: 28,
-    color: Colors.stars.empty,
-  },
-  starTextFilled: {
-    color: Colors.drawing.white,
+  starEmojiActive: {
+    opacity: 1,
   },
   ratingText: {
     fontSize: FontSize.xl,
@@ -932,26 +915,40 @@ const styles = StyleSheet.create({
   },
   comparisonContainer: {
     flexDirection: 'row',
-    gap: Spacing.md,
+    gap: Spacing.sm,
     marginBottom: Spacing.md,
     justifyContent: 'center',
   },
-  comparisonBox: {
-    alignItems: 'center',
+  comparisonCard: {
+    backgroundColor: Colors.surface,
+    borderRadius: BorderRadius.xl,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: Colors.border,
+    ...Colors.shadow.medium,
   },
-  comparisonLabel: {
-    fontSize: FontSize.sm,
-    fontWeight: FontWeight.semibold,
-    color: Colors.text.secondary,
-    textAlign: 'center',
-    marginBottom: Spacing.sm,
+  comparisonCardHeader: {
+    paddingVertical: Spacing.xs,
+    paddingHorizontal: Spacing.sm,
+  },
+  comparisonCardHeaderTemplate: {
+    backgroundColor: Colors.primary + '18',
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.primary + '22',
+  },
+  comparisonCardHeaderDrawing: {
+    backgroundColor: Colors.secondary + '18',
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.secondary + '22',
+  },
+  comparisonCardLabel: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.bold,
+    letterSpacing: 0.6,
   },
   comparisonImage: {
-    backgroundColor: Colors.surface,
-    borderRadius: BorderRadius.xl, // lg → xl (16px → 20px für Cards)
     justifyContent: 'center',
     alignItems: 'center',
-    ...Colors.shadow.medium, // Soft & Modern: Weiche Schatten für Vergleichs-Container
   },
   placeholderText: {
     fontSize: FontSize.md,
@@ -995,6 +992,29 @@ const styles = StyleSheet.create({
     fontSize: FontSize.md,
     color: Colors.text.secondary,
     textAlign: 'center',
+  },
+  galleryButton: {
+    width: '100%',
+    paddingVertical: Spacing.md,
+    borderRadius: BorderRadius.lg,
+    backgroundColor: Colors.surface,
+    borderWidth: 2,
+    borderStyle: 'dashed',
+    borderColor: Colors.border,
+    alignItems: 'center',
+    marginTop: Spacing.xs,
+  },
+  galleryButtonSaved: {
+    borderColor: Colors.success,
+    backgroundColor: Colors.success + '10',
+  },
+  galleryButtonText: {
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.semibold,
+    color: Colors.text.secondary,
+  },
+  galleryButtonTextSaved: {
+    color: Colors.success,
   },
   canvasIconRow: {
     position: 'absolute',

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -33,8 +33,6 @@ export default function GameScreen() {
   const { screenWidth, isSmall } = layout;
   const [showSettings, setShowSettings] = useState(false);
   const [showColorPicker, setShowColorPicker] = useState(false);
-  const [showToolPicker, setShowToolPicker] = useState(false);
-  const [showStrokeWidthPicker, setShowStrokeWidthPicker] = useState(false);
 
   // Drawing Canvas Hook
   const drawing = useDrawingCanvas();
@@ -144,11 +142,11 @@ export default function GameScreen() {
         </ErrorBoundary>
       </View>
 
-      {/* Kompakte Toolbar */}
-      <View style={[styles.compactToolbar, dynToolbar]}>
-        {/* Farbe */}
+      {/* Toolbar-Gruppe */}
+      <View style={[styles.toolbarGroup, dynToolbar]}>
+        {/* Reihe 1: Farb-Button */}
         <TouchableOpacity
-          style={[styles.toolbarButton, dynToolbarButton]}
+          style={[styles.colorButton, dynToolbarButton]}
           onPress={() => setShowColorPicker(true)}
           accessibilityLabel={t('game.draw.selectColor')}
           accessibilityRole="button"
@@ -157,29 +155,58 @@ export default function GameScreen() {
           <Text style={styles.toolbarButtonText}>{t('game.draw.color')}</Text>
         </TouchableOpacity>
 
-        {/* Werkzeug */}
-        <TouchableOpacity
-          style={[styles.toolbarButton, dynToolbarButton]}
-          onPress={() => setShowToolPicker(true)}
-          accessibilityLabel={t('game.draw.tool')}
-          accessibilityRole="button"
-        >
-          <Text style={styles.toolbarIcon}>{drawing.tool === 'brush' ? '🖌️' : '🪣'}</Text>
-          <Text style={styles.toolbarButtonText}>{t('game.draw.tool')}</Text>
-        </TouchableOpacity>
+        {/* Trennlinie */}
+        <View style={styles.toolbarDivider} />
 
-        {/* Strichstärke (nur bei Brush) */}
-        {drawing.tool === 'brush' && (
+        {/* Reihe 2: Pen/Fill + Strichstärken in einer Zeile */}
+        <View style={styles.toolRow}>
+          {/* Pen/Fill Toggle */}
           <TouchableOpacity
-            style={[styles.toolbarButton, dynToolbarButton]}
-            onPress={() => setShowStrokeWidthPicker(true)}
-            accessibilityLabel={t('game.draw.strokeWidth')}
+            style={[styles.toolToggleButton, drawing.tool === 'brush' && styles.toolToggleButtonActive]}
+            onPress={() => drawing.setTool('brush')}
+            accessibilityLabel={t('game.draw.toolBrush')}
             accessibilityRole="button"
           >
-            <View style={[styles.toolbarStrokePreview, { height: drawing.strokeWidth }]} />
-            <Text style={styles.toolbarButtonText}>{t('game.draw.strokeWidth')}</Text>
+            <Text style={styles.toolToggleIcon}>🖌️</Text>
           </TouchableOpacity>
-        )}
+          <TouchableOpacity
+            style={[styles.toolToggleButton, drawing.tool === 'fill' && styles.toolToggleButtonActive]}
+            onPress={() => drawing.setTool('fill')}
+            accessibilityLabel={t('game.draw.toolFill')}
+            accessibilityRole="button"
+          >
+            <Text style={styles.toolToggleIcon}>🪣</Text>
+          </TouchableOpacity>
+
+          {/* Vertikaler Trenner */}
+          <View style={styles.toolRowSeparator} />
+
+          {/* Strichstärken-Circles */}
+          {([2, 3, 5] as const).map((size) => (
+            <TouchableOpacity
+              key={size}
+              style={[
+                styles.strokeCircleButton,
+                drawing.tool === 'fill' && styles.strokeCircleDisabled,
+              ]}
+              onPress={() => { if (drawing.tool !== 'fill') drawing.setStrokeWidth(size); }}
+              disabled={drawing.tool === 'fill'}
+              accessibilityLabel={`${t('game.draw.strokeWidth')} ${size}`}
+              accessibilityRole="button"
+            >
+              <View style={[
+                styles.strokeCircle,
+                {
+                  width: size === 2 ? 10 : size === 3 ? 16 : 22,
+                  height: size === 2 ? 10 : size === 3 ? 16 : 22,
+                  backgroundColor: drawing.strokeWidth === size && drawing.tool !== 'fill'
+                    ? drawing.color
+                    : Colors.border,
+                },
+              ]} />
+            </TouchableOpacity>
+          ))}
+        </View>
       </View>
 
       {/* Buttons */}
@@ -199,12 +226,10 @@ export default function GameScreen() {
           accessibilityRole="button"
           onPress={() => {
             if (Platform.OS === 'web') {
-              // Auf Web: Direktes Löschen ohne Alert (Alert funktioniert nicht zuverlässig)
               if (drawing.paths.length > 0 && window.confirm('Möchtest du wirklich die gesamte Zeichnung löschen?')) { // platform-safe
                 drawing.setPaths([]);
               }
             } else {
-              // Native: Alert Dialog
               if (drawing.paths.length === 0) return;
               Alert.alert(
                 'Alles löschen?',
@@ -214,9 +239,7 @@ export default function GameScreen() {
                   {
                     text: 'Löschen',
                     style: 'destructive',
-                    onPress: () => {
-                      drawing.setPaths([]);
-                    }
+                    onPress: () => { drawing.setPaths([]); },
                   },
                 ]
               );
@@ -451,88 +474,6 @@ export default function GameScreen() {
         </View>
       </Modal>
 
-      {/* Tool Picker Modal */}
-      <Modal
-        visible={showToolPicker}
-        transparent
-        animationType="fade"
-        onRequestClose={() => setShowToolPicker(false)}
-      >
-        <View style={styles.modalOverlay}>
-          <View style={styles.pickerModal}>
-            <Text style={styles.pickerTitle}>{t('game.draw.tool')}</Text>
-            <View style={styles.pickerOptions}>
-              <TouchableOpacity
-                style={[styles.pickerOption, drawing.tool === 'brush' && styles.pickerOptionActive]}
-                onPress={() => {
-                  drawing.setTool('brush');
-                  setShowToolPicker(false);
-                }}
-              >
-                <Text style={styles.pickerOptionIcon}>🖌️</Text>
-                <Text style={styles.pickerOptionText}>{t('game.draw.toolBrush')}</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[styles.pickerOption, drawing.tool === 'fill' && styles.pickerOptionActive]}
-                onPress={() => {
-                  drawing.setTool('fill');
-                  setShowToolPicker(false);
-                }}
-              >
-                <Text style={styles.pickerOptionIcon}>🪣</Text>
-                <Text style={styles.pickerOptionText}>{t('game.draw.toolFill')}</Text>
-              </TouchableOpacity>
-            </View>
-          </View>
-        </View>
-      </Modal>
-
-      {/* Stroke Width Picker Modal */}
-      <Modal
-        visible={showStrokeWidthPicker}
-        transparent
-        animationType="fade"
-        onRequestClose={() => setShowStrokeWidthPicker(false)}
-      >
-        <View style={styles.modalOverlay}>
-          <View style={styles.pickerModal}>
-            <Text style={styles.pickerTitle}>{t('game.draw.strokeWidth')}</Text>
-            <View style={styles.pickerOptions}>
-              <TouchableOpacity
-                style={[styles.pickerOption, drawing.strokeWidth === 2 && styles.pickerOptionActive]}
-                onPress={() => {
-                  drawing.setStrokeWidth(2);
-                  setShowStrokeWidthPicker(false);
-                }}
-              >
-                <View style={[styles.strokePreviewLine, { height: 2 }]} />
-                <Text style={styles.pickerOptionText}>{t('game.draw.strokeWidthThin')}</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[styles.pickerOption, drawing.strokeWidth === 3 && styles.pickerOptionActive]}
-                onPress={() => {
-                  drawing.setStrokeWidth(3);
-                  setShowStrokeWidthPicker(false);
-                }}
-              >
-                <View style={[styles.strokePreviewLine, { height: 3 }]} />
-                <Text style={styles.pickerOptionText}>{t('game.draw.strokeWidthNormal')}</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[styles.pickerOption, drawing.strokeWidth === 5 && styles.pickerOptionActive]}
-                onPress={() => {
-                  drawing.setStrokeWidth(5);
-                  setShowStrokeWidthPicker(false);
-                }}
-              >
-                <View style={[styles.strokePreviewLine, { height: 5 }]} />
-                <Text style={styles.pickerOptionText}>{t('game.draw.strokeWidthThick')}</Text>
-              </TouchableOpacity>
-            </View>
-          </View>
-        </View>
-      </Modal>
-
       {/* Phase Content */}
       {phase === 'memorize' && renderMemorizePhase()}
       {phase === 'draw' && renderDrawPhase()}
@@ -716,23 +657,20 @@ const styles = StyleSheet.create({
     textShadowOffset: { width: 0, height: 0 },
     textShadowRadius: 3,
   },
-  // Kompakte Toolbar Styles
-  compactToolbar: {
-    flexDirection: 'row',
-    gap: Spacing.sm,
+  // Toolbar-Gruppe Styles
+  toolbarGroup: {
+    backgroundColor: Colors.surfaceAlt,
+    borderRadius: BorderRadius.xl,
+    padding: Spacing.sm,
     marginVertical: Spacing.sm,
+    gap: Spacing.xs,
   },
-  toolbarButton: {
-    flex: 1,
-    backgroundColor: Colors.surface,
-    borderRadius: BorderRadius.md,
-    paddingVertical: Spacing.sm,
-    paddingHorizontal: Spacing.xs,
+  colorButton: {
+    flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'center',
-    borderWidth: 2,
-    borderColor: Colors.border,
-    minHeight: 60,
+    gap: Spacing.sm,
+    paddingVertical: Spacing.xs,
+    paddingHorizontal: Spacing.xs,
   },
   toolbarColorPreview: {
     width: 28,
@@ -740,67 +678,58 @@ const styles = StyleSheet.create({
     borderRadius: BorderRadius.sm,
     borderWidth: 2,
     borderColor: Colors.border,
-    marginBottom: 4,
-  },
-  toolbarIcon: {
-    fontSize: 24,
-    marginBottom: 2,
-  },
-  toolbarStrokePreview: {
-    width: 30,
-    backgroundColor: Colors.text.primary,
-    borderRadius: 2,
-    marginBottom: 4,
   },
   toolbarButtonText: {
-    fontSize: FontSize.xs,
+    fontSize: FontSize.sm,
     color: Colors.text.secondary,
-    textAlign: 'center',
-  },
-  // Picker Modal Styles
-  pickerModal: {
-    backgroundColor: Colors.background,
-    borderRadius: BorderRadius.xl,
-    padding: Spacing.lg,
-    width: '80%',
-    maxWidth: 300,
-  },
-  pickerTitle: {
-    fontSize: FontSize.lg,
     fontWeight: FontWeight.semibold,
-    color: Colors.text.primary,
-    marginBottom: Spacing.md,
-    textAlign: 'center',
   },
-  pickerOptions: {
-    gap: Spacing.sm,
+  toolbarDivider: {
+    height: 1,
+    backgroundColor: Colors.border,
+    marginHorizontal: Spacing.xs,
   },
-  pickerOption: {
+  toolRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: Spacing.md,
-    padding: Spacing.md,
-    backgroundColor: Colors.surface,
+    gap: Spacing.sm,
+    paddingVertical: Spacing.xs,
+    paddingHorizontal: Spacing.xs,
+  },
+  toolToggleButton: {
+    width: 40,
+    height: 40,
     borderRadius: BorderRadius.md,
+    backgroundColor: Colors.surface,
+    alignItems: 'center',
+    justifyContent: 'center',
     borderWidth: 2,
     borderColor: Colors.border,
   },
-  pickerOptionActive: {
+  toolToggleButtonActive: {
+    backgroundColor: Colors.primary,
     borderColor: Colors.primary,
-    backgroundColor: Colors.primaryLight + '20',
   },
-  pickerOptionIcon: {
-    fontSize: 32,
+  toolToggleIcon: {
+    fontSize: 20,
   },
-  pickerOptionText: {
-    fontSize: FontSize.md,
-    color: Colors.text.primary,
-    flex: 1,
+  toolRowSeparator: {
+    width: 1,
+    height: 28,
+    backgroundColor: Colors.border,
+    marginHorizontal: Spacing.xs,
   },
-  strokePreviewLine: {
-    width: 40,
-    backgroundColor: Colors.text.primary,
-    borderRadius: 2,
+  strokeCircleButton: {
+    width: 36,
+    height: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  strokeCircle: {
+    borderRadius: 999,
+  },
+  strokeCircleDisabled: {
+    opacity: 0.35,
   },
   buttonRow: {
     flexDirection: 'row',

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -1,7 +1,7 @@
 /**
  * Design Tokens - Merke und Male
- * "Soft & Modern" Design-System (Option 1)
- * Warme, sanfte Ästhetik mit subtiler Tiefe und Eleganz
+ * "Warm Paper" Design-System
+ * Warme, papiertexturartige Ästhetik mit klarem Layout
  */
 
 export const Colors = {
@@ -17,18 +17,20 @@ export const Colors = {
     primary: ['#667eea', '#764ba2'],     // Lila-Gradient
     secondary: ['#f093fb', '#f5576c'],   // Rosa-Gradient
     warm: ['#FFB84D', '#FF6B6B'],        // Warm-Gradient
+    cta: ['#667eea', '#f093fb'],         // CTA-Gradient für primäre Buttons
   },
 
-  // UI Farben - "Soft & Modern"
-  background: '#FAFAFA',   // Cremeweiß (nicht pures Weiß)
-  surface: '#F5F5F5',      // Hellgrau - Karten/Container
-  surfaceElevated: '#EFEFEF', // Dunklerer Surface für mehr Tiefe
-  border: '#DDDDDD',       // Standardrahmen
+  // UI Farben - "Warm Paper"
+  background: '#f7f2eb',   // Warmes Cremeweiß - Papierton
+  surface: '#ffffff',      // Rein weiß - Cards/Container
+  surfaceElevated: '#fdfaf5', // Leicht warmes Weiß für erhöhte Elemente
+  surfaceAlt: '#ede7dd',   // Warmes Graubeige - Toolbar-Gruppen, Tab-Switcher
+  border: '#e8e0d5',       // Warmes Graubeige - Rahmen
   modalOverlay: 'rgba(0, 0, 0, 0.5)', // Halbtransparenter Overlay
   text: {
-    primary: '#2C3E50',    // Dunkelgrau - Haupttext (WCAG AAA)
-    secondary: '#5D6D7E',  // Mittelgrau - Sekundärtext (WCAG AA compliant, darkened from #7F8C8D)
-    light: '#717171',      // Grau - Platzhalter (WCAG AA compliant, darkened from #95A5A6)
+    primary: '#2c2c2c',    // Fast Schwarz - Haupttext (WCAG AAA)
+    secondary: '#9c8b7a',  // Warmes Graubraun - Sekundärtext
+    light: '#717171',      // Grau - Platzhalter (WCAG AA compliant)
   },
 
   // Shadow-System (Soft & Modern)

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -40,7 +40,11 @@
       "undo": "Rückgängig",
       "clear": "Alles löschen",
       "clearConfirm": "Wirklich alles löschen?",
-      "done": "Fertig"
+      "done": "Fertig",
+      "hintButton": "👁 1x",
+      "hintUsed": "Joker verbraucht",
+      "hintModalTitle": "Vorlage",
+      "drawFromMemory": "Zeichne aus dem Gedächtnis"
     },
     "result": {
       "title": "Bewerte selbst:",

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -40,7 +40,11 @@
       "undo": "Undo",
       "clear": "Clear all",
       "clearConfirm": "Really clear everything?",
-      "done": "Done"
+      "done": "Done",
+      "hintButton": "👁 1x",
+      "hintUsed": "Hint used",
+      "hintModalTitle": "Reference",
+      "drawFromMemory": "Draw from memory"
     },
     "result": {
       "title": "Rate yourself:",


### PR DESCRIPTION
## Summary

- **Side-by-side Vergleich** kommt jetzt zuerst (vor den Sternen)
- Zwei Cards mit farbigen Header-Balken: „ORIGINAL" (blau `#667eea`) | „DEINE ZEICHNUNG" (rosa `#f093fb`)
- Sterne als freistehendes Emoji ⭐ (inactive = 30% opacity, active = 100%) — kein Border-Box mehr
- Galerie-Speichern als separater Button mit gestricheltem Rahmen unterhalb der Aktions-Buttons
- Replay-Button (▶/⏹) für Zeitraffer bleibt als Overlay auf der Zeichnungs-Card
- **Überlagern-Feature nicht eingebaut** (wurde bewusst weggelassen)

Basiert auf Phase 3 (Hint Joker).

## Test plan

- [ ] Result-Screen vollständig durchspielen: Side-by-side sichtbar, Sterne tippbar, Feedback-Text erscheint
- [ ] Replay-Button (▶) startet Zeitraffer, ⏹ stoppt ihn
- [ ] Galerie-Speichern: Button wechselt zu ✓ grün nach Tippen
- [ ] Kein Überlagern-Toggle sichtbar
- [ ] `npm test` — 245 Tests grün
- [ ] `npx tsc --noEmit` — kein TypeScript-Fehler

🤖 Generated with [Claude Code](https://claude.com/claude-code)