### PR TITLE
fix: UX-Bugfixes — Icons, Sterne, Sprachwechsel, Settings-Grid

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Merke und Male",
     "slug": "merke-und-male",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "platforms": [
       "ios",
       "android",
@@ -43,7 +43,7 @@
       },
       "package": "com.s540d.merkeundmale",
       "permissions": [],
-      "versionCode": 53,
+      "versionCode": 54,
       "newArchEnabled": false,
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.s540d.merkeundmale",
       "privacyPolicy": "https://s540d.github.io/DrawFromMemory/PRIVACY_POLICY.html"

--- a/app.json
+++ b/app.json
@@ -43,7 +43,7 @@
       },
       "package": "com.s540d.merkeundmale",
       "permissions": [],
-      "versionCode": 54,
+      "versionCode": 55,
       "newArchEnabled": false,
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.s540d.merkeundmale",
       "privacyPolicy": "https://s540d.github.io/DrawFromMemory/PRIVACY_POLICY.html"

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -225,7 +225,7 @@ export default function GameScreen() {
             accessibilityLabel={t('game.draw.toolBrush')}
             accessibilityRole="button"
           >
-            <Text style={styles.toolToggleIcon}>🖌️</Text>
+            <Text style={styles.toolToggleIcon}>✏️</Text>
           </TouchableOpacity>
           <TouchableOpacity
             style={[styles.toolToggleButton, drawing.tool === 'fill' && styles.toolToggleButtonActive]}
@@ -758,7 +758,7 @@ const styles = StyleSheet.create({
     borderColor: Colors.primary,
   },
   toolToggleIcon: {
-    fontSize: 20,
+    fontSize: 18,
   },
   toolRowSeparator: {
     width: 1,
@@ -895,7 +895,7 @@ const styles = StyleSheet.create({
   },
   starEmoji: {
     fontSize: 36,
-    opacity: 0.3,
+    opacity: 0.15,
   },
   starEmojiActive: {
     opacity: 1,

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -301,13 +301,13 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
       <View style={[styles.card, { backgroundColor: colors.surface }]}>
         <View style={styles.actionGrid}>
           {([
-            { label: t('settings.feedback'), icon: '✉️', onPress: handleSendFeedback },
-            { label: t('settings.support'),  icon: '☕',  onPress: handleSupport },
-            { label: t('settings.share'),    icon: '↗',   onPress: handleShareApp },
-            { label: t('settings.aboutButton'), icon: 'ℹ', onPress: () => setShowAboutModal(true) },
-          ] as const).map(({ label, icon, onPress }, idx) => (
+            { id: 'feedback', label: t('settings.feedback'), icon: '✉️', onPress: handleSendFeedback },
+            { id: 'support',  label: t('settings.support'),  icon: '☕',  onPress: handleSupport },
+            { id: 'share',    label: t('settings.share'),    icon: '↗',   onPress: handleShareApp },
+            { id: 'about',    label: t('settings.aboutButton'), icon: 'ℹ', onPress: () => setShowAboutModal(true) },
+          ] as const).map(({ id, label, icon, onPress }, idx) => (
             <TouchableOpacity
-              key={label}
+              key={id}
               style={[
                 styles.actionGridItem,
                 { borderColor: colors.border },
@@ -315,8 +315,14 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
                 idx % 2 === 1 && styles.actionGridItemRight,
               ]}
               onPress={onPress}
+              accessibilityRole="button"
+              accessibilityLabel={label}
             >
-              <Text style={[styles.actionGridIcon, { color: colors.primary }]}>{icon}</Text>
+              <Text
+                accessible={false}
+                importantForAccessibility="no"
+                style={[styles.actionGridIcon, { color: colors.primary }]}
+              >{icon}</Text>
               <Text style={[styles.actionGridLabel, { color: colors.text.primary }]}>{label}</Text>
             </TouchableOpacity>
           ))}
@@ -479,13 +485,13 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     gap: Spacing.xs,
-    borderTopWidth: 1,
+    borderTopWidth: StyleSheet.hairlineWidth,
   },
   actionGridItemTop: {
     borderTopWidth: 0,
   },
   actionGridItemRight: {
-    borderLeftWidth: 1,
+    borderLeftWidth: StyleSheet.hairlineWidth,
   },
   actionGridIcon: {
     fontSize: 22,

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -38,10 +38,6 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
   const handleLanguageChange = async (lang: 'de' | 'en') => {
     await setLanguage(lang);
     setCurrentLang(lang);
-    Alert.alert(
-      t('settings.languageChanged'),
-      t('settings.languageChangedMessage')
-    );
   };
 
   const handleThemeChange = async (newTheme: 'light' | 'dark' | 'system') => {
@@ -303,10 +299,28 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
         {t('settings.aboutSupport')}
       </Text>
       <View style={[styles.card, { backgroundColor: colors.surface }]}>
-        {renderTapRow(t('settings.feedback'), handleSendFeedback)}
-        {renderTapRow(t('settings.support'), handleSupport)}
-        {renderTapRow(t('settings.share'), handleShareApp)}
-        {renderTapRow(t('settings.aboutButton'), () => setShowAboutModal(true))}
+        <View style={styles.actionGrid}>
+          {([
+            { label: t('settings.feedback'), icon: '✉️', onPress: handleSendFeedback },
+            { label: t('settings.support'),  icon: '☕',  onPress: handleSupport },
+            { label: t('settings.share'),    icon: '↗',   onPress: handleShareApp },
+            { label: t('settings.aboutButton'), icon: 'ℹ', onPress: () => setShowAboutModal(true) },
+          ] as const).map(({ label, icon, onPress }, idx) => (
+            <TouchableOpacity
+              key={label}
+              style={[
+                styles.actionGridItem,
+                { borderColor: colors.border },
+                idx < 2 && styles.actionGridItemTop,
+                idx % 2 === 1 && styles.actionGridItemRight,
+              ]}
+              onPress={onPress}
+            >
+              <Text style={[styles.actionGridIcon, { color: colors.primary }]}>{icon}</Text>
+              <Text style={[styles.actionGridLabel, { color: colors.text.primary }]}>{label}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
       </View>
 
       {renderAboutModal()}
@@ -451,6 +465,34 @@ const styles = StyleSheet.create({
   rowChevron: {
     fontSize: FontSize.lg,
     marginLeft: Spacing.sm,
+  },
+
+  // ── Action Grid ─────────────────────────────────────────────────────────
+  actionGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  actionGridItem: {
+    width: '50%',
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: Spacing.xs,
+    borderTopWidth: 1,
+  },
+  actionGridItemTop: {
+    borderTopWidth: 0,
+  },
+  actionGridItemRight: {
+    borderLeftWidth: 1,
+  },
+  actionGridIcon: {
+    fontSize: 22,
+  },
+  actionGridLabel: {
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.medium,
   },
 
   // ── Segment-Control ─────────────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merke-und-male",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "expo-router/entry",
   "homepage": "https://s540d.github.io/DrawFromMemory/",
   "repository": {


### PR DESCRIPTION
## Summary

Fixes #159 — vier UX-Bugs behoben:

- **Tool-Icons**: Pinsel-Emoji zu ✏️ geändert (besser skalierbar bei kleiner Größe), beide Icons auf fontSize 18 verkleinert
- **Sterne (Result-Screen)**: Ausgraute Sterne von `opacity: 0.3` → `0.15` — deutlicherer Kontrast zwischen angeklickt und noch nicht angeklickt
- **Sprachwechsel-Popup**: `Alert.alert()` nach Sprachänderung entfernt — i18n ist bereits reaktiv (seit #91f7a38), kein Neustart nötig
- **Settings: Aktions-Bereich**: Feedback/Support/Teilen/Über jetzt als **2×2 Grid** (statt 4 Tap-Zeilen) — kompakter, visuell klarer

## Test plan

- [ ] Tool-Icons im Zeichnen-Screen prüfen (✏️ + 🪣, beide erkennbar bei kleiner Größe)
- [ ] Result-Screen: Ausgegraute Sterne deutlich matter als aktive
- [ ] Sprache wechseln: kein Popup erscheint, UI wechselt sofort reaktiv
- [ ] Einstellungen: Aktions-Grid 2×2 korrekt dargestellt (Light + Dark Mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)