### PR TITLE
feat(1.3): Level 11–20 — 10 neue SVG-Vorlagen (Tiere, Fahrzeuge, Natur)

### DIFF
--- a/components/LevelImageDisplay.tsx
+++ b/components/LevelImageDisplay.tsx
@@ -35,6 +35,16 @@ const IMAGE_ELEMENT_COUNTS: Record<string, number> = {
   'extra-02-car.svg': 15,
   'level-09-fish.svg': 15,
   'level-10-butterfly.svg': 16,
+  'level-11-cat-simple.svg': 11,
+  'level-12-dog-simple.svg': 9,
+  'level-13-bird-simple.svg': 8,
+  'level-14-car-v2.svg': 18,
+  'level-15-train.svg': 18,
+  'level-16-bicycle.svg': 23,
+  'level-17-tree-detailed.svg': 14,
+  'level-18-flower-detailed.svg': 16,
+  'level-19-fish-tropical.svg': 17,
+  'level-20-house-detailed.svg': 25,
 };
 
 /**
@@ -566,6 +576,336 @@ function renderSvgForImage(image: LevelImage, svgSize: number, viewBox: string):
             {/* Lower right wing */}
             <Ellipse cx="130" cy="115" rx="28" ry="22" fill="#BB6BD9" stroke="#000000" strokeWidth="2" rotation="-15" origin="130, 115" />
             <Ellipse cx="135" cy="115" rx="12" ry="10" fill="#FFFFFF" stroke="none" opacity="0.4" rotation="-15" origin="135, 115" />
+          </Svg>
+        );
+
+      case 'level-11-cat-simple.svg':
+        return (
+          <Svg width={svgSize} height={svgSize} viewBox={viewBox}>
+            {/* Head */}
+            <Circle cx="100" cy="85" r="38" fill="#FFA500" stroke="#000000" strokeWidth="2" />
+            {/* Left ear */}
+            <Polygon points="72,55 65,25 88,52" fill="#FFA500" stroke="#000000" strokeWidth="2" />
+            {/* Right ear */}
+            <Polygon points="128,55 135,25 112,52" fill="#FFA500" stroke="#000000" strokeWidth="2" />
+            {/* Left eye */}
+            <Circle cx="88" cy="80" r="6" fill="#000000" />
+            {/* Right eye */}
+            <Circle cx="112" cy="80" r="6" fill="#000000" />
+            {/* Nose */}
+            <Polygon points="100,92 95,100 105,100" fill="#FFB6C1" />
+            {/* Body */}
+            <Ellipse cx="100" cy="145" rx="35" ry="30" fill="#FFA500" stroke="#000000" strokeWidth="2" />
+            {/* Tail */}
+            <Path d="M 130 155 Q 165 145 160 115" stroke="#FFA500" strokeWidth="7" fill="none" strokeLinecap="round" />
+            {/* Left whisker 1 */}
+            <Line x1="55" y1="88" x2="88" y2="92" stroke="#000000" strokeWidth="1.5" />
+            {/* Left whisker 2 */}
+            <Line x1="55" y1="96" x2="88" y2="97" stroke="#000000" strokeWidth="1.5" />
+            {/* Right whisker 1 */}
+            <Line x1="145" y1="88" x2="112" y2="92" stroke="#000000" strokeWidth="1.5" />
+          </Svg>
+        );
+
+      case 'level-12-dog-simple.svg':
+        return (
+          <Svg width={svgSize} height={svgSize} viewBox={viewBox}>
+            {/* Body */}
+            <Ellipse cx="105" cy="130" rx="45" ry="28" fill="#D2691E" stroke="#000000" strokeWidth="2" />
+            {/* Head */}
+            <Circle cx="65" cy="95" r="30" fill="#D2691E" stroke="#000000" strokeWidth="2" />
+            {/* Floppy ear */}
+            <Ellipse cx="52" cy="82" rx="13" ry="26" fill="#A0522D" stroke="#000000" strokeWidth="2" />
+            {/* Snout */}
+            <Ellipse cx="46" cy="102" rx="16" ry="12" fill="#CD853F" stroke="#000000" strokeWidth="1.5" />
+            {/* Nose */}
+            <Circle cx="43" cy="100" r="5" fill="#000000" />
+            {/* Eye */}
+            <Circle cx="68" cy="90" r="5" fill="#000000" />
+            {/* Front left leg */}
+            <Rect x="85" y="148" width="10" height="28" fill="#D2691E" stroke="#000000" strokeWidth="2" rx="3" />
+            {/* Front right leg */}
+            <Rect x="108" y="148" width="10" height="28" fill="#D2691E" stroke="#000000" strokeWidth="2" rx="3" />
+            {/* Tail */}
+            <Path d="M 148 118 Q 172 105 168 82" stroke="#A0522D" strokeWidth="8" fill="none" strokeLinecap="round" />
+          </Svg>
+        );
+
+      case 'level-13-bird-simple.svg':
+        return (
+          <Svg width={svgSize} height={svgSize} viewBox={viewBox}>
+            {/* Body */}
+            <Ellipse cx="100" cy="110" rx="38" ry="25" fill="#1E90FF" stroke="#000000" strokeWidth="2" />
+            {/* Head */}
+            <Circle cx="130" cy="88" r="22" fill="#1E90FF" stroke="#000000" strokeWidth="2" />
+            {/* Beak */}
+            <Polygon points="152,88 170,84 152,94" fill="#FFD700" stroke="#000000" strokeWidth="1.5" />
+            {/* Eye */}
+            <Circle cx="136" cy="84" r="4" fill="#000000" />
+            {/* Wing */}
+            <Ellipse cx="88" cy="105" rx="30" ry="18" fill="#4169E1" stroke="#000000" strokeWidth="2" rotation="-15" origin="88,105" />
+            {/* Tail */}
+            <Polygon points="62,110 38,100 38,120" fill="#4169E1" stroke="#000000" strokeWidth="2" />
+            {/* Left leg */}
+            <Line x1="95" y1="133" x2="90" y2="152" stroke="#FFD700" strokeWidth="3" strokeLinecap="round" />
+            {/* Right leg */}
+            <Line x1="108" y1="133" x2="113" y2="152" stroke="#FFD700" strokeWidth="3" strokeLinecap="round" />
+          </Svg>
+        );
+
+      case 'level-14-car-v2.svg':
+        return (
+          <Svg width={svgSize} height={svgSize} viewBox="0 0 240 180">
+            {/* Car body */}
+            <Rect x="25" y="80" width="190" height="55" fill="#2ECC71" stroke="#000000" strokeWidth="2" rx="8" />
+            {/* Roof */}
+            <Path d="M 65 80 L 80 42 L 170 42 L 185 80" fill="#27AE60" stroke="#000000" strokeWidth="2" />
+            {/* Windshield */}
+            <Path d="M 83 45 L 73 78 L 118 78 L 118 45 Z" fill="#87CEEB" stroke="#000000" strokeWidth="1.5" />
+            {/* Rear window */}
+            <Path d="M 122 45 L 122 78 L 167 78 L 157 45 Z" fill="#87CEEB" stroke="#000000" strokeWidth="1.5" />
+            {/* Front bumper */}
+            <Rect x="200" y="92" width="18" height="28" fill="#1E8449" stroke="#000000" strokeWidth="2" rx="4" />
+            {/* Rear bumper */}
+            <Rect x="22" y="92" width="14" height="28" fill="#1E8449" stroke="#000000" strokeWidth="2" rx="4" />
+            {/* Headlight */}
+            <Circle cx="213" cy="103" r="6" fill="#FFD700" stroke="#000000" strokeWidth="1.5" />
+            {/* Taillight */}
+            <Circle cx="28" cy="103" r="5" fill="#E74C3C" stroke="#000000" strokeWidth="1.5" />
+            {/* Front wheel */}
+            <Circle cx="172" cy="133" r="22" fill="#333333" stroke="#000000" strokeWidth="2" />
+            <Circle cx="172" cy="133" r="12" fill="#808080" stroke="#000000" strokeWidth="1.5" />
+            <Circle cx="172" cy="133" r="4" fill="#333333" />
+            {/* Rear wheel */}
+            <Circle cx="68" cy="133" r="22" fill="#333333" stroke="#000000" strokeWidth="2" />
+            <Circle cx="68" cy="133" r="12" fill="#808080" stroke="#000000" strokeWidth="1.5" />
+            <Circle cx="68" cy="133" r="4" fill="#333333" />
+            {/* Door line */}
+            <Line x1="125" y1="82" x2="125" y2="132" stroke="#000000" strokeWidth="1.5" />
+            {/* Door handle front */}
+            <Line x1="148" y1="100" x2="165" y2="100" stroke="#000000" strokeWidth="2" strokeLinecap="round" />
+            {/* Door handle rear */}
+            <Line x1="80" y1="100" x2="97" y2="100" stroke="#000000" strokeWidth="2" strokeLinecap="round" />
+            {/* Exhaust */}
+            <Rect x="22" y="125" width="12" height="5" fill="#888888" stroke="#000000" strokeWidth="1" rx="2" />
+          </Svg>
+        );
+
+      case 'level-15-train.svg':
+        return (
+          <Svg width={svgSize} height={svgSize} viewBox="0 0 280 200">
+            {/* Main body */}
+            <Rect x="20" y="70" width="200" height="80" fill="#E74C3C" stroke="#000000" strokeWidth="2" rx="10" />
+            {/* Locomotive front */}
+            <Rect x="200" y="80" width="45" height="60" fill="#C0392B" stroke="#000000" strokeWidth="2" rx="6" />
+            {/* Chimney */}
+            <Rect x="215" y="55" width="16" height="28" fill="#333333" stroke="#000000" strokeWidth="2" rx="3" />
+            {/* Steam */}
+            <Circle cx="215" cy="50" r="8" fill="#DDDDDD" stroke="#AAAAAA" strokeWidth="1" opacity="0.8" />
+            {/* Window 1 */}
+            <Rect x="35" y="82" width="35" height="28" fill="#87CEEB" stroke="#000000" strokeWidth="2" rx="3" />
+            {/* Window 2 */}
+            <Rect x="85" y="82" width="35" height="28" fill="#87CEEB" stroke="#000000" strokeWidth="2" rx="3" />
+            {/* Window 3 */}
+            <Rect x="135" y="82" width="35" height="28" fill="#87CEEB" stroke="#000000" strokeWidth="2" rx="3" />
+            {/* Front window */}
+            <Rect x="210" y="88" width="25" height="22" fill="#87CEEB" stroke="#000000" strokeWidth="2" rx="3" />
+            {/* Wheels */}
+            <Circle cx="55" cy="148" r="18" fill="#333333" stroke="#000000" strokeWidth="2" />
+            <Circle cx="55" cy="148" r="9" fill="#808080" />
+            <Circle cx="120" cy="148" r="18" fill="#333333" stroke="#000000" strokeWidth="2" />
+            <Circle cx="120" cy="148" r="9" fill="#808080" />
+            <Circle cx="185" cy="148" r="18" fill="#333333" stroke="#000000" strokeWidth="2" />
+            <Circle cx="185" cy="148" r="9" fill="#808080" />
+            <Circle cx="230" cy="148" r="14" fill="#333333" stroke="#000000" strokeWidth="2" />
+            <Circle cx="230" cy="148" r="7" fill="#808080" />
+            {/* Rail */}
+            <Line x1="10" y1="165" x2="270" y2="165" stroke="#555555" strokeWidth="4" strokeLinecap="round" />
+            {/* Headlight */}
+            <Circle cx="242" cy="110" r="7" fill="#FFD700" stroke="#000000" strokeWidth="1.5" />
+          </Svg>
+        );
+
+      case 'level-16-bicycle.svg':
+        return (
+          <Svg width={svgSize} height={svgSize} viewBox="0 0 240 200">
+            {/* Rear wheel */}
+            <Circle cx="65" cy="130" r="48" fill="none" stroke="#333333" strokeWidth="5" />
+            <Circle cx="65" cy="130" r="5" fill="#333333" />
+            {/* Rear spokes */}
+            <Line x1="65" y1="82" x2="65" y2="178" stroke="#888888" strokeWidth="1.5" />
+            <Line x1="17" y1="130" x2="113" y2="130" stroke="#888888" strokeWidth="1.5" />
+            <Line x1="31" y1="96" x2="99" y2="164" stroke="#888888" strokeWidth="1.5" />
+            <Line x1="99" y1="96" x2="31" y2="164" stroke="#888888" strokeWidth="1.5" />
+            {/* Front wheel */}
+            <Circle cx="178" cy="130" r="48" fill="none" stroke="#333333" strokeWidth="5" />
+            <Circle cx="178" cy="130" r="5" fill="#333333" />
+            {/* Front spokes */}
+            <Line x1="178" y1="82" x2="178" y2="178" stroke="#888888" strokeWidth="1.5" />
+            <Line x1="130" y1="130" x2="226" y2="130" stroke="#888888" strokeWidth="1.5" />
+            <Line x1="144" y1="96" x2="212" y2="164" stroke="#888888" strokeWidth="1.5" />
+            <Line x1="212" y1="96" x2="144" y2="164" stroke="#888888" strokeWidth="1.5" />
+            {/* Frame */}
+            <Line x1="65" y1="130" x2="115" y2="75" stroke="#E74C3C" strokeWidth="5" strokeLinecap="round" />
+            <Line x1="115" y1="75" x2="178" y2="130" stroke="#E74C3C" strokeWidth="5" strokeLinecap="round" />
+            <Line x1="115" y1="75" x2="140" y2="130" stroke="#E74C3C" strokeWidth="5" strokeLinecap="round" />
+            <Line x1="65" y1="130" x2="140" y2="130" stroke="#E74C3C" strokeWidth="5" strokeLinecap="round" />
+            {/* Seat post */}
+            <Line x1="115" y1="75" x2="105" y2="50" stroke="#333333" strokeWidth="4" strokeLinecap="round" />
+            {/* Seat */}
+            <Ellipse cx="100" cy="48" rx="18" ry="6" fill="#333333" stroke="#000000" strokeWidth="1.5" />
+            {/* Handlebar stem */}
+            <Line x1="140" y1="130" x2="148" y2="60" stroke="#333333" strokeWidth="4" strokeLinecap="round" />
+            {/* Handlebar */}
+            <Line x1="135" y1="60" x2="165" y2="60" stroke="#333333" strokeWidth="4" strokeLinecap="round" />
+            {/* Pedal crank */}
+            <Circle cx="140" cy="130" r="10" fill="#888888" stroke="#333333" strokeWidth="2" />
+            {/* Pedals */}
+            <Line x1="130" y1="140" x2="118" y2="148" stroke="#333333" strokeWidth="3" strokeLinecap="round" />
+            <Line x1="150" y1="120" x2="162" y2="112" stroke="#333333" strokeWidth="3" strokeLinecap="round" />
+          </Svg>
+        );
+
+      case 'level-17-tree-detailed.svg':
+        return (
+          <Svg width={svgSize} height={svgSize} viewBox={viewBox}>
+            {/* Trunk */}
+            <Rect x="86" y="115" width="28" height="65" fill="#8B4513" stroke="#000000" strokeWidth="2" rx="3" />
+            {/* Trunk texture */}
+            <Line x1="92" y1="120" x2="90" y2="175" stroke="#6B3410" strokeWidth="1.5" />
+            <Line x1="108" y1="120" x2="110" y2="175" stroke="#6B3410" strokeWidth="1.5" />
+            {/* Roots */}
+            <Ellipse cx="90" cy="178" rx="12" ry="5" fill="#8B4513" stroke="#000000" strokeWidth="1.5" />
+            <Ellipse cx="110" cy="178" rx="12" ry="5" fill="#8B4513" stroke="#000000" strokeWidth="1.5" />
+            {/* Bottom crown layer */}
+            <Circle cx="100" cy="92" r="42" fill="#27AE60" stroke="#000000" strokeWidth="2" />
+            {/* Left crown */}
+            <Circle cx="68" cy="98" r="28" fill="#27AE60" stroke="#000000" strokeWidth="2" />
+            {/* Right crown */}
+            <Circle cx="132" cy="98" r="28" fill="#27AE60" stroke="#000000" strokeWidth="2" />
+            {/* Top crown */}
+            <Circle cx="100" cy="62" r="32" fill="#2ECC71" stroke="#000000" strokeWidth="2" />
+            {/* Highlight */}
+            <Circle cx="82" cy="68" r="14" fill="#2ECC71" stroke="none" opacity="0.6" />
+            {/* Small branches */}
+            <Line x1="100" y1="115" x2="75" y2="100" stroke="#8B4513" strokeWidth="3" strokeLinecap="round" />
+            <Line x1="100" y1="115" x2="125" y2="100" stroke="#8B4513" strokeWidth="3" strokeLinecap="round" />
+            {/* Apple */}
+            <Circle cx="125" cy="88" r="7" fill="#E74C3C" stroke="#000000" strokeWidth="1.5" />
+            {/* Apple stem */}
+            <Line x1="125" y1="81" x2="127" y2="75" stroke="#8B4513" strokeWidth="1.5" strokeLinecap="round" />
+          </Svg>
+        );
+
+      case 'level-18-flower-detailed.svg':
+        return (
+          <Svg width={svgSize} height={svgSize} viewBox={viewBox}>
+            {/* Pot */}
+            <Polygon points="75,185 125,185 118,160 82,160" fill="#8B4513" stroke="#000000" strokeWidth="2" />
+            <Rect x="72" y="182" width="56" height="8" fill="#A0522D" stroke="#000000" strokeWidth="2" rx="2" />
+            {/* Soil */}
+            <Ellipse cx="100" cy="160" rx="18" ry="5" fill="#5D3A1A" />
+            {/* Stem */}
+            <Path d="M 100 158 Q 95 130 100 80" stroke="#27AE60" strokeWidth="5" fill="none" strokeLinecap="round" />
+            {/* Left leaf */}
+            <Ellipse cx="80" cy="125" rx="18" ry="28" fill="#32CD32" stroke="#27AE60" strokeWidth="2" rotation="-35" origin="80,125" />
+            {/* Right leaf */}
+            <Ellipse cx="120" cy="105" rx="18" ry="28" fill="#32CD32" stroke="#27AE60" strokeWidth="2" rotation="35" origin="120,105" />
+            {/* Flower center */}
+            <Circle cx="100" cy="58" r="16" fill="#FFD700" stroke="#FFA500" strokeWidth="2" />
+            {/* Petals top/bottom */}
+            <Ellipse cx="100" cy="27" rx="11" ry="20" fill="#FF69B4" stroke="#FF1493" strokeWidth="1.5" />
+            <Ellipse cx="100" cy="89" rx="11" ry="20" fill="#FF69B4" stroke="#FF1493" strokeWidth="1.5" />
+            {/* Petals left/right */}
+            <Ellipse cx="69" cy="58" rx="20" ry="11" fill="#FF69B4" stroke="#FF1493" strokeWidth="1.5" />
+            <Ellipse cx="131" cy="58" rx="20" ry="11" fill="#FF69B4" stroke="#FF1493" strokeWidth="1.5" />
+            {/* Diagonal petals */}
+            <Ellipse cx="79" cy="37" rx="13" ry="18" fill="#FF85C1" stroke="#FF1493" strokeWidth="1.5" rotation="-45" origin="79,37" />
+            <Ellipse cx="121" cy="37" rx="13" ry="18" fill="#FF85C1" stroke="#FF1493" strokeWidth="1.5" rotation="45" origin="121,37" />
+            <Ellipse cx="79" cy="79" rx="13" ry="18" fill="#FF85C1" stroke="#FF1493" strokeWidth="1.5" rotation="45" origin="79,79" />
+            <Ellipse cx="121" cy="79" rx="13" ry="18" fill="#FF85C1" stroke="#FF1493" strokeWidth="1.5" rotation="-45" origin="121,79" />
+            {/* Center dot */}
+            <Circle cx="100" cy="58" r="6" fill="#FFA500" stroke="#000000" strokeWidth="1" />
+          </Svg>
+        );
+
+      case 'level-19-fish-tropical.svg':
+        return (
+          <Svg width={svgSize} height={svgSize} viewBox={viewBox}>
+            {/* Fish body */}
+            <Ellipse cx="105" cy="100" rx="52" ry="35" fill="#FF6347" stroke="#000000" strokeWidth="2" />
+            {/* Tail fin */}
+            <Polygon points="157,100 185,72 185,128" fill="#FFD700" stroke="#000000" strokeWidth="2" />
+            {/* Dorsal fin */}
+            <Path d="M 88 65 Q 105 42 125 65" fill="#FFD700" stroke="#000000" strokeWidth="2" />
+            {/* Pectoral fin */}
+            <Ellipse cx="115" cy="118" rx="18" ry="10" fill="#FFD700" stroke="#000000" strokeWidth="2" rotation="30" origin="115,118" />
+            {/* Eye ring */}
+            <Circle cx="72" cy="92" r="12" fill="#FFFFFF" stroke="#000000" strokeWidth="2" />
+            {/* Eye */}
+            <Circle cx="74" cy="92" r="6" fill="#000000" />
+            <Circle cx="76" cy="90" r="2" fill="#FFFFFF" />
+            {/* Mouth */}
+            <Path d="M 53 100 Q 57 106 53 112" stroke="#000000" strokeWidth="2" fill="none" />
+            {/* Stripe 1 */}
+            <Path d="M 90 65 Q 88 100 90 135" stroke="#FFFFFF" strokeWidth="5" fill="none" strokeLinecap="round" opacity="0.6" />
+            {/* Stripe 2 */}
+            <Path d="M 110 65 Q 108 100 110 135" stroke="#FFFFFF" strokeWidth="5" fill="none" strokeLinecap="round" opacity="0.6" />
+            {/* Stripe 3 */}
+            <Path d="M 130 68 Q 128 100 130 132" stroke="#FFFFFF" strokeWidth="5" fill="none" strokeLinecap="round" opacity="0.6" />
+            {/* Bubbles */}
+            <Circle cx="45" cy="82" r="5" fill="none" stroke="#87CEEB" strokeWidth="1.5" />
+            <Circle cx="37" cy="68" r="4" fill="none" stroke="#87CEEB" strokeWidth="1.5" />
+            <Circle cx="30" cy="56" r="3" fill="none" stroke="#87CEEB" strokeWidth="1.5" />
+            {/* Scale pattern */}
+            <Path d="M 92 86 Q 105 80 118 86" stroke="#CC3333" strokeWidth="1.5" fill="none" />
+            <Path d="M 98 100 Q 112 94 126 100" stroke="#CC3333" strokeWidth="1.5" fill="none" />
+            <Path d="M 92 114 Q 105 108 118 114" stroke="#CC3333" strokeWidth="1.5" fill="none" />
+          </Svg>
+        );
+
+      case 'level-20-house-detailed.svg':
+        return (
+          <Svg width={svgSize} height={svgSize} viewBox="0 0 220 240">
+            {/* Sky / background */}
+            <Rect width="220" height="240" fill="#E8F4F8" />
+            {/* House body */}
+            <Rect x="40" y="100" width="130" height="115" fill="#E74C3C" stroke="#000000" strokeWidth="2" />
+            {/* Roof */}
+            <Polygon points="30,100 110,28 190,100" fill="#8B4513" stroke="#000000" strokeWidth="2" />
+            {/* Chimney */}
+            <Rect x="148" y="48" width="18" height="38" fill="#A0522D" stroke="#000000" strokeWidth="2" />
+            {/* Door */}
+            <Rect x="88" y="148" width="34" height="55" fill="#654321" stroke="#000000" strokeWidth="2" rx="3" />
+            {/* Door arch */}
+            <Path d="M 88 148 Q 105 132 122 148" fill="#654321" stroke="#000000" strokeWidth="2" />
+            {/* Door handle */}
+            <Circle cx="116" cy="175" r="3" fill="#FFD700" />
+            {/* Left window */}
+            <Rect x="52" y="118" width="30" height="28" fill="#87CEEB" stroke="#000000" strokeWidth="2" rx="2" />
+            <Line x1="67" y1="118" x2="67" y2="146" stroke="#000000" strokeWidth="1.5" />
+            <Line x1="52" y1="132" x2="82" y2="132" stroke="#000000" strokeWidth="1.5" />
+            {/* Right window */}
+            <Rect x="138" y="118" width="30" height="28" fill="#87CEEB" stroke="#000000" strokeWidth="2" rx="2" />
+            <Line x1="153" y1="118" x2="153" y2="146" stroke="#000000" strokeWidth="1.5" />
+            <Line x1="138" y1="132" x2="168" y2="132" stroke="#000000" strokeWidth="1.5" />
+            {/* Ground */}
+            <Rect x="0" y="214" width="220" height="26" fill="#27AE60" />
+            {/* Path */}
+            <Polygon points="88,215 122,215 130,238 80,238" fill="#F0D080" stroke="#000000" strokeWidth="1" />
+            {/* Left tree */}
+            <Rect x="16" y="165" width="8" height="30" fill="#8B4513" stroke="#000000" strokeWidth="1.5" />
+            <Circle cx="20" cy="152" r="18" fill="#27AE60" stroke="#000000" strokeWidth="1.5" />
+            {/* Right bush */}
+            <Circle cx="188" cy="200" r="14" fill="#2ECC71" stroke="#000000" strokeWidth="1.5" />
+            <Circle cx="200" cy="205" r="10" fill="#27AE60" stroke="#000000" strokeWidth="1.5" />
+            {/* Fence left */}
+            <Line x1="0" y1="215" x2="75" y2="215" stroke="#8B4513" strokeWidth="3" />
+            <Line x1="10" y1="205" x2="10" y2="215" stroke="#8B4513" strokeWidth="3" strokeLinecap="round" />
+            <Line x1="25" y1="205" x2="25" y2="215" stroke="#8B4513" strokeWidth="3" strokeLinecap="round" />
+            <Line x1="40" y1="205" x2="40" y2="215" stroke="#8B4513" strokeWidth="3" strokeLinecap="round" />
+            <Line x1="55" y1="205" x2="55" y2="215" stroke="#8B4513" strokeWidth="3" strokeLinecap="round" />
+            <Line x1="70" y1="205" x2="70" y2="215" stroke="#8B4513" strokeWidth="3" strokeLinecap="round" />
           </Svg>
         );
 

--- a/services/ImagePoolManager.ts
+++ b/services/ImagePoolManager.ts
@@ -146,6 +146,92 @@ const imagePool: LevelImage[] = [
     colors: ['#000000', '#3498DB', '#FFD700', '#FFA500']
   },
 
+  // Tiere – Difficulty 3 (Level 11–13)
+  {
+    filename: 'level-11-cat-simple.svg',
+    difficulty: 3,
+    displayName: 'Katze',
+    displayNameEn: 'Cat',
+    strokeCount: 11,
+    colors: ['#000000', '#FFA500', '#FFB6C1']
+  },
+  {
+    filename: 'level-12-dog-simple.svg',
+    difficulty: 3,
+    displayName: 'Hund',
+    displayNameEn: 'Dog',
+    strokeCount: 9,
+    colors: ['#000000', '#D2691E', '#CD853F']
+  },
+  {
+    filename: 'level-13-bird-simple.svg',
+    difficulty: 3,
+    displayName: 'Vogel',
+    displayNameEn: 'Bird',
+    strokeCount: 8,
+    colors: ['#000000', '#1E90FF', '#FFD700']
+  },
+
+  // Fahrzeuge – Difficulty 4 (Level 14–16)
+  {
+    filename: 'level-14-car-v2.svg',
+    difficulty: 4,
+    displayName: 'Auto',
+    displayNameEn: 'Car',
+    strokeCount: 17,
+    colors: ['#000000', '#2ECC71', '#87CEEB', '#FFD700', '#333333']
+  },
+  {
+    filename: 'level-15-train.svg',
+    difficulty: 4,
+    displayName: 'Zug',
+    displayNameEn: 'Train',
+    strokeCount: 16,
+    colors: ['#000000', '#E74C3C', '#87CEEB', '#FFD700', '#333333']
+  },
+  {
+    filename: 'level-16-bicycle.svg',
+    difficulty: 4,
+    displayName: 'Fahrrad',
+    displayNameEn: 'Bicycle',
+    strokeCount: 18,
+    colors: ['#000000', '#E74C3C', '#333333', '#FFD700']
+  },
+
+  // Natur – Difficulty 5 (Level 17–20)
+  {
+    filename: 'level-17-tree-detailed.svg',
+    difficulty: 5,
+    displayName: 'Baum',
+    displayNameEn: 'Tree',
+    strokeCount: 14,
+    colors: ['#000000', '#8B4513', '#27AE60', '#2ECC71', '#90EE90']
+  },
+  {
+    filename: 'level-18-flower-detailed.svg',
+    difficulty: 5,
+    displayName: 'Blume',
+    displayNameEn: 'Flower',
+    strokeCount: 16,
+    colors: ['#000000', '#27AE60', '#FF69B4', '#FFD700', '#FF1493', '#8B4513']
+  },
+  {
+    filename: 'level-19-fish-tropical.svg',
+    difficulty: 5,
+    displayName: 'Tropenfisch',
+    displayNameEn: 'Tropical Fish',
+    strokeCount: 18,
+    colors: ['#000000', '#FF6347', '#FFD700', '#FFFFFF', '#87CEEB']
+  },
+  {
+    filename: 'level-20-house-detailed.svg',
+    difficulty: 5,
+    displayName: 'Haus mit Garten',
+    displayNameEn: 'House with Garden',
+    strokeCount: 22,
+    colors: ['#000000', '#E74C3C', '#8B4513', '#87CEEB', '#27AE60', '#FFD700', '#654321']
+  },
+
   // Schwierig (Schwierigkeit 5)
   {
     filename: 'level-09-fish.svg',

--- a/services/ImagePoolManager.ts
+++ b/services/ImagePoolManager.ts
@@ -153,7 +153,8 @@ const imagePool: LevelImage[] = [
     displayName: 'Katze',
     displayNameEn: 'Cat',
     strokeCount: 11,
-    colors: ['#000000', '#FFA500', '#FFB6C1']
+    colors: ['#000000', '#FFA500', '#FFB6C1'],
+    minLevel: 11,
   },
   {
     filename: 'level-12-dog-simple.svg',
@@ -161,7 +162,8 @@ const imagePool: LevelImage[] = [
     displayName: 'Hund',
     displayNameEn: 'Dog',
     strokeCount: 9,
-    colors: ['#000000', '#D2691E', '#CD853F']
+    colors: ['#000000', '#D2691E', '#CD853F'],
+    minLevel: 11,
   },
   {
     filename: 'level-13-bird-simple.svg',
@@ -169,7 +171,8 @@ const imagePool: LevelImage[] = [
     displayName: 'Vogel',
     displayNameEn: 'Bird',
     strokeCount: 8,
-    colors: ['#000000', '#1E90FF', '#FFD700']
+    colors: ['#000000', '#1E90FF', '#FFD700'],
+    minLevel: 11,
   },
 
   // Fahrzeuge – Difficulty 4 (Level 14–16)
@@ -179,7 +182,8 @@ const imagePool: LevelImage[] = [
     displayName: 'Auto',
     displayNameEn: 'Car',
     strokeCount: 17,
-    colors: ['#000000', '#2ECC71', '#87CEEB', '#FFD700', '#333333']
+    colors: ['#000000', '#2ECC71', '#87CEEB', '#FFD700', '#333333'],
+    minLevel: 11,
   },
   {
     filename: 'level-15-train.svg',
@@ -187,7 +191,8 @@ const imagePool: LevelImage[] = [
     displayName: 'Zug',
     displayNameEn: 'Train',
     strokeCount: 16,
-    colors: ['#000000', '#E74C3C', '#87CEEB', '#FFD700', '#333333']
+    colors: ['#000000', '#E74C3C', '#87CEEB', '#FFD700', '#333333'],
+    minLevel: 11,
   },
   {
     filename: 'level-16-bicycle.svg',
@@ -195,7 +200,8 @@ const imagePool: LevelImage[] = [
     displayName: 'Fahrrad',
     displayNameEn: 'Bicycle',
     strokeCount: 18,
-    colors: ['#000000', '#E74C3C', '#333333', '#FFD700']
+    colors: ['#000000', '#E74C3C', '#333333', '#FFD700'],
+    minLevel: 11,
   },
 
   // Natur – Difficulty 5 (Level 17–20)
@@ -205,7 +211,8 @@ const imagePool: LevelImage[] = [
     displayName: 'Baum',
     displayNameEn: 'Tree',
     strokeCount: 14,
-    colors: ['#000000', '#8B4513', '#27AE60', '#2ECC71', '#90EE90']
+    colors: ['#000000', '#8B4513', '#27AE60', '#2ECC71', '#90EE90'],
+    minLevel: 11,
   },
   {
     filename: 'level-18-flower-detailed.svg',
@@ -213,7 +220,8 @@ const imagePool: LevelImage[] = [
     displayName: 'Blume',
     displayNameEn: 'Flower',
     strokeCount: 16,
-    colors: ['#000000', '#27AE60', '#FF69B4', '#FFD700', '#FF1493', '#8B4513']
+    colors: ['#000000', '#27AE60', '#FF69B4', '#FFD700', '#FF1493', '#8B4513'],
+    minLevel: 11,
   },
   {
     filename: 'level-19-fish-tropical.svg',
@@ -221,7 +229,8 @@ const imagePool: LevelImage[] = [
     displayName: 'Tropenfisch',
     displayNameEn: 'Tropical Fish',
     strokeCount: 18,
-    colors: ['#000000', '#FF6347', '#FFD700', '#FFFFFF', '#87CEEB']
+    colors: ['#000000', '#FF6347', '#FFD700', '#FFFFFF', '#87CEEB'],
+    minLevel: 11,
   },
   {
     filename: 'level-20-house-detailed.svg',
@@ -229,7 +238,8 @@ const imagePool: LevelImage[] = [
     displayName: 'Haus mit Garten',
     displayNameEn: 'House with Garden',
     strokeCount: 22,
-    colors: ['#000000', '#E74C3C', '#8B4513', '#87CEEB', '#27AE60', '#FFD700', '#654321']
+    colors: ['#000000', '#E74C3C', '#8B4513', '#87CEEB', '#27AE60', '#FFD700', '#654321'],
+    minLevel: 11,
   },
 
   // Schwierig (Schwierigkeit 5)
@@ -288,17 +298,19 @@ let lastShownImages: string[] = [];
  */
 export function getRandomImageForLevel(levelNumber: number): LevelImage {
   const targetDifficulty = getDifficultyForLevel(levelNumber);
-
-  // Filtere Bilder nach Schwierigkeit UND nicht kürzlich gezeigt
-  let availableImages = imagePool.filter(img =>
+  const isEligible = (img: LevelImage) =>
     img.difficulty === targetDifficulty &&
-    !lastShownImages.includes(img.filename)
+    (!img.minLevel || img.minLevel <= levelNumber);
+
+  // Filtere Bilder nach Schwierigkeit, minLevel-Guard UND nicht kürzlich gezeigt
+  let availableImages = imagePool.filter(img =>
+    isEligible(img) && !lastShownImages.includes(img.filename)
   );
 
-  // Falls alle Bilder dieser Schwierigkeit kürzlich gezeigt wurden, reset
+  // Falls alle eligible Bilder kürzlich gezeigt wurden, reset
   if (availableImages.length === 0) {
     lastShownImages = [];
-    availableImages = imagePool.filter(img => img.difficulty === targetDifficulty);
+    availableImages = imagePool.filter(isEligible);
   }
 
   // Wähle zufällig aus verfügbaren Bildern

--- a/services/LevelManager.ts
+++ b/services/LevelManager.ts
@@ -30,12 +30,18 @@ export function getDisplayDuration(levelNumber: number, extraTimeMode = false): 
  * Level 4-5: Difficulty 3
  * Level 6-7: Difficulty 4
  * Level 8-10: Difficulty 5
+ * Level 11-13: Difficulty 3 (Tiere)
+ * Level 14-16: Difficulty 4 (Fahrzeuge)
+ * Level 17-20: Difficulty 5 (Natur)
  */
 export function getDifficultyForLevel(levelNumber: number): Difficulty {
   if (levelNumber === 1) return 1;
   if (levelNumber <= 3) return 2;
   if (levelNumber <= 5) return 3;
   if (levelNumber <= 7) return 4;
+  if (levelNumber <= 10) return 5;
+  if (levelNumber <= 13) return 3;
+  if (levelNumber <= 16) return 4;
   return 5;
 }
 
@@ -54,7 +60,7 @@ export function getLevel(levelNumber: number): Level {
  * Gibt die Gesamtanzahl der Level zurück
  */
 export function getTotalLevels(): number {
-  return 10;
+  return 20;
 }
 
 /**

--- a/services/__tests__/LevelManager.test.ts
+++ b/services/__tests__/LevelManager.test.ts
@@ -17,6 +17,10 @@ describe('LevelManager', () => {
     it('should return a positive number', () => {
       expect(getTotalLevels()).toBeGreaterThan(0);
     });
+
+    it('should return 20', () => {
+      expect(getTotalLevels()).toBe(20);
+    });
   });
 
   describe('getLevel', () => {
@@ -65,6 +69,25 @@ describe('LevelManager', () => {
         expect(diff).toBeGreaterThanOrEqual(1);
         expect(diff).toBeLessThanOrEqual(5);
       }
+    });
+
+    it('should return difficulty 3 for levels 11–13 (Tiere)', () => {
+      expect(getDifficultyForLevel(11)).toBe(3);
+      expect(getDifficultyForLevel(12)).toBe(3);
+      expect(getDifficultyForLevel(13)).toBe(3);
+    });
+
+    it('should return difficulty 4 for levels 14–16 (Fahrzeuge)', () => {
+      expect(getDifficultyForLevel(14)).toBe(4);
+      expect(getDifficultyForLevel(15)).toBe(4);
+      expect(getDifficultyForLevel(16)).toBe(4);
+    });
+
+    it('should return difficulty 5 for levels 17–20 (Natur)', () => {
+      expect(getDifficultyForLevel(17)).toBe(5);
+      expect(getDifficultyForLevel(18)).toBe(5);
+      expect(getDifficultyForLevel(19)).toBe(5);
+      expect(getDifficultyForLevel(20)).toBe(5);
     });
   });
 

--- a/services/__tests__/LevelManager.test.ts
+++ b/services/__tests__/LevelManager.test.ts
@@ -57,10 +57,8 @@ describe('LevelManager', () => {
       expect(getDifficultyForLevel(1)).toBe(1);
     });
 
-    it('should return increasing difficulty for higher levels', () => {
-      const diff1 = getDifficultyForLevel(1);
-      const diff10 = getDifficultyForLevel(10);
-      expect(diff10).toBeGreaterThanOrEqual(diff1);
+    it('should return difficulty 5 for level 10 (Ende Phase 1)', () => {
+      expect(getDifficultyForLevel(10)).toBe(5);
     });
 
     it('should return valid difficulty range (1-5)', () => {

--- a/types/index.ts
+++ b/types/index.ts
@@ -17,6 +17,7 @@ export interface LevelImage {
   displayNameEn: string;
   strokeCount: number;
   colors: string[]; // Array von Hex-Farben für dieses Bild
+  minLevel?: number; // Wenn gesetzt, nur ab dieser Level-Nummer im Pool
 }
 
 /**


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Implementiert Issue #167 — Phase 1.3: 10 weitere Level (11–20).

- **`services/LevelManager.ts`** — `getTotalLevels()` → 20; `getDifficultyForLevel()` erweitert für Level 11–20 (11–13: Diff 3, 14–16: Diff 4, 17–20: Diff 5)
- **`services/ImagePoolManager.ts`** — 10 neue `LevelImage`-Einträge (Katze, Hund, Vogel bei Diff 3; Auto, Zug, Fahrrad bei Diff 4; Baum, Blume, Tropenfisch, Haus mit Garten bei Diff 5)
- **`components/LevelImageDisplay.tsx`** — 10 neue inline-SVG-Cases + `IMAGE_ELEMENT_COUNTS`-Einträge
- **`services/__tests__/LevelManager.test.ts`** — Difficulty-Mapping für Level 11–20 explizit geprüft, `getTotalLevels() === 20`

## Akzeptanzkriterien (aus #167)

- [x] Level 11–20 in `LevelManager` registriert und spielbar
- [x] `getTotalLevels()` gibt 20 zurück
- [x] Levels-Screen zeigt 20 Karten (scrollbar — keine UI-Änderung nötig, da dynamisch aus `getAllLevels()` gerendert)
- [x] Alle SVGs als inline react-native-svg implementiert (Web + Android kompatibel, kein Image-Roundtrip)
- [x] Test: `LevelManager.test.ts` — Gesamtlevelanzahl + Difficulty-Mapping für alle neuen Level

## Test plan

- [ ] `npm test` — alle Tests grün (45 Tests in den betroffenen Suites)
- [ ] `npx tsc --noEmit` — kein TypeScript-Fehler
- [ ] Levels-Screen öffnen → 20 Level-Karten sichtbar, scrollbar
- [ ] Level 11–13 spielen → Tier-SVGs erscheinen, Timer ~3 s
- [ ] Level 14–16 spielen → Fahrzeug-SVGs erscheinen, Timer ~2 s
- [ ] Level 17–20 spielen → Natur-SVGs erscheinen, Timer ~1,5 s

Closes #167 (1.3)

https://claude.ai/code/session_01XoRBo5H21TR2gLUxmZuJUc
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoRBo5H21TR2gLUxmZuJUc)_