### PR TITLE
docs: Android-Mindestanforderung API 26 dokumentieren (Issue #172)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@
 **Merke und Male** — Gedächtnistraining-App für Kinder (React Native / Expo).
 Spieler sehen ein Bild kurz, zeichnen es aus dem Gedächtnis, vergleichen das Ergebnis.
 
-- **Aktuell: v1.3.4** — Play-Store-ready, keine offenen Blocker
-- **In staging (seit 2026-05-08):** PR #164 — i18n-Fix: hardcodierte App-Titel in HomeScreen & GameScreen durch `t('app.name')` ersetzt
+- **Aktuell: v1.4.2** — Play-Store-ready, keine offenen Blocker
+- **Mindestanforderung Android: API 26 (Android 8.0 Oreo)** — Nexus 6 (max. API 25) wird nicht mehr unterstützt (Issue #172)
 - **Live Demo:** https://s540d.github.io/DrawFromMemory/
 - **Repo:** https://github.com/S540d/DrawFromMemory
 
@@ -107,5 +107,5 @@ Das größte technische Thema der letzten Entwicklungsphase war die Flood-Fill a
 ## Offene Issues / Bekannte Einschränkungen
 
 - **jest-expo → @tootallnate/once** (low severity): Fix erfordert `jest-expo@47` — breaking change, noch nicht gemacht
-- **Nexus 6 Flood-Fill**: Implementierung fertig, aber kein Gerät für manuelle Tests vorhanden
+- **Nexus 6**: EOL — ab React Native 0.83.x / Skia 2.x ist `minSdkVersion` ≥ 26; Nexus 6 endet bei API 25 (geschlossen via Issue #172)
 - **iOS**: Nicht primär getestet (Fokus auf Web + Android)

--- a/app.json
+++ b/app.json
@@ -44,6 +44,7 @@
       "package": "com.s540d.merkeundmale",
       "permissions": [],
       "versionCode": 58,
+      "minSdkVersion": 26,
       "newArchEnabled": false,
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.s540d.merkeundmale",
       "privacyPolicy": "https://s540d.github.io/DrawFromMemory/PRIVACY_POLICY.html"


### PR DESCRIPTION
$(cat <<'EOF'
## Zusammenfassung

Schließt Issue #172 — Nexus 6 kann die App nicht mehr installieren.

**Ursache:** React Native 0.83.2 + `@shopify/react-native-skia` 2.4.18 setzen `minSdkVersion` ≥ 26 (Android 8.0 Oreo). Das Nexus 6 endet bei Android 7.1.1 (API 25) und unterschreitet diese Anforderung.

## Änderungen

- **`app.json`** — `minSdkVersion: 26` explizit gesetzt, damit EAS/Play Store die Gerätekompatibilität korrekt kommuniziert (statt implizitem Wert aus RN/Skia)
- **`CLAUDE.md`** — Version auf v1.4.2 aktualisiert; Nexus 6 als EOL dokumentiert; Mindestanforderung Android 8.0 ergänzt

## Test plan

- [ ] `npx tsc --noEmit` — keine TypeScript-Fehler
- [ ] `npm test` — alle Tests grün
- [ ] EAS-Build: Play Store Device-Catalog zeigt Nexus 6 als inkompatibel

Closes #172

https://claude.ai/code/session_01S1k1Yoyn72iHM6G2EbmhMp
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1k1Yoyn72iHM6G2EbmhMp)_