### PR TITLE
feat: UI/UX Phase A — Farbpalette, Dark Mode, Custom Font, Typografie (Issue #176 §1.1–2.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,26 +5,32 @@
 **Merke und Male** — Gedächtnistraining-App für Kinder (React Native / Expo).
 Spieler sehen ein Bild kurz, zeichnen es aus dem Gedächtnis, vergleichen das Ergebnis.
 
-- **Aktuell: v1.4.2** — Play-Store-ready, keine offenen Blocker
-- **Mindestanforderung Android: API 26 (Android 8.0 Oreo)** — Nexus 6 (max. API 25) wird nicht mehr unterstützt (Issue #172)
+- **Aktuell: v1.4.2** (package.json + app.json; versionCode 58)
+- **Mindestanforderung Android: API 26 (Android 8.0 Oreo)** — Nexus 6 (max. API 25) wird nicht mehr unterstützt (Issue #172, geschlossen)
 - **Live Demo:** https://s540d.github.io/DrawFromMemory/
 - **Repo:** https://github.com/S540d/DrawFromMemory
+- **Play Store:** `com.s540d.merkeundmale`
 
 ---
 
 ## Tech Stack
 
-| Bereich | Technologie |
+| Bereich | Technologie / Version |
 |---|---|
-| Framework | React Native + Expo (SDK 55) |
-| Navigation | Expo Router (file-based) |
-| Native Drawing | `@shopify/react-native-skia` |
+| Framework | React Native 0.83.2 + Expo SDK 55 |
+| React | 19.2.0 |
+| Navigation | Expo Router ~55.0.5 (file-based) |
+| Native Drawing | `@shopify/react-native-skia` 2.4.18 |
 | Web Drawing | Canvas API (`DrawingCanvas.web.tsx`) |
+| Animationen | `react-native-reanimated` ~4.2.2 |
 | State | React Hooks + AsyncStorage |
-| i18n | custom `services/i18n.ts` (de/en) |
-| Tests | Jest + jest-expo (241 Tests) |
-| CI | GitHub Actions (`ci-cd.yml`) |
-| Crash Reporting | Sentry (optional via `EXPO_PUBLIC_SENTRY_DSN`) |
+| Theming | ThemeContext (light / dark / system) |
+| Sound | Web Audio API (web) + `expo-haptics` (native) |
+| i18n | Custom `services/i18n.ts` (de/en), Locales in `locales/` |
+| Tests | Jest 29 + jest-expo ~55 (241 Tests, jsdom-Environment) |
+| CI | GitHub Actions (`.github/workflows/ci-cd.yml`) |
+| Build (Native) | EAS Build (`eas.json`) |
+| Crash Reporting | Sentry via `EXPO_PUBLIC_SENTRY_DSN` (optional, no-op on Web) |
 
 ---
 
@@ -32,80 +38,233 @@ Spieler sehen ein Bild kurz, zeichnen es aus dem Gedächtnis, vergleichen das Er
 
 ```
 app/
+  _layout.tsx           # Root-Layout, ThemeProvider, SafeAreaProvider, SentryService
+  index.tsx             # Home Screen (Startseite)
   game.tsx              # Haupt-Spielschirm (Merken → Zeichnen → Ergebnis)
   gallery.tsx           # Galerie gespeicherter Zeichnungen
-  levels.tsx            # Level-Auswahl
-  settings.tsx          # Einstellungen
+  levels.tsx            # Level-Auswahl (10 Level, Difficulty 1-5)
+  settings.tsx          # Einstellungen (via ParentalGate geschützt)
 
 components/
-  DrawingCanvas.tsx          # Web-Implementierung
+  DrawingCanvas.tsx          # Re-Export + öffentliches API (useDrawingCanvas)
+  DrawingCanvas.hooks.ts     # useDrawingCanvas Hook (color, strokeWidth, tool, paths, undo, clear)
+  DrawingCanvas.shared.ts    # Gemeinsame Typen (DrawingPath) und Styles
   DrawingCanvas.native.tsx   # Native Skia-Implementierung (Flood-Fill via Rect-Spans)
   DrawingCanvas.web.tsx      # Web Canvas-Implementierung
-  LevelImageDisplay.tsx      # SVG-Bild mit schrittweisem Aufdecken
+  LevelImageDisplay.tsx      # SVG-Bild mit schrittweisem Aufdecken (revealStep)
   ParentalGate.tsx           # Eltern-Sperre für Einstellungen
+  SettingsModal.tsx          # Einstellungen-Modal (In-Game)
+  ErrorBoundary.tsx          # Fehlerbehandlung für Render-Fehler
+  AnimatedPrimitives.tsx     # AnimatedFeedback, AnimatedNumber, etc.
+  AnimatedSplashScreen.tsx   # Animierter Splash Screen
+  Badge.tsx                  # UI-Primitiv: Badge
+  Chip.tsx                   # UI-Primitiv: Chip
+  Button.tsx                 # UI-Primitiv: Button
+  SkeletonLoader.tsx         # Skeleton Placeholder
 
 services/
   FloodFillService.ts        # Flood-Fill-Algorithmus (Scanline, 1-Bit-Palette)
   SoftwareRasterizer.ts      # CPU-Rasterizer für native Fill-Grenzenerkennung
   NativeFillLayerService.ts  # Konvertiert DrawingPath[] → native Skia Rect-Spans
-  LevelManager.ts            # Level-Definitionen und -Verwaltung
-  StorageManager.ts          # AsyncStorage-Wrapper
-  useGamePhase.ts            # Spielphasen-Hook (Merken/Zeichnen/Ergebnis)
-  useTimer.ts                # Timer-Hook mit Pause/Resume
+  ImagePoolManager.ts        # Bilderpool: wählt zufällige Bilder nach Schwierigkeit
+  LevelManager.ts            # Level-Definitionen (10 Level, Anzeigedauer, Difficulty)
+  StorageManager.ts          # AsyncStorage-Wrapper mit In-Memory-Fallback für Web
+  RatingManager.ts           # Stern-Bewertungen und rotierende Motivations-Nachrichten
+  SoundManager.ts            # Web Audio API (Web) + expo-haptics (Native)
+  SentryService.ts           # Sentry-Wrapper (init, captureException, etc.)
+  ThemeContext.tsx            # ThemeProvider + useTheme Hook (light/dark/system)
+  i18n.ts                    # Übersetzungs-Service (de/en) mit listener-basiertem Reload
+  useGamePhase.ts            # Spielphasen-Hook: memorize / draw / result + Replay
+  useTimer.ts                # Timer-Hook (Countdown, pause/resume via phase)
+
+constants/
+  Colors.ts                  # Design-Tokens: Primärfarben, Gradienten, Drawing-Farben
+  Layout.ts                  # Spacing, FontSize, FontWeight, BorderRadius
+  WebAccessibility.ts        # Web-spezifische Accessibility-Konstanten
+
+utils/
+  platform.ts                # isWeb/isIOS/isAndroid, safeWebAPI(), Storage-Adapter
+  useScreenLayout.ts         # Responsiver Layout-Hook (xs/sm/md/lg nach nutzbarer Höhe)
+
+types/
+  index.ts                   # Globale TypeScript-Typen (LevelImage, GamePhase, AppSettings, …)
+
+locales/
+  de/translations.json       # Deutsche Übersetzungen
+  en/translations.json       # Englische Übersetzungen
+
+assets/images/levels/        # Kanonische SVG-Bilder (level-01-sun.svg … extra-04-bird.svg)
+assets/images/levels-{1-5}/  # Level-sortierte Kopien der gleichen SVGs
 ```
+
+---
+
+## Path-Aliase (tsconfig.json)
+
+```jsonc
+"@/*"           → "./*"
+"@services/*"   → "./services/*"
+"@components/*" → "./components/*"
+"@utils/*"      → "./utils/*"
+```
+
+App- und Produktionscode verwendet diese Aliase (`@services/LevelManager`, nicht `../services/LevelManager`). Testdateien in `__tests__/` nutzen weiterhin relative Imports, da Jest die Babel-Aliase nicht auflöst.
 
 ---
 
 ## Entwicklungs-Workflow
 
 ```bash
-npm start          # Expo Dev Server
-npm test           # Jest (--runInBand für stabile Ergebnisse)
-npm run lint       # ESLint
-npm run build:web  # Web-Build (gh-pages)
-npx tsc --noEmit   # TypeScript-Check
+npm start                          # Expo Dev Server
+npm run android                    # Android-Emulator
+npm run ios                        # iOS-Simulator
+npm run web                        # Web-Dev-Server
+npm test                           # Jest (alle Tests)
+npm run test:watch                 # Jest Watch Mode
+npm run test:coverage              # Testabdeckung
+npm run lint                       # ESLint
+npm run validate:svg-counts        # Prüft SVG-Element-Counts in LevelImageDisplay.tsx
+npx tsc --noEmit                   # TypeScript-Check
+npm run build:web                  # Web-Build für gh-pages (expo export --platform web)
+npm run build:android              # EAS Build (Android, Production)
+npm run build:android:preview      # EAS Build (Android, Preview APK)
+npm run build:android:local        # Lokaler EAS-Build (preview)
+npm run build:android:local:production  # Lokaler EAS-Build (production)
+npm run prepare-release            # Vorbereitungs-Script für Release
+npm run validate                   # Vollständige Release-Validierung
+npm run deploy:ghpages             # Deployment auf GitHub Pages
 ```
 
-**Branch-Strategie:** Feature-Branches → PR → `testing` (QA) → `staging` (Pre-Production) → `main` (Produktion). Alle drei Branches (`main`, `staging`, `testing`) müssen immer existieren und dürfen nie gelöscht werden.
+**Branch-Strategie:** Feature-Branches → PR → `testing` (QA) → `staging` (Pre-Production) → `main` (Produktion).
+Die drei Branches `main`, `staging`, `testing` müssen immer existieren und dürfen nie gelöscht werden.
 
 ---
 
 ## CI/CD (`.github/workflows/ci-cd.yml`)
 
-Jobs:
-1. **Code Quality & Linting** — ESLint
-2. **Unit Tests & Coverage** — Jest
-3. **Build Web** — Expo Web Build
-4. **Security Audit** — `npm audit --audit-level=high` (blockiert bei high/critical)
-5. **Credential Scan** — Keystore & sensible Dateien
-6. **Docs Privacy Check** — prüft `docs/private/` auf versehentliche Commits
-7. **Platform Compatibility** — React Native Kompatibilitätsprüfung
+Läuft auf `push` und `pull_request` gegen `main` und `staging`.
+
+| Job | Name | Inhalt |
+|---|---|---|
+| 1 | Code Quality & Linting | ESLint, kein `console.log` in `app/`/`components/`, Web-API-Guards prüfen, AsyncStorage-Usage, `validate:svg-counts`, TypeScript-Check (`npx tsc --noEmit \|\| true`, non-blocking) |
+| 2 | Unit Tests & Coverage | `npm run test:ci` (Coverage-Artefakt wird hochgeladen) |
+| 3 | Build Web | `expo export --platform web` |
+| 4 | Platform Checks | Versionskonsistenz: `package.json` vs. `app.json` müssen identische Version haben |
+| 5 | Security Audit | `npm audit --audit-level=high` — blockiert bei high/critical |
+| 6 | Docs Privacy Check | `docs/private/` darf nicht committed sein |
+| 7 | Keystore & Credential Scan | Keine `.keystore`/`.jks` Dateien, keine hardcodierten Passwörter |
+| 8 | Release Readiness Report | Nur bei Push auf `main`; generiert manuelles Checklist-Summary |
+
+**Coverage-Schwellenwerte (jest.config.js):** branches 15 %, functions 25 %, lines 25 %, statements 25 %.
+
+---
+
+## Spielmechanik & Phasen
+
+```
+memorize  →  draw  →  result
+```
+
+1. **Memorize**: SVG-Bild wird 3 Sekunden angezeigt (progressiver Aufdeckeffekt via `revealStep`). Timer läuft via `useTimer`.
+2. **Draw**: Zeichnen auf `DrawingCanvas` (Pinsel + Flood-Fill). Tool wechselt nach Fill automatisch zu Brush zurück (Issue #45).
+3. **Result**: Sternbewertung (1–5), Replay-Animation, Speichern in Galerie möglich.
+
+Level-Anzahl: 10 (Difficulty 1–5). Alle Level haben 3 s Anzeigezeit.
+Bilderpool: `ImagePoolManager.ts` wählt zufällig nach Difficulty-Klasse aus.
+
+---
+
+## DrawingCanvas-Architektur
+
+| Datei | Zweck |
+|---|---|
+| `DrawingCanvas.tsx` | Re-Export, öffentliches API (`DrawingCanvas`, `useDrawingCanvas`) |
+| `DrawingCanvas.hooks.ts` | `useDrawingCanvas()` Hook: color, strokeWidth, tool, paths, undo, clearCanvas |
+| `DrawingCanvas.shared.ts` | `DrawingPath` Interface, Shared-Styles |
+| `DrawingCanvas.native.tsx` | Skia-Implementierung: `<Path>` für Strokes, `<Rect>`-Spans für Fills |
+| `DrawingCanvas.web.tsx` | HTML5-Canvas-Implementierung |
+
+**DrawingPath-Typ:**
+```typescript
+interface DrawingPath {
+  points: { x: number; y: number }[];
+  color: string;
+  strokeWidth: number;
+  type?: 'stroke' | 'fill'; // default = 'stroke'
+}
+```
 
 ---
 
 ## Flood-Fill Architektur (Native)
 
-Das größte technische Thema der letzten Entwicklungsphase war die Flood-Fill auf alten Android-Geräten (Nexus 6 / Adreno 420). Die GPU-Pipeline (`readPixels` / `MakeImage`) ist dort unzuverlässig.
+CPU-Flood-Fill auf alten Android-Geräten (Nexus 6 / Adreno 420) — die GPU-Pipeline (`readPixels` / `MakeImage`) ist dort unzuverlässig.
 
-**Aktueller Ansatz (v1.3.4):**
-- CPU-Flood-Fill via `floodFillPixels()` (Scanline-Algorithmus, 1-Bit-Palette)
-- Ergebnis wird als horizontale Rect-Spans (`FloodFillSpan[]`) ausgegeben
-- Native rendering via Skia `<Rect>` Elemente (kein Image-Roundtrip)
+- CPU-Flood-Fill via `floodFillPixels()` (Scanline-Algorithmus, 1-Bit-Palette → ~20× weniger RAM als RGBA)
+- Ergebnis: horizontale `FloodFillSpan[]` (Run-Length-Encoding)
+- Native Rendering via Skia `<Rect>` Elemente — kein Image-Roundtrip
 - Strokes werden IMMER als `<Path>` Komponenten gerendert — kein Mode-Switching
 - `NativeFillLayerService` konvertiert `DrawingPath[]` → renderfähige Layers
+- `SoftwareRasterizer` rastert bisherige Strokes für die Grenzenerkennung des Fill-Algorithmus
+
+---
+
+## Theming
+
+`ThemeContext.tsx` stellt `useTheme()` bereit:
+- `theme`: aktuell aktives Schema (`'light' | 'dark'`)
+- `themeSetting`: gespeicherte Präferenz (`'light' | 'dark' | 'system'`)
+- `colors`: typisiertes `ThemeColors`-Objekt (primary, background, text, drawing, difficulty, stars, …)
+- `setTheme(theme)`: persistiert in `StorageManager`
+
+Beim SSR/Hydration startet die App immer mit `'light'` (verhindert Hydration-Mismatch).
+
+---
+
+## Speicherung (StorageManager)
+
+AsyncStorage-Wrapper mit In-Memory-Fallback für Web (GitHub Pages).
+Storage-Keys beginnen mit `@merke_male:`.
+
+Gespeicherte Felder: `progress`, `theme`, `language`, `sound_enabled`, `music_enabled`, `extra_time_mode`, `gallery`.
+
+---
+
+## Konventionen für AI-Assistenten
+
+### Verboten (wird von CI geprüft)
+- `console.log` / `console.debug` in `app/` oder `components/`
+- `window.*` ohne `Platform.OS === 'web'`-Guard oder `// platform-safe`-Kommentar
+- `localStorage.*` ohne Platform-Check (AsyncStorage verwenden)
+- `.keystore` / `.jks` Dateien committen
+
+### Pflicht bei neuen SVG-Bildern
+`IMAGE_ELEMENT_COUNTS` in `LevelImageDisplay.tsx` muss um den neuen Dateinamen ergänzt werden, sonst schlägt `npm run validate:svg-counts` fehl.
+
+### Imports
+Path-Aliase nutzen: `@services/...`, `@components/...`, `@utils/...`.
+
+### Plattform-spezifischer Code
+Web-APIs über `utils/platform.ts` absichern (`safeWebAPI`, `isWeb`-Guard). Für Storage stets `StorageManager` nutzen — nicht direkt `AsyncStorage` oder `localStorage`.
+
+### Tests
+- Test-Dateien liegen bei `services/__tests__/`, `components/__tests__/`, `utils/__tests__/`, `__tests__/`
+- Jest-Umgebung: `jsdom`; Skia wird gemockt via `__mocks__/@shopify/react-native-skia.js`
+- `npm test` (kein `--runInBand` nötig, aber stabil)
 
 ---
 
 ## Security
 
 - `npm audit --audit-level=high` in CI — Pipeline blockiert bei high/critical
-- Verbleibende 5 low-Findings: `@tootallnate/once` via jest-expo-Chain — fix erfordert breaking jest-expo Major-Upgrade, intentionally excluded
+- Verbleibende 5 low-Findings: `@tootallnate/once` via jest-expo-Chain — Fix würde ein Breaking-Major-Upgrade von jest-expo erfordern (aktuell `~55.0.9`), intentionally excluded
 - Alle high/critical Vulnerabilities zuletzt gefixt: 2026-04-21 via PR #144
 
 ---
 
 ## Offene Issues / Bekannte Einschränkungen
 
-- **jest-expo → @tootallnate/once** (low severity): Fix erfordert `jest-expo@47` — breaking change, noch nicht gemacht
-- **Nexus 6**: EOL — ab React Native 0.83.x / Skia 2.x ist `minSdkVersion` ≥ 26; Nexus 6 endet bei API 25 (geschlossen via Issue #172)
+- **jest-expo → @tootallnate/once** (low severity): Fix würde Breaking-Major-Upgrade von jest-expo erfordern (aktuell `~55.0.9`) — noch nicht gemacht
+- **Nexus 6**: EOL — `minSdkVersion` = 26; Nexus 6 endet bei API 25 (geschlossen via Issue #172)
 - **iOS**: Nicht primär getestet (Fokus auf Web + Android)
+- **iOS App Store**: Bundle ID `com.s540d.merkeundmale`, App Store URL noch TBD

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@
 **Merke und Male** — Gedächtnistraining-App für Kinder (React Native / Expo).
 Spieler sehen ein Bild kurz, zeichnen es aus dem Gedächtnis, vergleichen das Ergebnis.
 
-- **Aktuell: v1.3.4** — Play-Store-ready, keine offenen Blocker
-- **In staging (seit 2026-05-08):** PR #164 — i18n-Fix: hardcodierte App-Titel in HomeScreen & GameScreen durch `t('app.name')` ersetzt
+- **Aktuell: v1.4.2** — Play-Store-ready, keine offenen Blocker
+- **Mindestanforderung Android: API 26 (Android 8.0 Oreo)** — Nexus 6 (max. API 25) wird nicht mehr unterstützt (Issue #172)
 - **Live Demo:** https://s540d.github.io/DrawFromMemory/
 - **Repo:** https://github.com/S540d/DrawFromMemory
 
@@ -107,5 +107,5 @@ Das größte technische Thema der letzten Entwicklungsphase war die Flood-Fill a
 ## Offene Issues / Bekannte Einschränkungen
 
 - **jest-expo → @tootallnate/once** (low severity): Fix erfordert `jest-expo@47` — breaking change, noch nicht gemacht
-- **Nexus 6 Flood-Fill**: Implementierung fertig, aber kein Gerät für manuelle Tests vorhanden
+- **Nexus 6**: EOL — ab React Native 0.83.x / Skia 2.x ist `minSdkVersion` ≥ 26; Nexus 6 endet bei API 25 (geschlossen via Issue #172)
 - **iOS**: Nicht primär getestet (Fokus auf Web + Android)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Spieler sehen ein Bild kurz, zeichnen es aus dem Gedächtnis, vergleichen das Er
 | Theming | ThemeContext (light / dark / system) |
 | Sound | Web Audio API (web) + `expo-haptics` (native) |
 | i18n | Custom `services/i18n.ts` (de/en), Locales in `locales/` |
-| Tests | Jest 29 + jest-expo ~55 (241 Tests, jsdom-Environment) |
+| Tests | Jest 29 + jest-expo ~55 (272 Tests, jsdom-Environment) |
 | CI | GitHub Actions (`.github/workflows/ci-cd.yml`) |
 | Build (Native) | EAS Build (`eas.json`) |
 | Crash Reporting | Sentry via `EXPO_PUBLIC_SENTRY_DSN` (optional, no-op on Web) |

--- a/app.json
+++ b/app.json
@@ -44,6 +44,7 @@
       "package": "com.s540d.merkeundmale",
       "permissions": [],
       "versionCode": 58,
+      "minSdkVersion": 26,
       "newArchEnabled": false,
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.s540d.merkeundmale",
       "privacyPolicy": "https://s540d.github.io/DrawFromMemory/PRIVACY_POLICY.html"

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -8,6 +8,13 @@ import AnimatedSplashScreen from '@components/AnimatedSplashScreen';
 import { useCallback, useEffect, useState, useReducer } from 'react';
 import { initLanguage, addLanguageChangeListener } from '@services/i18n';
 import { initSentry } from '@services/SentryService';
+import { useFonts } from 'expo-font';
+import {
+  Nunito_400Regular,
+  Nunito_600SemiBold,
+  Nunito_700Bold,
+  Nunito_800ExtraBold,
+} from '@expo-google-fonts/nunito';
 
 // Initialize Sentry as early as possible (no-op on web or without DSN)
 initSentry();
@@ -20,6 +27,13 @@ function RootLayoutContent() {
   const [showSplash, setShowSplash] = useState(true);
   const handleSplashFinish = useCallback(() => setShowSplash(false), []);
   const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
+
+  useFonts({
+    Nunito_400Regular,
+    Nunito_600SemiBold,
+    Nunito_700Bold,
+    Nunito_800ExtraBold,
+  });
 
   // Initialize language from storage, then re-render so all screens show the correct language
   useEffect(() => {

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -11,7 +11,7 @@ import {
   isTodayCompleted,
 } from '@services/DailyChallengeManager';
 import Colors from '../constants/Colors';
-import { Spacing, FontSize, FontWeight, BorderRadius } from '../constants/Layout';
+import { Spacing, FontSize, FontWeight, FontFamily, BorderRadius } from '../constants/Layout';
 import SettingsModal from '@components/SettingsModal';
 
 export default function HomeScreen() {
@@ -146,11 +146,13 @@ const styles = StyleSheet.create({
   appTitle: {
     fontSize: FontSize.xl,
     fontWeight: FontWeight.bold,
+    fontFamily: FontFamily.bold,
     lineHeight: 28,
   },
   appTagline: {
     fontSize: FontSize.xs,
     fontWeight: FontWeight.semibold,
+    fontFamily: FontFamily.semibold,
     marginTop: 2,
   },
   settingsButton: {
@@ -166,15 +168,17 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    gap: Spacing.md,
+    gap: Spacing.lg,
   },
   heroEmoji: {
-    fontSize: 64,
+    fontSize: 72,
   },
   heroTitle: {
-    fontSize: FontSize.xxl,
+    fontSize: FontSize.display,
     fontWeight: FontWeight.bold,
+    fontFamily: FontFamily.extraBold,
     textAlign: 'center',
+    lineHeight: 48,
   },
   buttonContainer: {
     gap: Spacing.md,

--- a/app/levels.tsx
+++ b/app/levels.tsx
@@ -6,7 +6,7 @@ import { useTheme } from '@services/ThemeContext';
 import { getAllLevels } from '@services/LevelManager';
 import storageManager from '@services/StorageManager';
 import Colors from '../constants/Colors';
-import { Spacing, FontSize, FontWeight, BorderRadius } from '../constants/Layout';
+import { Spacing, FontSize, FontWeight, FontFamily, BorderRadius } from '../constants/Layout';
 import { AnimatedCard } from '@components/AnimatedPrimitives';
 import { Badge } from '@components/Badge';
 
@@ -122,26 +122,29 @@ const styles = StyleSheet.create({
   header: {
     paddingHorizontal: Spacing.lg,
     paddingTop: Spacing.xl,
-    paddingBottom: Spacing.md,
+    paddingBottom: Spacing.lg,
     borderBottomWidth: 1,
     borderBottomColor: Colors.surface,
   },
   backButton: {
     fontSize: FontSize.md,
+    fontFamily: FontFamily.semibold,
     color: Colors.primary,
     marginBottom: Spacing.sm,
   },
   title: {
-    fontSize: FontSize.xl,
+    fontSize: FontSize.xxl,
     fontWeight: FontWeight.bold,
+    fontFamily: FontFamily.extraBold,
     color: Colors.text.primary,
   },
   listContent: {
     padding: Spacing.lg,
+    paddingBottom: Spacing.xxl,
   },
   row: {
     justifyContent: 'space-between',
-    marginBottom: Spacing.md,
+    marginBottom: Spacing.lg,
   },
   levelCard: {
     backgroundColor: Colors.surface,

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -6,18 +6,20 @@
 
 export const Colors = {
   // Primärfarben - Gradient-ready
-  primary: '#667eea',      // Lila/Blau - Kreativität & Spielfreude
-  primaryLight: '#8599f3', // Hellere Variante
-  primaryDark: '#4c63d2',  // Dunklere Variante
-  secondary: '#f093fb',    // Rosa - Spielerisch & Warm
-  accent: '#A8E6CF',       // Mint - Zusätzlicher Akzent
+  primary: '#7C5CFF',      // Vivid Purple - kräftiger, kinderfreundlicher (Issue #176)
+  primaryLight: '#9E84FF', // Hellere Variante
+  primaryDark: '#5A3FE0',  // Dunklere Variante
+  secondary: '#F093FB',    // Rosa - Spielerisch & Warm
+  accent: '#4ECDC4',       // Mint-Teal - frischer Akzent
+  accentWarm: '#FFB547',   // Apricot - spielerisch warm
 
   // Gradient-Kombinationen (für LinearGradient)
   gradient: {
-    primary: ['#667eea', '#764ba2'],     // Lila-Gradient
-    secondary: ['#f093fb', '#f5576c'],   // Rosa-Gradient
-    warm: ['#FFB84D', '#FF6B6B'],        // Warm-Gradient
-    cta: ['#667eea', '#f093fb'],         // CTA-Gradient für primäre Buttons
+    primary: ['#7C5CFF', '#F093FB'],     // Primary Gradient (Vivid Purple → Rosa)
+    secondary: ['#F093FB', '#f5576c'],   // Rosa-Gradient
+    warm: ['#FFB547', '#FF6B6B'],        // Apricot-Gradient
+    cta: ['#7C5CFF', '#F093FB'],         // CTA-Gradient mit neuem Primary
+    teal: ['#4ECDC4', '#44CF6C'],        // Teal-Gradient
   },
 
   // UI Farben - "Warm Paper"

--- a/constants/Layout.ts
+++ b/constants/Layout.ts
@@ -23,7 +23,8 @@ export const BorderRadius = {
 /**
  * Typografie-Hierarchie
  *
- * H1 – App-Titel (Home-Screen):              xxl  = 32 px  bold
+ * Display – Hero-Headline (Home):            display = 40 px  extraBold
+ * H1 – App-Titel / Screen-Headlines:         xxl  = 32 px  bold
  * H2 – Screen-Titel:                         xl   = 24 px  bold
  * H3 – Modal-/Phase-/Abschnitts-Titel:       lg   = 20 px  semibold
  * Body / Labels:                              md   = 16 px  regular / medium
@@ -38,6 +39,7 @@ export const FontSize = {
   lg: 20,
   xl: 24,
   xxl: 32,
+  display: 40,
   huge: 48,
 };
 
@@ -48,9 +50,21 @@ export const FontWeight = {
   bold: '700' as const,
 };
 
+/**
+ * Schriftfamilien — Nunito (via @expo-google-fonts/nunito)
+ * Fallback auf System-Font bis Fonts geladen sind.
+ */
+export const FontFamily = {
+  regular: 'Nunito_400Regular',
+  semibold: 'Nunito_600SemiBold',
+  bold: 'Nunito_700Bold',
+  extraBold: 'Nunito_800ExtraBold',
+};
+
 export default {
   Spacing,
   BorderRadius,
   FontSize,
   FontWeight,
+  FontFamily,
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -32,7 +32,7 @@ module.exports = {
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   transformIgnorePatterns: [
-    'node_modules/(?!(react-native|@react-native|expo|@expo|@shopify/react-native-skia)/)',
+    'node_modules/(?!(react-native|@react-native|expo|@expo|@expo-google-fonts|@shopify/react-native-skia)/)',
   ],
   globals: {
     __DEV__: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "merke-und-male",
       "version": "1.4.2",
       "dependencies": {
+        "@expo-google-fonts/nunito": "^0.4.2",
         "@expo/metro-runtime": "~55.0.6",
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@sentry/react-native": "~7.11.0",
@@ -1562,6 +1563,12 @@
       "resolved": "https://registry.npmjs.org/@expo-google-fonts/material-symbols/-/material-symbols-0.4.26.tgz",
       "integrity": "sha512-1RBDVbRQDIAldwf0oV9QjEallOJ+FkkuYxgKFc345Vzi0dK/ipVITWTUTJHr49Jh1XQuEyVKdHH+mo3DXqZU7g==",
       "license": "MIT AND Apache-2.0"
+    },
+    "node_modules/@expo-google-fonts/nunito": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/nunito/-/nunito-0.4.2.tgz",
+      "integrity": "sha512-1KCWphw/I2ugqfs9iRHUCkPTnomNgGPtF4AvqVquoEKxr0EL+mcLNLgeixsslbaSFevRR6/KJAE3sc8g0VaY0Q==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@expo-google-fonts/nunito": "^0.4.2",
     "@expo/metro-runtime": "~55.0.6",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@sentry/react-native": "~7.11.0",

--- a/services/ThemeContext.tsx
+++ b/services/ThemeContext.tsx
@@ -21,11 +21,13 @@ export interface ThemeColors {
   primaryDark: string;
   secondary: string;
   accent: string;
+  accentWarm: string;
 
   // Background & Surface
   background: string;
   surface: string;
   surfaceElevated: string;
+  surfaceAlt: string;
   border: string;
   modalOverlay: string;
 
@@ -70,15 +72,17 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 // Light theme colors
 const LIGHT_COLORS: ThemeColors = {
-  primary: '#667eea',
-  primaryLight: '#8599f3',
-  primaryDark: '#4c63d2',
-  secondary: '#f093fb',
-  accent: '#A8E6CF',
+  primary: '#7C5CFF',
+  primaryLight: '#9E84FF',
+  primaryDark: '#5A3FE0',
+  secondary: '#F093FB',
+  accent: '#4ECDC4',
+  accentWarm: '#FFB547',
 
   background: '#FAFAFA',
   surface: '#F5F5F5',
   surfaceElevated: '#EFEFEF',
+  surfaceAlt: '#EDE8F5',
   border: '#DDDDDD',
   modalOverlay: 'rgba(0, 0, 0, 0.5)',
 
@@ -123,18 +127,20 @@ const LIGHT_COLORS: ThemeColors = {
   },
 };
 
-// Dark theme colors
+// Dark theme colors — wärmere, leicht lila getönte Töne (Issue #176 §1.2)
 const DARK_COLORS: ThemeColors = {
-  primary: '#8599f3',
-  primaryLight: '#a8b9f7',
-  primaryDark: '#667eea',
-  secondary: '#f5b3fc',
-  accent: '#7FD8B8',
+  primary: '#9E84FF',
+  primaryLight: '#B8A3FF',
+  primaryDark: '#7C5CFF',
+  secondary: '#F5B3FC',
+  accent: '#4ECDC4',
+  accentWarm: '#FFB547',
 
-  background: '#0F1419',
-  surface: '#1A1F2E',
-  surfaceElevated: '#242B3E',
-  border: '#3A4556',
+  background: '#1F1B2E',
+  surface: '#2A2340',
+  surfaceElevated: '#352B4D',
+  surfaceAlt: '#302848',
+  border: '#4A3F60',
   modalOverlay: 'rgba(0, 0, 0, 0.7)',
 
   text: {

--- a/services/__tests__/ThemeContext.test.tsx
+++ b/services/__tests__/ThemeContext.test.tsx
@@ -61,7 +61,7 @@ describe('ThemeContext', () => {
     await waitFor(() => {
       expect(result.current.theme).toBe('dark');
     });
-    expect(result.current.colors.background).toBe('#0F1419');
+    expect(result.current.colors.background).toBe('#1F1B2E');
   });
 
   it('follows system theme when setting is system', async () => {


### PR DESCRIPTION
$(cat <<'EOF'
## Zusammenfassung

Umsetzt Issue #176 §§ 1.1–2.2 (Phase A: Foundation). Keine Breaking Changes, alle 272 Tests grün, TypeScript clean.

## Änderungen

### §1.1 — Lebendigere Farbpalette
- **Primary**: `#667eea` → `#7C5CFF` (Vivid Purple) — kräftiger, kinderfreundlicher
- **Accent**: `#A8E6CF` → `#4ECDC4` (Mint-Teal) — frischer
- **Neu**: `accentWarm: '#FFB547'` (Apricot) als spielerischer Warm-Ton
- **Gradients**: CTA-Gradient auf neuen Primary (`#7C5CFF → #F093FB`); neues Teal-Gradient
- `ThemeColors` Interface um `accentWarm` und `surfaceAlt` erweitert

### §1.2 — Dark Mode aufpolieren
- **Background**: `#0F1419` → `#1F1B2E` — wärmer, leicht lila getönt
- **Surface**: `#1A1F2E` → `#2A2340` — Purple-Tint statt neutrales Grau
- **SurfaceElevated**: `#242B3E` → `#352B4D`
- **Border**: `#3A4556` → `#4A3F60`
- `surfaceAlt: '#302848'` ergänzt

### §2.1 — Custom Font (Nunito)
- `@expo-google-fonts/nunito` installiert (400 / 600 / 700 / 800)
- Font-Loading via `useFonts` in `app/_layout.tsx` (non-blocking; Splash Screen gibt Ladezeit)
- `FontFamily`-Konstanten in `constants/Layout.ts` (regular / semibold / bold / extraBold)
- `jest.config.js`: `@expo-google-fonts` in `transformIgnorePatterns` ergänzt

### §2.2 — Display-Hierarchie verstärken
- `FontSize.display = 40` neu in `constants/Layout.ts`
- **Home heroTitle**: 32 px → 40 px (`FontSize.display`) + `FontFamily.extraBold` + mehr Whitespace (gap lg statt md, größeres Emoji)
- **Levels-Titel**: 24 px → 32 px (`FontSize.xxl`) + `FontFamily.extraBold`
- Mehr Whitespace: `row.marginBottom` lg statt md, `listContent.paddingBottom` xxl

## Test plan

- [ ] `npm test` → 272/272 grün
- [ ] `npx tsc --noEmit` → keine Fehler
- [ ] Light Mode: primäre Buttons / Links erscheinen in `#7C5CFF`
- [ ] Dark Mode: Hintergrund warmviolett (`#1F1B2E`), keine grauen Flächen mehr
- [ ] Home-Screen: Hero-Titel deutlich größer (40 px), runde Nunito-Schrift sichtbar
- [ ] Levels-Screen: Titel 32 px, mehr Abstand zwischen Cards

## Technische Constraints eingehalten
- Web + Android lauffähig (kein iOS-Lock-in)
- Keine Skia-Imports ohne `.native.tsx`
- Kein `console.log` in `app/` oder `components/`
- AsyncStorage über StorageManager

Closes #176 (Phase A)

https://claude.ai/code/session_01WaoMkFrUnk2HZZvhfgLQGR
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaoMkFrUnk2HZZvhfgLQGR)_