### PR TITLE
fix: i18n & Refactoring aus staging

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Merke und Male",
     "slug": "merke-und-male",
-    "version": "1.4.0",
+    "version": "1.4.2",
     "platforms": [
       "ios",
       "android",
@@ -43,7 +43,7 @@
       },
       "package": "com.s540d.merkeundmale",
       "permissions": [],
-      "versionCode": 53,
+      "versionCode": 58,
       "newArchEnabled": false,
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.s540d.merkeundmale",
       "privacyPolicy": "https://s540d.github.io/DrawFromMemory/PRIVACY_POLICY.html"

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -4,7 +4,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useScreenLayout } from '@utils/useScreenLayout';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { getTotalLevels } from '@services/LevelManager';
-import { useTranslation, getCurrentLanguage } from '@services/i18n';
+import { useTranslation, getLanguage } from '@services/i18n';
 import { useTheme } from '@services/ThemeContext';
 import { DrawingColors } from '../constants/Colors';
 import Colors from '../constants/Colors';
@@ -40,7 +40,7 @@ export default function GameScreen() {
   const drawing = useDrawingCanvas();
 
   // Get current language for accessibility
-  const currentLang = getCurrentLanguage();
+  const currentLang = getLanguage();
 
   // Level aus URL-Parameter auslesen, falls vorhanden, und validieren
   const parsedLevel = params.level ? parseInt(params.level as string, 10) : 1;
@@ -284,18 +284,18 @@ export default function GameScreen() {
           accessibilityRole="button"
           onPress={() => {
             if (Platform.OS === 'web') {
-              if (drawing.paths.length > 0 && window.confirm('Möchtest du wirklich die gesamte Zeichnung löschen?')) { // platform-safe
+              if (drawing.paths.length > 0 && window.confirm(t('game.draw.clearConfirm'))) { // platform-safe
                 drawing.setPaths([]);
               }
             } else {
               if (drawing.paths.length === 0) return;
               Alert.alert(
-                'Alles löschen?',
-                'Möchtest du wirklich die gesamte Zeichnung löschen?',
+                t('game.draw.clear'),
+                t('game.draw.clearConfirm'),
                 [
-                  { text: 'Abbrechen', style: 'cancel' },
+                  { text: t('common.cancel'), style: 'cancel' },
                   {
-                    text: 'Löschen',
+                    text: t('common.yes'),
                     style: 'destructive',
                     onPress: () => { drawing.setPaths([]); },
                   },

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -225,7 +225,7 @@ export default function GameScreen() {
             accessibilityLabel={t('game.draw.toolBrush')}
             accessibilityRole="button"
           >
-            <Text style={styles.toolToggleIcon}>🖌️</Text>
+            <Text style={styles.toolToggleIcon}>✏️</Text>
           </TouchableOpacity>
           <TouchableOpacity
             style={[styles.toolToggleButton, drawing.tool === 'fill' && styles.toolToggleButtonActive]}
@@ -462,7 +462,7 @@ export default function GameScreen() {
           accessibilityRole="button"
           accessibilityLabel={t('common.back')}
         >
-          <Text style={styles.headerTitle}>Merke & Male</Text>
+          <Text style={styles.headerTitle}>{t('app.name')}</Text>
           <Text style={styles.headerSub}>Level {levelNumber}{levelName ? ` · ${levelName}` : ''}</Text>
         </TouchableOpacity>
         <View style={styles.headerRight}>
@@ -758,7 +758,7 @@ const styles = StyleSheet.create({
     borderColor: Colors.primary,
   },
   toolToggleIcon: {
-    fontSize: 20,
+    fontSize: 18,
   },
   toolRowSeparator: {
     width: 1,
@@ -895,7 +895,7 @@ const styles = StyleSheet.create({
   },
   starEmoji: {
     fontSize: 36,
-    opacity: 0.3,
+    opacity: 0.15,
   },
   starEmojiActive: {
     opacity: 1,

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -22,7 +22,7 @@ export default function HomeScreen() {
       {/* Top bar */}
       <View style={styles.topBar}>
         <View>
-          <Text style={[styles.appTitle, { color: colors.text.primary }]}>Merke & Male</Text>
+          <Text style={[styles.appTitle, { color: colors.text.primary }]}>{t('app.name')}</Text>
           <Text style={[styles.appTagline, { color: colors.text.secondary }]}>{t('home.subtitle')}</Text>
         </View>
         <Pressable

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -38,10 +38,6 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
   const handleLanguageChange = async (lang: 'de' | 'en') => {
     await setLanguage(lang);
     setCurrentLang(lang);
-    Alert.alert(
-      t('settings.languageChanged'),
-      t('settings.languageChangedMessage')
-    );
   };
 
   const handleThemeChange = async (newTheme: 'light' | 'dark' | 'system') => {
@@ -303,10 +299,34 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
         {t('settings.aboutSupport')}
       </Text>
       <View style={[styles.card, { backgroundColor: colors.surface }]}>
-        {renderTapRow(t('settings.feedback'), handleSendFeedback)}
-        {renderTapRow(t('settings.support'), handleSupport)}
-        {renderTapRow(t('settings.share'), handleShareApp)}
-        {renderTapRow(t('settings.aboutButton'), () => setShowAboutModal(true))}
+        <View style={styles.actionGrid}>
+          {([
+            { id: 'feedback', label: t('settings.feedback'), icon: '✉️', onPress: handleSendFeedback },
+            { id: 'support',  label: t('settings.support'),  icon: '☕',  onPress: handleSupport },
+            { id: 'share',    label: t('settings.share'),    icon: '↗',   onPress: handleShareApp },
+            { id: 'about',    label: t('settings.aboutButton'), icon: 'ℹ', onPress: () => setShowAboutModal(true) },
+          ] as const).map(({ id, label, icon, onPress }, idx) => (
+            <TouchableOpacity
+              key={id}
+              style={[
+                styles.actionGridItem,
+                { borderColor: colors.border },
+                idx < 2 && styles.actionGridItemTop,
+                idx % 2 === 1 && styles.actionGridItemRight,
+              ]}
+              onPress={onPress}
+              accessibilityRole="button"
+              accessibilityLabel={label}
+            >
+              <Text
+                accessible={false}
+                importantForAccessibility="no"
+                style={[styles.actionGridIcon, { color: colors.primary }]}
+              >{icon}</Text>
+              <Text style={[styles.actionGridLabel, { color: colors.text.primary }]}>{label}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
       </View>
 
       {renderAboutModal()}
@@ -451,6 +471,34 @@ const styles = StyleSheet.create({
   rowChevron: {
     fontSize: FontSize.lg,
     marginLeft: Spacing.sm,
+  },
+
+  // ── Action Grid ─────────────────────────────────────────────────────────
+  actionGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  actionGridItem: {
+    width: '50%',
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: Spacing.xs,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  actionGridItemTop: {
+    borderTopWidth: 0,
+  },
+  actionGridItemRight: {
+    borderLeftWidth: StyleSheet.hairlineWidth,
+  },
+  actionGridIcon: {
+    fontSize: 22,
+  },
+  actionGridLabel: {
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.medium,
   },
 
   // ── Segment-Control ─────────────────────────────────────────────────────

--- a/components/__tests__/GameScreen.test.tsx
+++ b/components/__tests__/GameScreen.test.tsx
@@ -34,7 +34,7 @@ jest.mock('../../services/LevelManager', () => ({
 
 jest.mock('../../services/i18n', () => ({
   t: (key: string) => key,
-  getCurrentLanguage: () => 'en',
+  getLanguage: () => 'en',
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 

--- a/components/__tests__/GameScreen.test.tsx
+++ b/components/__tests__/GameScreen.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ back: jest.fn() }),
+  useLocalSearchParams: () => ({}),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('../../utils/useScreenLayout', () => ({
+  useScreenLayout: () => ({
+    screenWidth: 1280,
+    isSmall: false,
+    headerPaddingHorizontal: 16,
+    canvasMaxHeight: 400,
+    canvasMinHeight: 250,
+    canvasMarginVertical: 12,
+    toolbarMarginVertical: 12,
+    toolbarButtonMinHeight: 44,
+    toolbarButtonPaddingVertical: 8,
+    buttonMinHeight: 44,
+    buttonPaddingVertical: 8,
+    imagePlaceholderMinSize: 180,
+    memorizeImageSize: 220,
+  }),
+}));
+
+jest.mock('../../services/LevelManager', () => ({
+  getTotalLevels: () => 10,
+}));
+
+jest.mock('../../services/i18n', () => ({
+  t: (key: string) => key,
+  getCurrentLanguage: () => 'en',
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../../services/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#fff',
+      surface: '#f0f0f0',
+      primary: '#6200ee',
+      text: { primary: '#000', secondary: '#666', light: '#999' },
+    },
+  }),
+}));
+
+jest.mock('../../components/LevelImageDisplay', () => {
+  const { View } = require('react-native');
+  return function LevelImageDisplay() { return <View />; };
+});
+
+jest.mock('../../components/DrawingCanvas', () => {
+  const { View } = require('react-native');
+  const DrawingCanvas = () => <View testID="drawing-canvas" />;
+  return {
+    __esModule: true,
+    default: DrawingCanvas,
+    useDrawingCanvas: () => ({
+      color: '#000',
+      strokeWidth: 2,
+      tool: 'brush',
+      paths: [],
+      setPaths: jest.fn(),
+      clearCanvas: jest.fn(),
+      setColor: jest.fn(),
+      setTool: jest.fn(),
+      setStrokeWidth: jest.fn(),
+      undo: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('../../components/SettingsModal', () => {
+  const { View } = require('react-native');
+  return function SettingsModal() { return <View />; };
+});
+
+jest.mock('../../components/ErrorBoundary', () => ({
+  ErrorBoundary: ({ children }: any) => {
+    const { View } = require('react-native');
+    return <View>{children}</View>;
+  },
+}));
+
+jest.mock('../../components/AnimatedPrimitives', () => {
+  const { View } = require('react-native');
+  return {
+    AnimatedFeedback: ({ children, visible }: any) => visible ? <View>{children}</View> : null,
+  };
+});
+
+jest.mock('../../services/SoundManager', () => ({
+  __esModule: true,
+  default: { init: jest.fn(), playPhaseTransition: jest.fn() },
+}));
+
+jest.mock('../../services/useGamePhase', () => ({
+  useGamePhase: () => ({
+    phase: 'memorize',
+    setPhase: jest.fn(),
+    levelNumber: 1,
+    currentImage: null,
+    timeRemaining: 5,
+    userRating: 0,
+    revealStep: 0,
+    savedToGallery: false,
+    isReplaying: false,
+    setIsReplaying: jest.fn(),
+    replayPaths: [],
+    handleRatingSubmit: jest.fn(),
+    saveToGallery: jest.fn(),
+    startReplay: jest.fn(),
+    restartCurrentLevel: jest.fn(),
+    startNextLevel: jest.fn(),
+    restartFromLevel1: jest.fn(),
+  }),
+}));
+
+import GameScreen from '../../app/game';
+
+const getAllTexts = (getAllByType: (type: any) => any[]) => {
+  const { Text } = require('react-native');
+  return getAllByType(Text).map((n: any) => n.props.children).flat();
+};
+
+describe('GameScreen', () => {
+  it('renders the app name via translation key, not hardcoded', async () => {
+    const { UNSAFE_getAllByType } = render(<GameScreen />);
+    await act(async () => {});
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain('app.name');
+    expect(texts).not.toContain('Merke & Male');
+  });
+});

--- a/components/__tests__/HomeScreen.test.tsx
+++ b/components/__tests__/HomeScreen.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('expo-linear-gradient', () => {
+  const { View } = require('react-native');
+  return {
+    LinearGradient: ({ children, style }: any) => <View style={style}>{children}</View>,
+  };
+});
+
+jest.mock('../../components/SettingsModal', () => {
+  const { View } = require('react-native');
+  return function SettingsModal() { return <View />; };
+});
+
+jest.mock('../../services/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#fff',
+      surface: '#f0f0f0',
+      primary: '#6200ee',
+      text: { primary: '#000', secondary: '#666', light: '#999' },
+    },
+  }),
+}));
+
+jest.mock('../../services/i18n', () => ({
+  t: (key: string) => key,
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import HomeScreen from '../../app/index';
+
+const getAllTexts = (getAllByType: (type: any) => any[]) => {
+  const { Text } = require('react-native');
+  return getAllByType(Text).map((n: any) => n.props.children).flat();
+};
+
+describe('HomeScreen', () => {
+  it('renders the app name via translation key, not hardcoded', async () => {
+    const { UNSAFE_getAllByType } = render(<HomeScreen />);
+    await act(async () => {});
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain('app.name');
+    expect(texts).not.toContain('Merke & Male');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "merke-und-male",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "merke-und-male",
-      "version": "1.3.4",
+      "version": "1.4.0",
       "dependencies": {
         "@expo/metro-runtime": "~55.0.6",
         "@react-native-async-storage/async-storage": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merke-und-male",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "main": "expo-router/entry",
   "homepage": "https://s540d.github.io/DrawFromMemory/",
   "repository": {

--- a/services/ImagePoolManager.ts
+++ b/services/ImagePoolManager.ts
@@ -4,6 +4,7 @@
  */
 
 import { LevelImage, Difficulty } from '../types';
+import { getDifficultyForLevel } from './LevelManager';
 
 /**
  * Bilderpool mit allen verfügbaren Bildern
@@ -193,23 +194,6 @@ const imagePool: LevelImage[] = [
  * um direkte Wiederholungen zu vermeiden
  */
 let lastShownImages: string[] = [];
-
-/**
- * Ermittelt die Schwierigkeit basierend auf der Level-Nummer
- * IMPORTANT: Must match LevelManager.ts getDifficultyForLevel()
- * Level 1: Difficulty 1
- * Level 2-3: Difficulty 2
- * Level 4-5: Difficulty 3
- * Level 6-7: Difficulty 4
- * Level 8-10: Difficulty 5
- */
-function getDifficultyForLevel(levelNumber: number): Difficulty {
-  if (levelNumber === 1) return 1;
-  if (levelNumber <= 3) return 2;
-  if (levelNumber <= 5) return 3;
-  if (levelNumber <= 7) return 4;
-  return 5;
-}
 
 /**
  * Wählt ein zufälliges Bild für ein Level aus

--- a/services/i18n.ts
+++ b/services/i18n.ts
@@ -128,13 +128,6 @@ export function getLanguage(): Language {
 }
 
 /**
- * Alias for getLanguage() - returns current language
- */
-export function getCurrentLanguage(): Language {
-  return currentLanguage;
-}
-
-/**
  * Übersetzt einen Key
  * Unterstützt verschachtelte Keys mit Punktnotation (z.B. "home.title")
  * Unterstützt Platzhalter (z.B. "{{number}}")


### PR DESCRIPTION
## Summary

- Hardcodierte App-Titel ("Merke & Male") in HomeScreen & GameScreen durch `t('app.name')` ersetzt
- Löschen-Dialog im GameScreen vollständig lokalisiert (Alert-Texte, Bestätigung)
- Sprachänderungs-Alert in SettingsModal entfernt (reaktive i18n macht ihn überflüssig)
- Settings: About/Support-Bereich als 2×2-Grid statt Liste (bessere UX)
- `getDifficultyForLevel()` aus ImagePoolManager entfernt — Duplikat von LevelManager
- `getCurrentLanguage()` Alias aus i18n entfernt — nur noch `getLanguage()`
- Brush-Icon 🖌️ → ✏️, kleinere Style-Anpassungen (icon fontSize, star opacity)
- Neue Tests: GameScreen + HomeScreen i18n-Abdeckung

## Test plan

- [ ] App-Titel auf Home- und GameScreen erscheint sprachabhängig (DE/EN)
- [ ] Löschen-Dialog zeigt lokalisierte Texte (Alert auf Native, confirm() auf Web)
- [ ] Sprachwechsel in Settings funktioniert ohne Alert-Popup
- [ ] Settings About/Support-Grid zeigt 4 Buttons korrekt (2×2)
- [ ] Alle 245 Tests grün (`npm run test:ci`)
- [ ] TypeScript-Check sauber (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)