### PR TITLE
feat(2.2): Daily Challenge — Bild des Tages

### DIFF
--- a/app/gallery.tsx
+++ b/app/gallery.tsx
@@ -95,6 +95,11 @@ export default function GalleryScreen() {
                 />
               </View>
               <View style={styles.cardInfo}>
+                {entry.isDailyChallenge && (
+                  <View style={styles.dailyBadge}>
+                    <Text style={styles.dailyBadgeText}>{t('gallery.dailyChallengeLabel')}</Text>
+                  </View>
+                )}
                 <Text style={[styles.cardTitle, { color: colors.text.primary }]}>
                   {entry.imageName}
                 </Text>
@@ -214,6 +219,19 @@ const styles = StyleSheet.create({
   deleteIcon: {
     color: '#FFFFFF',
     fontSize: 14,
+    fontWeight: FontWeight.bold,
+  },
+  dailyBadge: {
+    alignSelf: 'flex-start',
+    backgroundColor: '#F59E0B',
+    borderRadius: BorderRadius.sm,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    marginBottom: 4,
+  },
+  dailyBadgeText: {
+    color: '#fff',
+    fontSize: 10,
     fontWeight: FontWeight.bold,
   },
 });

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -50,6 +50,8 @@ export default function GameScreen() {
       ? parsedLevel
       : 1;
 
+  const isDailyChallenge = params.daily === '1';
+
   const {
     phase,
     setPhase,
@@ -72,6 +74,7 @@ export default function GameScreen() {
     initialLevel,
     drawingPaths: drawing.paths,
     clearCanvas: drawing.clearCanvas,
+    isDailyChallenge,
   });
 
   // Reset hint joker when level changes

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,10 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import { View, Text, StyleSheet, Pressable, TouchableOpacity } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { useRouter } from 'expo-router';
+import { useRouter, useFocusEffect } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useFocusEffect } from 'expo-router';
-import { useCallback } from 'react';
 import { useTranslation } from '@services/i18n';
 import { useTheme } from '@services/ThemeContext';
 import {
@@ -24,20 +22,24 @@ export default function HomeScreen() {
   const [showSettings, setShowSettings] = useState(false);
   const [dailyCompleted, setDailyCompleted] = useState(false);
   const [secondsLeft, setSecondsLeft] = useState(() => getSecondsUntilMidnight());
-  const dailyLevel = getDailyChallengeLevel();
+  const [dailyLevel, setDailyLevel] = useState(() => getDailyChallengeLevel());
 
-  // Reload completion state whenever screen is focused
+  // On focus: refresh all daily state and start countdown interval.
+  // Interval also re-checks state every minute to handle midnight rollover
+  // without requiring the user to navigate away and back.
   useFocusEffect(
     useCallback(() => {
-      isTodayCompleted().then(setDailyCompleted);
+      const refresh = async () => {
+        setSecondsLeft(getSecondsUntilMidnight());
+        setDailyLevel(getDailyChallengeLevel());
+        setDailyCompleted(await isTodayCompleted());
+      };
+      refresh();
+
+      const id = setInterval(refresh, 60_000);
+      return () => clearInterval(id);
     }, [])
   );
-
-  // Update countdown every 60 seconds
-  useEffect(() => {
-    const id = setInterval(() => setSecondsLeft(getSecondsUntilMidnight()), 60_000);
-    return () => clearInterval(id);
-  }, []);
 
   const countdownHours = Math.floor(secondsLeft / 3600);
   const countdownMinutes = Math.floor((secondsLeft % 3600) / 60);

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,10 +1,17 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, Pressable, TouchableOpacity } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useFocusEffect } from 'expo-router';
+import { useCallback } from 'react';
 import { useTranslation } from '@services/i18n';
 import { useTheme } from '@services/ThemeContext';
+import {
+  getDailyChallengeLevel,
+  getSecondsUntilMidnight,
+  isTodayCompleted,
+} from '@services/DailyChallengeManager';
 import Colors from '../constants/Colors';
 import { Spacing, FontSize, FontWeight, BorderRadius } from '../constants/Layout';
 import SettingsModal from '@components/SettingsModal';
@@ -15,6 +22,25 @@ export default function HomeScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const [showSettings, setShowSettings] = useState(false);
+  const [dailyCompleted, setDailyCompleted] = useState(false);
+  const [secondsLeft, setSecondsLeft] = useState(() => getSecondsUntilMidnight());
+  const dailyLevel = getDailyChallengeLevel();
+
+  // Reload completion state whenever screen is focused
+  useFocusEffect(
+    useCallback(() => {
+      isTodayCompleted().then(setDailyCompleted);
+    }, [])
+  );
+
+  // Update countdown every 60 seconds
+  useEffect(() => {
+    const id = setInterval(() => setSecondsLeft(getSecondsUntilMidnight()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const countdownHours = Math.floor(secondsLeft / 3600);
+  const countdownMinutes = Math.floor((secondsLeft % 3600) / 60);
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top + Spacing.sm, paddingBottom: insets.bottom + Spacing.lg }]}>
@@ -56,6 +82,30 @@ export default function HomeScreen() {
           >
             <Text style={styles.gradientButtonText}>{t('home.startButton')}</Text>
           </LinearGradient>
+        </TouchableOpacity>
+
+        {/* Daily Challenge */}
+        <TouchableOpacity
+          style={[
+            styles.dailyChallengeButton,
+            { backgroundColor: colors.surface, borderColor: dailyCompleted ? colors.text.light : '#F59E0B' },
+            dailyCompleted && styles.dailyChallengeCompleted,
+          ]}
+          onPress={() => !dailyCompleted && router.push(`/game?level=${dailyLevel}&daily=1`)}
+          accessibilityRole="button"
+          disabled={dailyCompleted}
+        >
+          <Text style={styles.dailyChallengeEmoji}>📅</Text>
+          <View style={styles.dailyChallengeInfo}>
+            <Text style={[styles.dailyChallengeTitle, { color: dailyCompleted ? colors.text.secondary : '#D97706' }]}>
+              {t('dailyChallenge.title')}
+            </Text>
+            <Text style={[styles.dailyChallengeMeta, { color: colors.text.secondary }]}>
+              {dailyCompleted
+                ? t('dailyChallenge.completed')
+                : `${t('dailyChallenge.level', { number: String(dailyLevel) })} · ${t('dailyChallenge.countdown', { hours: String(countdownHours), minutes: String(countdownMinutes) })}`}
+            </Text>
+          </View>
         </TouchableOpacity>
 
         <TouchableOpacity
@@ -158,5 +208,33 @@ const styles = StyleSheet.create({
   secondaryButtonText: {
     fontSize: FontSize.md,
     fontWeight: FontWeight.semibold,
+  },
+  dailyChallengeButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.lg,
+    borderRadius: BorderRadius.lg,
+    borderWidth: 2,
+    minHeight: 52,
+    gap: Spacing.sm,
+    ...Colors.shadow.small,
+  },
+  dailyChallengeCompleted: {
+    opacity: 0.6,
+  },
+  dailyChallengeEmoji: {
+    fontSize: 24,
+  },
+  dailyChallengeInfo: {
+    flex: 1,
+  },
+  dailyChallengeTitle: {
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.bold,
+  },
+  dailyChallengeMeta: {
+    fontSize: FontSize.xs,
+    marginTop: 1,
   },
 });

--- a/components/__tests__/HomeScreen.test.tsx
+++ b/components/__tests__/HomeScreen.test.tsx
@@ -3,6 +3,13 @@ import { render, act } from '@testing-library/react-native';
 
 jest.mock('expo-router', () => ({
   useRouter: () => ({ push: jest.fn() }),
+  useFocusEffect: (cb: () => void) => { cb(); },
+}));
+
+jest.mock('../../services/DailyChallengeManager', () => ({
+  getDailyChallengeLevel: () => 3,
+  getSecondsUntilMidnight: () => 3600,
+  isTodayCompleted: () => Promise.resolve(false),
 }));
 
 jest.mock('react-native-safe-area-context', () => ({

--- a/components/__tests__/HomeScreen.test.tsx
+++ b/components/__tests__/HomeScreen.test.tsx
@@ -3,7 +3,13 @@ import { render, act } from '@testing-library/react-native';
 
 jest.mock('expo-router', () => ({
   useRouter: () => ({ push: jest.fn() }),
-  useFocusEffect: (cb: () => void) => { cb(); },
+  useFocusEffect: (cb: () => (() => void) | void) => {
+    const { useEffect } = require('react');
+    useEffect(() => {
+      const cleanup = cb();
+      return typeof cleanup === 'function' ? cleanup : undefined;
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  },
 }));
 
 jest.mock('../../services/DailyChallengeManager', () => ({

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -126,7 +126,16 @@
     "saved": "Gespeichert!",
     "delete": "Löschen",
     "deleteTitle": "Zeichnung löschen",
-    "deleteConfirm": "Möchtest du diese Zeichnung wirklich löschen?"
+    "deleteConfirm": "Möchtest du diese Zeichnung wirklich löschen?",
+    "dailyChallengeLabel": "Daily Challenge"
+  },
+  "dailyChallenge": {
+    "title": "Tägliche Challenge",
+    "subtitle": "Bild des Tages",
+    "start": "Challenge starten",
+    "completed": "Heute erledigt ✓",
+    "countdown": "Neu in {{hours}}h {{minutes}}m",
+    "level": "Level {{number}}"
   },
   "errors": {
     "skiaUnavailableTitle": "Zeichenfläche nicht verfügbar",

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -126,7 +126,16 @@
     "saved": "Saved!",
     "delete": "Delete",
     "deleteTitle": "Delete drawing",
-    "deleteConfirm": "Do you really want to delete this drawing?"
+    "deleteConfirm": "Do you really want to delete this drawing?",
+    "dailyChallengeLabel": "Daily Challenge"
+  },
+  "dailyChallenge": {
+    "title": "Daily Challenge",
+    "subtitle": "Picture of the Day",
+    "start": "Start Challenge",
+    "completed": "Done for today ✓",
+    "countdown": "New in {{hours}}h {{minutes}}m",
+    "level": "Level {{number}}"
   },
   "errors": {
     "skiaUnavailableTitle": "Drawing surface unavailable",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "merke-und-male",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "merke-und-male",
-      "version": "1.4.0",
+      "version": "1.4.2",
       "dependencies": {
         "@expo/metro-runtime": "~55.0.6",
         "@react-native-async-storage/async-storage": "^2.2.0",

--- a/services/DailyChallengeManager.ts
+++ b/services/DailyChallengeManager.ts
@@ -1,0 +1,94 @@
+/**
+ * DailyChallengeManager - Tägliche Challenge (Bild des Tages)
+ * Deterministisch aus Datum berechnet, kein Server nötig.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { getTotalLevels } from './LevelManager';
+
+const STORAGE_KEY = '@merke_male:daily_challenge';
+
+interface DailyChallengeState {
+  lastCompletedDate: string | null;
+}
+
+const MEMORY: Record<string, string> = {};
+
+async function loadState(): Promise<DailyChallengeState> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      MEMORY[STORAGE_KEY] = raw;
+      return JSON.parse(raw);
+    }
+  } catch {
+    const raw = MEMORY[STORAGE_KEY];
+    if (raw) return JSON.parse(raw);
+  }
+  return { lastCompletedDate: null };
+}
+
+async function saveState(state: DailyChallengeState): Promise<void> {
+  const raw = JSON.stringify(state);
+  MEMORY[STORAGE_KEY] = raw;
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, raw);
+  } catch {
+    // in-memory fallback is sufficient for web sessions
+  }
+}
+
+/**
+ * Gibt den Datums-Key im Format "YYYY-MM-DD" zurück.
+ */
+export function getDailyChallengeKey(date: Date = new Date()): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * Berechnet deterministisch das Level des Tages aus dem Datum.
+ * Gleicher Tag → gleicher Level für alle Nutzer, kein Server nötig.
+ */
+export function getDailyChallengeLevel(date: Date = new Date()): number {
+  const y = date.getFullYear();
+  const m = date.getMonth() + 1;
+  const d = date.getDate();
+  const dateValue = y * 10000 + m * 100 + d;
+  const total = getTotalLevels();
+  return (dateValue % total) + 1;
+}
+
+/**
+ * Gibt die verbleibenden Sekunden bis Mitternacht zurück.
+ */
+export function getSecondsUntilMidnight(now: Date = new Date()): number {
+  const midnight = new Date(now);
+  midnight.setHours(24, 0, 0, 0);
+  return Math.max(0, Math.floor((midnight.getTime() - now.getTime()) / 1000));
+}
+
+/**
+ * Prüft ob die heutige Challenge bereits abgeschlossen wurde.
+ */
+export async function isTodayCompleted(date: Date = new Date()): Promise<boolean> {
+  try {
+    const state = await loadState();
+    return state.lastCompletedDate === getDailyChallengeKey(date);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Markiert die heutige Challenge als abgeschlossen.
+ */
+export async function markTodayCompleted(date: Date = new Date()): Promise<void> {
+  try {
+    await saveState({ lastCompletedDate: getDailyChallengeKey(date) });
+  } catch {
+    // best-effort
+  }
+}

--- a/services/StorageManager.ts
+++ b/services/StorageManager.ts
@@ -107,6 +107,7 @@ export interface GalleryEntry {
   paths: { points: { x: number; y: number }[]; color: string; strokeWidth: number; type?: 'stroke' | 'fill' }[];
   rating: number;
   savedAt: string; // ISO timestamp
+  isDailyChallenge?: boolean;
 }
 
 class StorageManager {

--- a/services/__tests__/DailyChallengeManager.test.ts
+++ b/services/__tests__/DailyChallengeManager.test.ts
@@ -3,6 +3,7 @@
  * Prüft Determinismus, Countdown und Completion-Tracking
  */
 
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   getDailyChallengeKey,
   getDailyChallengeLevel,
@@ -104,9 +105,8 @@ describe('DailyChallengeManager', () => {
   });
 
   describe('isTodayCompleted / markTodayCompleted', () => {
-    beforeEach(() => {
-      jest.resetModules();
-      // Reset module-level MEMORY between tests by re-importing
+    beforeEach(async () => {
+      await AsyncStorage.clear();
     });
 
     it('returns false when no challenge has been completed', async () => {

--- a/services/__tests__/DailyChallengeManager.test.ts
+++ b/services/__tests__/DailyChallengeManager.test.ts
@@ -1,0 +1,133 @@
+/**
+ * DailyChallengeManager Tests
+ * Prüft Determinismus, Countdown und Completion-Tracking
+ */
+
+import {
+  getDailyChallengeKey,
+  getDailyChallengeLevel,
+  getSecondsUntilMidnight,
+  isTodayCompleted,
+  markTodayCompleted,
+} from '../DailyChallengeManager';
+import { getTotalLevels } from '../LevelManager';
+
+// Mock AsyncStorage
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+describe('DailyChallengeManager', () => {
+  describe('getDailyChallengeKey', () => {
+    it('formats date as YYYY-MM-DD', () => {
+      const date = new Date(2026, 4, 21); // May 21, 2026
+      expect(getDailyChallengeKey(date)).toBe('2026-05-21');
+    });
+
+    it('pads month and day with leading zeros', () => {
+      const date = new Date(2026, 0, 5); // January 5, 2026
+      expect(getDailyChallengeKey(date)).toBe('2026-01-05');
+    });
+  });
+
+  describe('getDailyChallengeLevel', () => {
+    it('returns a level within valid range (1 to totalLevels)', () => {
+      const total = getTotalLevels();
+      const dates = [
+        new Date(2026, 0, 1),
+        new Date(2026, 5, 15),
+        new Date(2026, 11, 31),
+        new Date(2025, 6, 4),
+      ];
+      for (const d of dates) {
+        const level = getDailyChallengeLevel(d);
+        expect(level).toBeGreaterThanOrEqual(1);
+        expect(level).toBeLessThanOrEqual(total);
+      }
+    });
+
+    it('returns the same level for the same date (deterministic)', () => {
+      const date = new Date(2026, 4, 21);
+      const level1 = getDailyChallengeLevel(date);
+      const level2 = getDailyChallengeLevel(new Date(2026, 4, 21));
+      expect(level1).toBe(level2);
+    });
+
+    it('returns different levels for different dates', () => {
+      const levels = new Set<number>();
+      for (let day = 1; day <= 10; day++) {
+        levels.add(getDailyChallengeLevel(new Date(2026, 4, day)));
+      }
+      // At least 2 distinct levels across 10 consecutive days
+      expect(levels.size).toBeGreaterThan(1);
+    });
+
+    it('is consistent across multiple date constructions', () => {
+      const dates = [
+        [2026, 5, 21],
+        [2026, 1, 1],
+        [2025, 12, 25],
+        [2027, 3, 15],
+      ] as const;
+      for (const [y, m, d] of dates) {
+        const a = getDailyChallengeLevel(new Date(y, m - 1, d));
+        const b = getDailyChallengeLevel(new Date(y, m - 1, d));
+        expect(a).toBe(b);
+      }
+    });
+  });
+
+  describe('getSecondsUntilMidnight', () => {
+    it('returns a value between 0 and 86400', () => {
+      const now = new Date(2026, 4, 21, 15, 30, 0); // 15:30:00
+      const seconds = getSecondsUntilMidnight(now);
+      expect(seconds).toBeGreaterThan(0);
+      expect(seconds).toBeLessThanOrEqual(86400);
+    });
+
+    it('returns close to 86400 seconds just after midnight', () => {
+      const justAfterMidnight = new Date(2026, 4, 21, 0, 0, 1); // 00:00:01
+      const seconds = getSecondsUntilMidnight(justAfterMidnight);
+      expect(seconds).toBeCloseTo(86399, -2); // within ~100s
+    });
+
+    it('returns close to 0 just before midnight', () => {
+      const justBeforeMidnight = new Date(2026, 4, 21, 23, 59, 59); // 23:59:59
+      const seconds = getSecondsUntilMidnight(justBeforeMidnight);
+      expect(seconds).toBeLessThanOrEqual(2);
+    });
+
+    it('never returns a negative value', () => {
+      const midnightExact = new Date(2026, 4, 21, 24, 0, 0);
+      expect(getSecondsUntilMidnight(midnightExact)).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('isTodayCompleted / markTodayCompleted', () => {
+    beforeEach(() => {
+      jest.resetModules();
+      // Reset module-level MEMORY between tests by re-importing
+    });
+
+    it('returns false when no challenge has been completed', async () => {
+      const date = new Date(2026, 4, 21);
+      const result = await isTodayCompleted(date);
+      expect(result).toBe(false);
+    });
+
+    it('returns true after markTodayCompleted', async () => {
+      const date = new Date(2026, 4, 22);
+      await markTodayCompleted(date);
+      const result = await isTodayCompleted(date);
+      expect(result).toBe(true);
+    });
+
+    it('returns false for a different day even after completion', async () => {
+      const completedDate = new Date(2026, 4, 22);
+      const otherDate = new Date(2026, 4, 23);
+      await markTodayCompleted(completedDate);
+      const result = await isTodayCompleted(otherDate);
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/services/useGamePhase.ts
+++ b/services/useGamePhase.ts
@@ -24,6 +24,9 @@ export function useGamePhase({
   isDailyChallenge = false,
 }: UseGamePhaseOptions) {
   const router = useRouter();
+  // dailyChallengeLevel is fixed at mount; only the initial level counts as the
+  // daily challenge — subsequent levels (if the user continues) must not be tagged.
+  const dailyChallengeLevel = isDailyChallenge ? initialLevel : null;
   const [phase, setPhase] = useState<GamePhase>('memorize');
   const [levelNumber, setLevelNumber] = useState(initialLevel);
   const [currentImage, setCurrentImage] = useState<LevelImage | null>(null);
@@ -153,7 +156,7 @@ export function useGamePhase({
       SoundManager.playStarTap(rating);
       setUserRating(rating);
       await storageManager.saveLevelProgress(levelNumber, rating);
-      if (isDailyChallenge) {
+      if (dailyChallengeLevel !== null && levelNumber === dailyChallengeLevel) {
         await markTodayCompleted();
       }
     } catch (error) {
@@ -170,7 +173,7 @@ export function useGamePhase({
         imageName: currentImage.displayName,
         paths: drawingPaths,
         rating: userRating,
-        isDailyChallenge: isDailyChallenge || undefined,
+        isDailyChallenge: (dailyChallengeLevel !== null && levelNumber === dailyChallengeLevel) || undefined,
       });
       SoundManager.playSuccess();
       setSavedToGallery(true);

--- a/services/useGamePhase.ts
+++ b/services/useGamePhase.ts
@@ -4,6 +4,7 @@ import { getRandomImageForLevel } from '@services/ImagePoolManager';
 import { getLevel, getTotalLevels } from '@services/LevelManager';
 import { getImageElementCount } from '@components/LevelImageDisplay';
 import storageManager from '@services/StorageManager';
+import { markTodayCompleted } from '@services/DailyChallengeManager';
 import SoundManager from '@services/SoundManager';
 import { useTimer } from '@services/useTimer';
 import type { DrawingPath } from '@components/DrawingCanvas';
@@ -13,12 +14,14 @@ interface UseGamePhaseOptions {
   initialLevel: number;
   drawingPaths: DrawingPath[];
   clearCanvas: () => void;
+  isDailyChallenge?: boolean;
 }
 
 export function useGamePhase({
   initialLevel,
   drawingPaths,
   clearCanvas,
+  isDailyChallenge = false,
 }: UseGamePhaseOptions) {
   const router = useRouter();
   const [phase, setPhase] = useState<GamePhase>('memorize');
@@ -150,6 +153,9 @@ export function useGamePhase({
       SoundManager.playStarTap(rating);
       setUserRating(rating);
       await storageManager.saveLevelProgress(levelNumber, rating);
+      if (isDailyChallenge) {
+        await markTodayCompleted();
+      }
     } catch (error) {
       console.error('Error saving rating:', error);
     }
@@ -164,6 +170,7 @@ export function useGamePhase({
         imageName: currentImage.displayName,
         paths: drawingPaths,
         rating: userRating,
+        isDailyChallenge: isDailyChallenge || undefined,
       });
       SoundManager.playSuccess();
       setSavedToGallery(true);


### PR DESCRIPTION
## Zusammenfassung

Implementiert Feature **2.2 — Daily Challenge (Bild des Tages)** aus Issue #167.

- **Deterministischer Level pro Tag** – `DailyChallengeManager.getDailyChallengeLevel(date)` berechnet den Level aus dem Datum (`YYYYMMDD % totalLevels + 1`), kein Server nötig, gleicher Level für alle Nutzer am gleichen Tag
- **Home Screen Card** – eigener Eintrag mit Level-Nummer, Countdown bis Mitternacht und „Heute erledigt ✓"-Zustand; reagiert auf Screen-Focus (Zustand wird beim Zurücknavigieren aktualisiert)
- **Galerie-Label** – Einträge aus der Daily Challenge zeigen ein oranges „Daily Challenge"-Badge
- **Completion-Tracking** – Rating-Submit markiert die heutige Challenge automatisch als erledigt (AsyncStorage + In-Memory-Fallback für Web)
- **i18n** – alle UI-Strings in DE + EN (`dailyChallenge.*`, `gallery.dailyChallengeLabel`)

## Geänderte Dateien

| Datei | Änderung |
|-------|----------|
| `services/DailyChallengeManager.ts` | Neu — Kernlogik (deterministischer Level, Countdown, Completion) |
| `services/__tests__/DailyChallengeManager.test.ts` | Neu — 13 Tests (Determinismus, Countdown, Grenzfälle) |
| `services/StorageManager.ts` | `GalleryEntry.isDailyChallenge?: boolean` |
| `services/useGamePhase.ts` | `isDailyChallenge` Option, persistiert Flag in Galerie + markiert Completion |
| `app/game.tsx` | Liest `?daily=1` URL-Parameter |
| `app/index.tsx` | Daily Challenge Card mit Countdown |
| `app/gallery.tsx` | Badge für Daily-Challenge-Einträge |
| `locales/de/translations.json` | `dailyChallenge.*`, `gallery.dailyChallengeLabel` |
| `locales/en/translations.json` | Dito EN |
| `components/__tests__/HomeScreen.test.tsx` | Mock für `useFocusEffect` + `DailyChallengeManager` ergänzt |

## Akzeptanzkriterien (aus Issue #167)

- [x] Gleicher Level für alle Nutzer am gleichen Tag (deterministisch)
- [x] Countdown bis Mitternacht im UI
- [x] Galerie-Label vorhanden
- [x] Test: Deterministik für mehrere Daten

## Test Plan

- [ ] Alle 260 Jest-Tests grün (`npm test --runInBand`)
- [ ] Home Screen zeigt Daily Challenge Card mit Level und Countdown
- [ ] Tapping „Challenge starten" öffnet das Spiel mit dem korrekten Level
- [ ] Nach Abschluss und Rating: Card zeigt „Heute erledigt ✓"
- [ ] Gespeicherte Zeichnung in der Galerie zeigt oranges „Daily Challenge"-Badge
- [ ] Countdown aktualisiert sich (60s-Interval)
- [ ] Dark Mode: Badge und Card korrekt dargestellt

Closes #167 (Teil 2.2)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFBmzLKsEvbQ8SpruYRC11)_