### PR TITLE
feat: Issue #167 Phase 1 — Variabler Timer, Level-Sterne, 10 neue Level (11–20)

### DIFF
--- a/app/levels.tsx
+++ b/app/levels.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { View, Text, StyleSheet, FlatList, TouchableOpacity, useWindowDimensions } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useTranslation } from '@services/i18n';
@@ -21,7 +21,7 @@ export default function LevelsScreen() {
   const { t } = useTranslation();
   const router = useRouter();
   const { colors } = useTheme();
-  const levels = getAllLevels();
+  const levels = useMemo(() => getAllLevels(), []);
   const [ratings, setRatings] = useState<Record<number, number | null>>({});
   // Use hook for responsive dimensions (SSR-safe)
   const { width: screenWidth } = useWindowDimensions();
@@ -37,9 +37,7 @@ export default function LevelsScreen() {
       if (mounted) setRatings(Object.fromEntries(entries));
     });
     return () => { mounted = false; };
-    // levels is derived from getAllLevels() which is static — no re-fetch needed
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [levels]);
 
   const renderStars = (rating: number | null, levelNumber: number) => {
     const filled = rating === null ? 0 : Math.ceil(rating / 2);

--- a/app/levels.tsx
+++ b/app/levels.tsx
@@ -37,6 +37,8 @@ export default function LevelsScreen() {
       if (mounted) setRatings(Object.fromEntries(entries));
     });
     return () => { mounted = false; };
+    // levels is derived from getAllLevels() which is static — no re-fetch needed
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const renderStars = (rating: number | null, levelNumber: number) => {

--- a/components/__tests__/LevelsScreen.test.tsx
+++ b/components/__tests__/LevelsScreen.test.tsx
@@ -7,7 +7,7 @@ jest.mock('expo-router', () => ({
 
 jest.mock('../../services/i18n', () => ({
   useTranslation: () => ({
-    t: (key: string, opts?: any) => (opts?.number != null ? `Level ${opts.number}` : key),
+    t: (key: string, opts?: any) => (opts?.number !== null && opts?.number !== undefined ? `Level ${opts.number}` : key),
   }),
 }));
 


### PR DESCRIPTION
## Summary

Setzt Phase 1 aus Issue #167 um — alle drei P1-Features:

- **1.1 Variabler Memorize-Timer** (`LevelManager.ts`): `getDisplayDuration()` gibt jetzt schwierigkeitsabhängige Werte zurück (5/4/3/2/1.5 s). `extraTimeMode=true` addiert +3 s. `useGamePhase` liest Wert aus `LevelManager` statt Hardcode.
- **1.2 Sterne-Bewertung im Levels-Screen** (`app/levels.tsx`): Jede Level-Karte zeigt ★★★ (0–3 Sterne) basierend auf `StorageManager.getLevelRating()`. Ungespielt = ☆☆☆. Dark-Mode-konform via `colors.stars`.
- **1.3 10 weitere Level (11–20)** (`LevelManager`, `ImagePoolManager`, `LevelImageDisplay`): Tiere (11–13, Diff 3), Fahrzeuge (14–16, Diff 4), Natur (17–20, Diff 5). `getTotalLevels()` gibt 20 zurück.

## Test plan

- [x] 272 Tests grün (`npm run test:ci`)
- [x] Lint sauber (`npm run lint`)
- [x] Neue Tests: `getDisplayDuration` alle 5 Difficulty-Stufen ± extraTimeMode, `getTotalLevels() === 20`, Difficulty-Mapping Level 11–20
- [x] `LevelsScreen.test.tsx`: Mock für `getLevelRating`, Sterne-Anzeige

Closes #167 (Phase 1)

🤖 Generated with [Claude Code](https://claude.ai/code)