### PR TITLE
feat: Sprint A — FloatingStars + AnimatedHero (v1.5.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,8 @@ npm run deploy:ghpages             # Deployment auf GitHub Pages
 **Branch-Strategie:** Feature-Branches → PR → `testing` (QA) → `staging` (Pre-Production) → `main` (Produktion).
 Die drei Branches `main`, `staging`, `testing` müssen immer existieren und dürfen nie gelöscht werden.
 
+> **⚠️ REGEL FÜR AI-ASSISTENTEN:** Merges auf `main` sind VERBOTEN ohne explizite schriftliche Freigabe durch den Nutzer in der aktuellen Konversation. Das gilt auch für `staging → main`. Immer nach `testing → staging` stoppen und auf Freigabe warten. `main` ist production — nur der Nutzer entscheidet, wann etwas dort landet.
+
 ---
 
 ## CI/CD (`.github/workflows/ci-cd.yml`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,26 +5,32 @@
 **Merke und Male** — Gedächtnistraining-App für Kinder (React Native / Expo).
 Spieler sehen ein Bild kurz, zeichnen es aus dem Gedächtnis, vergleichen das Ergebnis.
 
-- **Aktuell: v1.4.2** — Play-Store-ready, keine offenen Blocker
-- **Mindestanforderung Android: API 26 (Android 8.0 Oreo)** — Nexus 6 (max. API 25) wird nicht mehr unterstützt (Issue #172)
+- **Aktuell: v1.4.2** (package.json + app.json; versionCode 58)
+- **Mindestanforderung Android: API 26 (Android 8.0 Oreo)** — Nexus 6 (max. API 25) wird nicht mehr unterstützt (Issue #172, geschlossen)
 - **Live Demo:** https://s540d.github.io/DrawFromMemory/
 - **Repo:** https://github.com/S540d/DrawFromMemory
+- **Play Store:** `com.s540d.merkeundmale`
 
 ---
 
 ## Tech Stack
 
-| Bereich | Technologie |
+| Bereich | Technologie / Version |
 |---|---|
-| Framework | React Native + Expo (SDK 55) |
-| Navigation | Expo Router (file-based) |
-| Native Drawing | `@shopify/react-native-skia` |
+| Framework | React Native 0.83.2 + Expo SDK 55 |
+| React | 19.2.0 |
+| Navigation | Expo Router ~55.0.5 (file-based) |
+| Native Drawing | `@shopify/react-native-skia` 2.4.18 |
 | Web Drawing | Canvas API (`DrawingCanvas.web.tsx`) |
+| Animationen | `react-native-reanimated` ~4.2.2 |
 | State | React Hooks + AsyncStorage |
-| i18n | custom `services/i18n.ts` (de/en) |
-| Tests | Jest + jest-expo (241 Tests) |
-| CI | GitHub Actions (`ci-cd.yml`) |
-| Crash Reporting | Sentry (optional via `EXPO_PUBLIC_SENTRY_DSN`) |
+| Theming | ThemeContext (light / dark / system) |
+| Sound | Web Audio API (web) + `expo-haptics` (native) |
+| i18n | Custom `services/i18n.ts` (de/en), Locales in `locales/` |
+| Tests | Jest 29 + jest-expo ~55 (241 Tests, jsdom-Environment) |
+| CI | GitHub Actions (`.github/workflows/ci-cd.yml`) |
+| Build (Native) | EAS Build (`eas.json`) |
+| Crash Reporting | Sentry via `EXPO_PUBLIC_SENTRY_DSN` (optional, no-op on Web) |
 
 ---
 
@@ -32,80 +38,233 @@ Spieler sehen ein Bild kurz, zeichnen es aus dem Gedächtnis, vergleichen das Er
 
 ```
 app/
+  _layout.tsx           # Root-Layout, ThemeProvider, SafeAreaProvider, SentryService
+  index.tsx             # Home Screen (Startseite)
   game.tsx              # Haupt-Spielschirm (Merken → Zeichnen → Ergebnis)
   gallery.tsx           # Galerie gespeicherter Zeichnungen
-  levels.tsx            # Level-Auswahl
-  settings.tsx          # Einstellungen
+  levels.tsx            # Level-Auswahl (10 Level, Difficulty 1-5)
+  settings.tsx          # Einstellungen (via ParentalGate geschützt)
 
 components/
-  DrawingCanvas.tsx          # Web-Implementierung
+  DrawingCanvas.tsx          # Re-Export + öffentliches API (useDrawingCanvas)
+  DrawingCanvas.hooks.ts     # useDrawingCanvas Hook (color, strokeWidth, tool, paths, undo, clear)
+  DrawingCanvas.shared.ts    # Gemeinsame Typen (DrawingPath) und Styles
   DrawingCanvas.native.tsx   # Native Skia-Implementierung (Flood-Fill via Rect-Spans)
   DrawingCanvas.web.tsx      # Web Canvas-Implementierung
-  LevelImageDisplay.tsx      # SVG-Bild mit schrittweisem Aufdecken
+  LevelImageDisplay.tsx      # SVG-Bild mit schrittweisem Aufdecken (revealStep)
   ParentalGate.tsx           # Eltern-Sperre für Einstellungen
+  SettingsModal.tsx          # Einstellungen-Modal (In-Game)
+  ErrorBoundary.tsx          # Fehlerbehandlung für Render-Fehler
+  AnimatedPrimitives.tsx     # AnimatedFeedback, AnimatedNumber, etc.
+  AnimatedSplashScreen.tsx   # Animierter Splash Screen
+  Badge.tsx                  # UI-Primitiv: Badge
+  Chip.tsx                   # UI-Primitiv: Chip
+  Button.tsx                 # UI-Primitiv: Button
+  SkeletonLoader.tsx         # Skeleton Placeholder
 
 services/
   FloodFillService.ts        # Flood-Fill-Algorithmus (Scanline, 1-Bit-Palette)
   SoftwareRasterizer.ts      # CPU-Rasterizer für native Fill-Grenzenerkennung
   NativeFillLayerService.ts  # Konvertiert DrawingPath[] → native Skia Rect-Spans
-  LevelManager.ts            # Level-Definitionen und -Verwaltung
-  StorageManager.ts          # AsyncStorage-Wrapper
-  useGamePhase.ts            # Spielphasen-Hook (Merken/Zeichnen/Ergebnis)
-  useTimer.ts                # Timer-Hook mit Pause/Resume
+  ImagePoolManager.ts        # Bilderpool: wählt zufällige Bilder nach Schwierigkeit
+  LevelManager.ts            # Level-Definitionen (10 Level, Anzeigedauer, Difficulty)
+  StorageManager.ts          # AsyncStorage-Wrapper mit In-Memory-Fallback für Web
+  RatingManager.ts           # Stern-Bewertungen und rotierende Motivations-Nachrichten
+  SoundManager.ts            # Web Audio API (Web) + expo-haptics (Native)
+  SentryService.ts           # Sentry-Wrapper (init, captureException, etc.)
+  ThemeContext.tsx            # ThemeProvider + useTheme Hook (light/dark/system)
+  i18n.ts                    # Übersetzungs-Service (de/en) mit listener-basiertem Reload
+  useGamePhase.ts            # Spielphasen-Hook: memorize / draw / result + Replay
+  useTimer.ts                # Timer-Hook (Countdown, pause/resume via phase)
+
+constants/
+  Colors.ts                  # Design-Tokens: Primärfarben, Gradienten, Drawing-Farben
+  Layout.ts                  # Spacing, FontSize, FontWeight, BorderRadius
+  WebAccessibility.ts        # Web-spezifische Accessibility-Konstanten
+
+utils/
+  platform.ts                # isWeb/isIOS/isAndroid, safeWebAPI(), Storage-Adapter
+  useScreenLayout.ts         # Responsiver Layout-Hook (xs/sm/md/lg nach nutzbarer Höhe)
+
+types/
+  index.ts                   # Globale TypeScript-Typen (LevelImage, GamePhase, AppSettings, …)
+
+locales/
+  de/translations.json       # Deutsche Übersetzungen
+  en/translations.json       # Englische Übersetzungen
+
+assets/images/levels/        # Kanonische SVG-Bilder (level-01-sun.svg … extra-04-bird.svg)
+assets/images/levels-{1-5}/  # Level-sortierte Kopien der gleichen SVGs
 ```
+
+---
+
+## Path-Aliase (tsconfig.json)
+
+```jsonc
+"@/*"           → "./*"
+"@services/*"   → "./services/*"
+"@components/*" → "./components/*"
+"@utils/*"      → "./utils/*"
+```
+
+App- und Produktionscode verwendet diese Aliase (`@services/LevelManager`, nicht `../services/LevelManager`). Testdateien in `__tests__/` nutzen weiterhin relative Imports, da Jest die Babel-Aliase nicht auflöst.
 
 ---
 
 ## Entwicklungs-Workflow
 
 ```bash
-npm start          # Expo Dev Server
-npm test           # Jest (--runInBand für stabile Ergebnisse)
-npm run lint       # ESLint
-npm run build:web  # Web-Build (gh-pages)
-npx tsc --noEmit   # TypeScript-Check
+npm start                          # Expo Dev Server
+npm run android                    # Android-Emulator
+npm run ios                        # iOS-Simulator
+npm run web                        # Web-Dev-Server
+npm test                           # Jest (alle Tests)
+npm run test:watch                 # Jest Watch Mode
+npm run test:coverage              # Testabdeckung
+npm run lint                       # ESLint
+npm run validate:svg-counts        # Prüft SVG-Element-Counts in LevelImageDisplay.tsx
+npx tsc --noEmit                   # TypeScript-Check
+npm run build:web                  # Web-Build für gh-pages (expo export --platform web)
+npm run build:android              # EAS Build (Android, Production)
+npm run build:android:preview      # EAS Build (Android, Preview APK)
+npm run build:android:local        # Lokaler EAS-Build (preview)
+npm run build:android:local:production  # Lokaler EAS-Build (production)
+npm run prepare-release            # Vorbereitungs-Script für Release
+npm run validate                   # Vollständige Release-Validierung
+npm run deploy:ghpages             # Deployment auf GitHub Pages
 ```
 
-**Branch-Strategie:** Feature-Branches → PR → `testing` (QA) → `staging` (Pre-Production) → `main` (Produktion). Alle drei Branches (`main`, `staging`, `testing`) müssen immer existieren und dürfen nie gelöscht werden.
+**Branch-Strategie:** Feature-Branches → PR → `testing` (QA) → `staging` (Pre-Production) → `main` (Produktion).
+Die drei Branches `main`, `staging`, `testing` müssen immer existieren und dürfen nie gelöscht werden.
 
 ---
 
 ## CI/CD (`.github/workflows/ci-cd.yml`)
 
-Jobs:
-1. **Code Quality & Linting** — ESLint
-2. **Unit Tests & Coverage** — Jest
-3. **Build Web** — Expo Web Build
-4. **Security Audit** — `npm audit --audit-level=high` (blockiert bei high/critical)
-5. **Credential Scan** — Keystore & sensible Dateien
-6. **Docs Privacy Check** — prüft `docs/private/` auf versehentliche Commits
-7. **Platform Compatibility** — React Native Kompatibilitätsprüfung
+Läuft auf `push` und `pull_request` gegen `main` und `staging`.
+
+| Job | Name | Inhalt |
+|---|---|---|
+| 1 | Code Quality & Linting | ESLint, kein `console.log` in `app/`/`components/`, Web-API-Guards prüfen, AsyncStorage-Usage, `validate:svg-counts`, TypeScript-Check (`npx tsc --noEmit \|\| true`, non-blocking) |
+| 2 | Unit Tests & Coverage | `npm run test:ci` (Coverage-Artefakt wird hochgeladen) |
+| 3 | Build Web | `expo export --platform web` |
+| 4 | Platform Checks | Versionskonsistenz: `package.json` vs. `app.json` müssen identische Version haben |
+| 5 | Security Audit | `npm audit --audit-level=high` — blockiert bei high/critical |
+| 6 | Docs Privacy Check | `docs/private/` darf nicht committed sein |
+| 7 | Keystore & Credential Scan | Keine `.keystore`/`.jks` Dateien, keine hardcodierten Passwörter |
+| 8 | Release Readiness Report | Nur bei Push auf `main`; generiert manuelles Checklist-Summary |
+
+**Coverage-Schwellenwerte (jest.config.js):** branches 15 %, functions 25 %, lines 25 %, statements 25 %.
+
+---
+
+## Spielmechanik & Phasen
+
+```
+memorize  →  draw  →  result
+```
+
+1. **Memorize**: SVG-Bild wird 3 Sekunden angezeigt (progressiver Aufdeckeffekt via `revealStep`). Timer läuft via `useTimer`.
+2. **Draw**: Zeichnen auf `DrawingCanvas` (Pinsel + Flood-Fill). Tool wechselt nach Fill automatisch zu Brush zurück (Issue #45).
+3. **Result**: Sternbewertung (1–5), Replay-Animation, Speichern in Galerie möglich.
+
+Level-Anzahl: 10 (Difficulty 1–5). Alle Level haben 3 s Anzeigezeit.
+Bilderpool: `ImagePoolManager.ts` wählt zufällig nach Difficulty-Klasse aus.
+
+---
+
+## DrawingCanvas-Architektur
+
+| Datei | Zweck |
+|---|---|
+| `DrawingCanvas.tsx` | Re-Export, öffentliches API (`DrawingCanvas`, `useDrawingCanvas`) |
+| `DrawingCanvas.hooks.ts` | `useDrawingCanvas()` Hook: color, strokeWidth, tool, paths, undo, clearCanvas |
+| `DrawingCanvas.shared.ts` | `DrawingPath` Interface, Shared-Styles |
+| `DrawingCanvas.native.tsx` | Skia-Implementierung: `<Path>` für Strokes, `<Rect>`-Spans für Fills |
+| `DrawingCanvas.web.tsx` | HTML5-Canvas-Implementierung |
+
+**DrawingPath-Typ:**
+```typescript
+interface DrawingPath {
+  points: { x: number; y: number }[];
+  color: string;
+  strokeWidth: number;
+  type?: 'stroke' | 'fill'; // default = 'stroke'
+}
+```
 
 ---
 
 ## Flood-Fill Architektur (Native)
 
-Das größte technische Thema der letzten Entwicklungsphase war die Flood-Fill auf alten Android-Geräten (Nexus 6 / Adreno 420). Die GPU-Pipeline (`readPixels` / `MakeImage`) ist dort unzuverlässig.
+CPU-Flood-Fill auf alten Android-Geräten (Nexus 6 / Adreno 420) — die GPU-Pipeline (`readPixels` / `MakeImage`) ist dort unzuverlässig.
 
-**Aktueller Ansatz (v1.3.4):**
-- CPU-Flood-Fill via `floodFillPixels()` (Scanline-Algorithmus, 1-Bit-Palette)
-- Ergebnis wird als horizontale Rect-Spans (`FloodFillSpan[]`) ausgegeben
-- Native rendering via Skia `<Rect>` Elemente (kein Image-Roundtrip)
+- CPU-Flood-Fill via `floodFillPixels()` (Scanline-Algorithmus, 1-Bit-Palette → ~20× weniger RAM als RGBA)
+- Ergebnis: horizontale `FloodFillSpan[]` (Run-Length-Encoding)
+- Native Rendering via Skia `<Rect>` Elemente — kein Image-Roundtrip
 - Strokes werden IMMER als `<Path>` Komponenten gerendert — kein Mode-Switching
 - `NativeFillLayerService` konvertiert `DrawingPath[]` → renderfähige Layers
+- `SoftwareRasterizer` rastert bisherige Strokes für die Grenzenerkennung des Fill-Algorithmus
+
+---
+
+## Theming
+
+`ThemeContext.tsx` stellt `useTheme()` bereit:
+- `theme`: aktuell aktives Schema (`'light' | 'dark'`)
+- `themeSetting`: gespeicherte Präferenz (`'light' | 'dark' | 'system'`)
+- `colors`: typisiertes `ThemeColors`-Objekt (primary, background, text, drawing, difficulty, stars, …)
+- `setTheme(theme)`: persistiert in `StorageManager`
+
+Beim SSR/Hydration startet die App immer mit `'light'` (verhindert Hydration-Mismatch).
+
+---
+
+## Speicherung (StorageManager)
+
+AsyncStorage-Wrapper mit In-Memory-Fallback für Web (GitHub Pages).
+Storage-Keys beginnen mit `@merke_male:`.
+
+Gespeicherte Felder: `progress`, `theme`, `language`, `sound_enabled`, `music_enabled`, `extra_time_mode`, `gallery`.
+
+---
+
+## Konventionen für AI-Assistenten
+
+### Verboten (wird von CI geprüft)
+- `console.log` / `console.debug` in `app/` oder `components/`
+- `window.*` ohne `Platform.OS === 'web'`-Guard oder `// platform-safe`-Kommentar
+- `localStorage.*` ohne Platform-Check (AsyncStorage verwenden)
+- `.keystore` / `.jks` Dateien committen
+
+### Pflicht bei neuen SVG-Bildern
+`IMAGE_ELEMENT_COUNTS` in `LevelImageDisplay.tsx` muss um den neuen Dateinamen ergänzt werden, sonst schlägt `npm run validate:svg-counts` fehl.
+
+### Imports
+Path-Aliase nutzen: `@services/...`, `@components/...`, `@utils/...`.
+
+### Plattform-spezifischer Code
+Web-APIs über `utils/platform.ts` absichern (`safeWebAPI`, `isWeb`-Guard). Für Storage stets `StorageManager` nutzen — nicht direkt `AsyncStorage` oder `localStorage`.
+
+### Tests
+- Test-Dateien liegen bei `services/__tests__/`, `components/__tests__/`, `utils/__tests__/`, `__tests__/`
+- Jest-Umgebung: `jsdom`; Skia wird gemockt via `__mocks__/@shopify/react-native-skia.js`
+- `npm test` (kein `--runInBand` nötig, aber stabil)
 
 ---
 
 ## Security
 
 - `npm audit --audit-level=high` in CI — Pipeline blockiert bei high/critical
-- Verbleibende 5 low-Findings: `@tootallnate/once` via jest-expo-Chain — fix erfordert breaking jest-expo Major-Upgrade, intentionally excluded
+- Verbleibende 5 low-Findings: `@tootallnate/once` via jest-expo-Chain — Fix würde ein Breaking-Major-Upgrade von jest-expo erfordern (aktuell `~55.0.9`), intentionally excluded
 - Alle high/critical Vulnerabilities zuletzt gefixt: 2026-04-21 via PR #144
 
 ---
 
 ## Offene Issues / Bekannte Einschränkungen
 
-- **jest-expo → @tootallnate/once** (low severity): Fix erfordert `jest-expo@47` — breaking change, noch nicht gemacht
-- **Nexus 6**: EOL — ab React Native 0.83.x / Skia 2.x ist `minSdkVersion` ≥ 26; Nexus 6 endet bei API 25 (geschlossen via Issue #172)
+- **jest-expo → @tootallnate/once** (low severity): Fix würde Breaking-Major-Upgrade von jest-expo erfordern (aktuell `~55.0.9`) — noch nicht gemacht
+- **Nexus 6**: EOL — `minSdkVersion` = 26; Nexus 6 endet bei API 25 (geschlossen via Issue #172)
 - **iOS**: Nicht primär getestet (Fokus auf Web + Android)
+- **iOS App Store**: Bundle ID `com.s540d.merkeundmale`, App Store URL noch TBD

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@
 **Merke und Male** — Gedächtnistraining-App für Kinder (React Native / Expo).
 Spieler sehen ein Bild kurz, zeichnen es aus dem Gedächtnis, vergleichen das Ergebnis.
 
-- **Aktuell: v1.3.4** — Play-Store-ready, keine offenen Blocker
-- **In staging (seit 2026-05-08):** PR #164 — i18n-Fix: hardcodierte App-Titel in HomeScreen & GameScreen durch `t('app.name')` ersetzt
+- **Aktuell: v1.4.2** — Play-Store-ready, keine offenen Blocker
+- **Mindestanforderung Android: API 26 (Android 8.0 Oreo)** — Nexus 6 (max. API 25) wird nicht mehr unterstützt (Issue #172)
 - **Live Demo:** https://s540d.github.io/DrawFromMemory/
 - **Repo:** https://github.com/S540d/DrawFromMemory
 
@@ -107,5 +107,5 @@ Das größte technische Thema der letzten Entwicklungsphase war die Flood-Fill a
 ## Offene Issues / Bekannte Einschränkungen
 
 - **jest-expo → @tootallnate/once** (low severity): Fix erfordert `jest-expo@47` — breaking change, noch nicht gemacht
-- **Nexus 6 Flood-Fill**: Implementierung fertig, aber kein Gerät für manuelle Tests vorhanden
+- **Nexus 6**: EOL — ab React Native 0.83.x / Skia 2.x ist `minSdkVersion` ≥ 26; Nexus 6 endet bei API 25 (geschlossen via Issue #172)
 - **iOS**: Nicht primär getestet (Fokus auf Web + Android)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 **Merke und Male** — Gedächtnistraining-App für Kinder (React Native / Expo).
 Spieler sehen ein Bild kurz, zeichnen es aus dem Gedächtnis, vergleichen das Ergebnis.
 
-- **Aktuell: v1.4.2** (package.json + app.json; versionCode 58)
+- **Aktuell: v1.5.1** (package.json + app.json; versionCode 59)
 - **Mindestanforderung Android: API 26 (Android 8.0 Oreo)** — Nexus 6 (max. API 25) wird nicht mehr unterstützt (Issue #172, geschlossen)
 - **Live Demo:** https://s540d.github.io/DrawFromMemory/
 - **Repo:** https://github.com/S540d/DrawFromMemory

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Merke und Male",
     "slug": "merke-und-male",
-    "version": "1.4.2",
+    "version": "1.5.1",
     "platforms": [
       "ios",
       "android",
@@ -43,7 +43,7 @@
       },
       "package": "com.s540d.merkeundmale",
       "permissions": [],
-      "versionCode": 58,
+      "versionCode": 59,
       "minSdkVersion": 26,
       "newArchEnabled": false,
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.s540d.merkeundmale",

--- a/app.json
+++ b/app.json
@@ -44,6 +44,7 @@
       "package": "com.s540d.merkeundmale",
       "permissions": [],
       "versionCode": 58,
+      "minSdkVersion": 26,
       "newArchEnabled": false,
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.s540d.merkeundmale",
       "privacyPolicy": "https://s540d.github.io/DrawFromMemory/PRIVACY_POLICY.html"

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -13,6 +13,8 @@ import {
 import Colors from '../constants/Colors';
 import { Spacing, FontSize, FontWeight, FontFamily, BorderRadius } from '../constants/Layout';
 import SettingsModal from '@components/SettingsModal';
+import { FloatingStars } from '@components/FloatingStars';
+import { AnimatedHero } from '@components/AnimatedHero';
 
 export default function HomeScreen() {
   const { t } = useTranslation();
@@ -46,6 +48,7 @@ export default function HomeScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top + Spacing.sm, paddingBottom: insets.bottom + Spacing.lg }]}>
+      <FloatingStars />
 
       {/* Top bar */}
       <View style={styles.topBar}>
@@ -64,7 +67,7 @@ export default function HomeScreen() {
 
       {/* Center hero */}
       <View style={styles.hero}>
-        <Text style={styles.heroEmoji}>🧠✏️</Text>
+        <AnimatedHero />
         <Text style={[styles.heroTitle, { color: colors.text.primary }]}>{t('home.title')}</Text>
       </View>
 
@@ -169,9 +172,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     gap: Spacing.lg,
-  },
-  heroEmoji: {
-    fontSize: 72,
   },
   heroTitle: {
     fontSize: FontSize.display,

--- a/app/levels.tsx
+++ b/app/levels.tsx
@@ -9,6 +9,7 @@ import Colors from '../constants/Colors';
 import { Spacing, FontSize, FontWeight, FontFamily, BorderRadius } from '../constants/Layout';
 import { GlassCard } from '@components/AnimatedPrimitives';
 import { Badge } from '@components/Badge';
+import { FloatingStars } from '@components/FloatingStars';
 
 // Default card width for SSR (will be recalculated on client)
 const DEFAULT_CARD_WIDTH = 150;
@@ -98,6 +99,7 @@ export default function LevelsScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <FloatingStars />
       {/* Header */}
       <View style={[styles.header, { borderBottomColor: colors.surface }]}>
         <TouchableOpacity onPress={() => router.back()}>

--- a/components/AnimatedHero.tsx
+++ b/components/AnimatedHero.tsx
@@ -18,7 +18,7 @@ export function AnimatedHero() {
   const brainScale       = useSharedValue(1);
   const pencilRotate     = useSharedValue(0);
   const pencilTranslateX = useSharedValue(0);
-  const sparkleOpacity   = useSharedValue(0);
+  const sparkleOpacity   = useSharedValue(0.2);
 
   useEffect(() => {
     let cancelled = false;
@@ -80,7 +80,12 @@ export function AnimatedHero() {
   }));
 
   return (
-    <View style={styles.container} testID="animated-hero">
+    <View
+      style={styles.container}
+      testID="animated-hero"
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+    >
       <View style={styles.row}>
         <Animated.View style={brainAnimStyle}>
           <Text style={styles.emoji}>🧠</Text>

--- a/components/AnimatedHero.tsx
+++ b/components/AnimatedHero.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect } from 'react';
+import { AccessibilityInfo, StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+
+/**
+ * Animated hero element for the Home Screen.
+ * Shows brain + pencil emojis with looping animations.
+ * Respects prefers-reduced-motion: static emoji fallback when enabled.
+ */
+export function AnimatedHero() {
+  const brainScale       = useSharedValue(1);
+  const pencilRotate     = useSharedValue(0);
+  const pencilTranslateX = useSharedValue(0);
+  const sparkleOpacity   = useSharedValue(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    AccessibilityInfo.isReduceMotionEnabled().then((rm) => {
+      if (cancelled || rm) return;
+
+      brainScale.value = withRepeat(
+        withSequence(
+          withTiming(1.08, { duration: 900, easing: Easing.inOut(Easing.ease) }),
+          withTiming(1.0,  { duration: 900, easing: Easing.inOut(Easing.ease) }),
+        ),
+        -1,
+        false
+      );
+
+      pencilRotate.value = withRepeat(
+        withSequence(
+          withTiming(-10, { duration: 600, easing: Easing.inOut(Easing.ease) }),
+          withTiming( 10, { duration: 600, easing: Easing.inOut(Easing.ease) }),
+        ),
+        -1,
+        false
+      );
+
+      pencilTranslateX.value = withRepeat(
+        withSequence(
+          withTiming(-6, { duration: 600, easing: Easing.inOut(Easing.ease) }),
+          withTiming( 6, { duration: 600, easing: Easing.inOut(Easing.ease) }),
+        ),
+        -1,
+        false
+      );
+
+      sparkleOpacity.value = withRepeat(
+        withSequence(
+          withTiming(1,   { duration: 1200, easing: Easing.inOut(Easing.ease) }),
+          withTiming(0.2, { duration: 1200, easing: Easing.inOut(Easing.ease) }),
+        ),
+        -1,
+        false
+      );
+    });
+    return () => { cancelled = true; };
+  }, [brainScale, pencilRotate, pencilTranslateX, sparkleOpacity]);
+
+  const brainAnimStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: brainScale.value }],
+  }));
+
+  const pencilAnimStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: pencilTranslateX.value },
+      { rotate: `${pencilRotate.value}deg` },
+    ],
+  }));
+
+  const sparkleAnimStyle = useAnimatedStyle(() => ({
+    opacity: sparkleOpacity.value,
+  }));
+
+  return (
+    <View style={styles.container} testID="animated-hero">
+      <View style={styles.row}>
+        <Animated.View style={brainAnimStyle}>
+          <Text style={styles.emoji}>🧠</Text>
+        </Animated.View>
+        <Animated.View style={pencilAnimStyle}>
+          <Text style={styles.emoji}>✏️</Text>
+        </Animated.View>
+      </View>
+      <Animated.View style={[styles.sparkleRow, sparkleAnimStyle]} pointerEvents="none">
+        <Text style={styles.sparkle}>✨</Text>
+        <Text style={styles.sparkle}>  </Text>
+        <Text style={styles.sparkle}>✨</Text>
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  emoji: {
+    fontSize: 68,
+  },
+  sparkleRow: {
+    flexDirection: 'row',
+    marginTop: 6,
+  },
+  sparkle: {
+    fontSize: 20,
+  },
+});
+
+export default AnimatedHero;

--- a/components/FloatingStars.tsx
+++ b/components/FloatingStars.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useState } from 'react';
+import { AccessibilityInfo, StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+import Colors from '../constants/Colors';
+
+interface DecorItem {
+  top: string;
+  left: string;
+  char: string;
+  size: number;
+  color: string;
+  opacity: number;
+  delay: number;
+  duration: number;
+  drift: number;
+}
+
+const DECOR_ITEMS: DecorItem[] = [
+  { top: '7%',  left: '4%',  char: '★', size: 18, color: Colors.primary,  opacity: 0.18, delay: 0,    duration: 4200, drift: 12 },
+  { top: '13%', left: '88%', char: '✦', size: 14, color: Colors.secondary, opacity: 0.15, delay: 700,  duration: 5100, drift: 8  },
+  { top: '32%', left: '3%',  char: '★', size: 12, color: Colors.primary,  opacity: 0.13, delay: 1400, duration: 4500, drift: 15 },
+  { top: '51%', left: '90%', char: '●', size: 10, color: Colors.secondary, opacity: 0.12, delay: 300,  duration: 5800, drift: 10 },
+  { top: '67%', left: '5%',  char: '✦', size: 16, color: Colors.primary,  opacity: 0.16, delay: 1100, duration: 4800, drift: 12 },
+  { top: '78%', left: '85%', char: '★', size: 14, color: Colors.secondary, opacity: 0.14, delay: 600,  duration: 5300, drift: 9  },
+  { top: '23%', left: '87%', char: '●', size: 9,  color: Colors.primary,  opacity: 0.11, delay: 1800, duration: 4000, drift: 14 },
+  { top: '61%', left: '77%', char: '★', size: 11, color: Colors.secondary, opacity: 0.13, delay: 900,  duration: 5600, drift: 11 },
+];
+
+function DecorElement({ item, animate }: { item: DecorItem; animate: boolean }) {
+  const translateY = useSharedValue(0);
+
+  useEffect(() => {
+    if (!animate) return;
+    translateY.value = withDelay(
+      item.delay,
+      withRepeat(
+        withSequence(
+          withTiming(-item.drift, { duration: item.duration / 2, easing: Easing.inOut(Easing.ease) }),
+          withTiming(0,           { duration: item.duration / 2, easing: Easing.inOut(Easing.ease) }),
+        ),
+        -1,
+        false
+      )
+    );
+  }, [animate, item, translateY]);
+
+  const animStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }],
+  }));
+
+  return (
+    <Animated.View
+      style={[
+        styles.item,
+        { top: item.top as any, left: item.left as any, opacity: item.opacity },
+        animStyle,
+      ]}
+      pointerEvents="none"
+      testID="floating-decor-item"
+    >
+      <Text style={{ fontSize: item.size, color: item.color }} accessibilityElementsHidden>
+        {item.char}
+      </Text>
+    </Animated.View>
+  );
+}
+
+export function FloatingStars() {
+  const [animate, setAnimate] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    AccessibilityInfo.isReduceMotionEnabled().then((rm) => {
+      if (!cancelled) setAnimate(!rm);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="none" testID="floating-stars">
+      {DECOR_ITEMS.map((item, i) => (
+        <DecorElement key={i} item={item} animate={animate} />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  item: {
+    position: 'absolute',
+  },
+});
+
+export default FloatingStars;

--- a/components/FloatingStars.tsx
+++ b/components/FloatingStars.tsx
@@ -60,13 +60,15 @@ function DecorElement({ item, animate }: { item: DecorItem; animate: boolean }) 
     <Animated.View
       style={[
         styles.item,
-        { top: item.top as any, left: item.left as any, opacity: item.opacity },
+        { top: item.top, left: item.left, opacity: item.opacity },
         animStyle,
       ]}
       pointerEvents="none"
       testID="floating-decor-item"
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
     >
-      <Text style={{ fontSize: item.size, color: item.color }} accessibilityElementsHidden>
+      <Text style={{ fontSize: item.size, color: item.color }} accessible={false}>
         {item.char}
       </Text>
     </Animated.View>

--- a/components/__tests__/AnimatedHero.test.tsx
+++ b/components/__tests__/AnimatedHero.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+
+jest.mock('react-native-reanimated', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: {
+      View,
+      createAnimatedComponent: (c: any) => c,
+    },
+    useSharedValue: (v: any) => ({ value: v }),
+    useAnimatedStyle: (_fn: any) => ({}),
+    withTiming: (v: any) => v,
+    withRepeat: (v: any) => v,
+    withSequence: (...args: any[]) => args[args.length - 1],
+    Easing: {
+      ease: (t: number) => t,
+      inOut: (fn: any) => fn,
+      out: (fn: any) => fn,
+    },
+  };
+});
+
+import { AnimatedHero } from '../AnimatedHero';
+import { Text } from 'react-native';
+
+const getAllTexts = (getAllByType: (t: any) => any[]) =>
+  getAllByType(Text).map((n: any) => n.props.children).flat().map(String);
+
+describe('AnimatedHero', () => {
+  it('renders without crashing', async () => {
+    expect(() => render(<AnimatedHero />)).not.toThrow();
+    await act(async () => {});
+  });
+
+  it('renders with testID', async () => {
+    const { getByTestId } = render(<AnimatedHero />);
+    await act(async () => {});
+    expect(getByTestId('animated-hero')).toBeTruthy();
+  });
+
+  it('renders brain and pencil emojis', async () => {
+    const { UNSAFE_getAllByType } = render(<AnimatedHero />);
+    await act(async () => {});
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain('🧠');
+    expect(texts).toContain('✏️');
+  });
+});

--- a/components/__tests__/AnimatedHero.test.tsx
+++ b/components/__tests__/AnimatedHero.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render, act } from '@testing-library/react-native';
 
+const withRepeatMock = jest.fn((v: any) => v);
+
 jest.mock('react-native-reanimated', () => {
   const { View } = require('react-native');
   return {
@@ -12,7 +14,7 @@ jest.mock('react-native-reanimated', () => {
     useSharedValue: (v: any) => ({ value: v }),
     useAnimatedStyle: (_fn: any) => ({}),
     withTiming: (v: any) => v,
-    withRepeat: (v: any) => v,
+    withRepeat: withRepeatMock,
     withSequence: (...args: any[]) => args[args.length - 1],
     Easing: {
       ease: (t: number) => t,
@@ -29,6 +31,10 @@ const getAllTexts = (getAllByType: (t: any) => any[]) =>
   getAllByType(Text).map((n: any) => n.props.children).flat().map(String);
 
 describe('AnimatedHero', () => {
+  beforeEach(() => {
+    withRepeatMock.mockClear();
+  });
+
   it('renders without crashing', async () => {
     expect(() => render(<AnimatedHero />)).not.toThrow();
     await act(async () => {});
@@ -46,5 +52,22 @@ describe('AnimatedHero', () => {
     const texts = getAllTexts(UNSAFE_getAllByType);
     expect(texts).toContain('🧠');
     expect(texts).toContain('✏️');
+  });
+
+  it('does not start animations when prefers-reduced-motion is enabled', async () => {
+    const { AccessibilityInfo } = require('react-native');
+    jest.spyOn(AccessibilityInfo, 'isReduceMotionEnabled').mockResolvedValueOnce(true);
+
+    render(<AnimatedHero />);
+    await act(async () => {});
+
+    expect(withRepeatMock).not.toHaveBeenCalled();
+  });
+
+  it('is hidden from screen readers', async () => {
+    const { getByTestId } = render(<AnimatedHero />);
+    await act(async () => {});
+    const hero = getByTestId('animated-hero');
+    expect(hero.props.importantForAccessibility).toBe('no-hide-descendants');
   });
 });

--- a/components/__tests__/FloatingStars.test.tsx
+++ b/components/__tests__/FloatingStars.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+
+jest.mock('react-native-reanimated', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: {
+      View,
+      createAnimatedComponent: (c: any) => c,
+    },
+    useSharedValue: (v: any) => ({ value: v }),
+    useAnimatedStyle: (_fn: any) => ({}),
+    withTiming: (v: any) => v,
+    withDelay: (_d: any, v: any) => v,
+    withRepeat: (v: any) => v,
+    withSequence: (...args: any[]) => args[args.length - 1],
+    Easing: {
+      ease: (t: number) => t,
+      inOut: (fn: any) => fn,
+      out: (fn: any) => fn,
+    },
+  };
+});
+
+import { FloatingStars } from '../FloatingStars';
+
+describe('FloatingStars', () => {
+  it('renders without crashing', async () => {
+    expect(() => render(<FloatingStars />)).not.toThrow();
+    await act(async () => {});
+  });
+
+  it('renders the container with testID', async () => {
+    const { getByTestId } = render(<FloatingStars />);
+    await act(async () => {});
+    expect(getByTestId('floating-stars')).toBeTruthy();
+  });
+
+  it('renders all decor items', async () => {
+    const { getAllByTestId } = render(<FloatingStars />);
+    await act(async () => {});
+    const items = getAllByTestId('floating-decor-item');
+    expect(items.length).toBe(8);
+  });
+
+  it('is not interactive (pointerEvents none)', async () => {
+    const { getByTestId } = render(<FloatingStars />);
+    await act(async () => {});
+    const container = getByTestId('floating-stars');
+    expect(container.props.pointerEvents).toBe('none');
+  });
+});

--- a/components/__tests__/FloatingStars.test.tsx
+++ b/components/__tests__/FloatingStars.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render, act } from '@testing-library/react-native';
 
+const withRepeatMock = jest.fn((v: any) => v);
+
 jest.mock('react-native-reanimated', () => {
   const { View } = require('react-native');
   return {
@@ -13,7 +15,7 @@ jest.mock('react-native-reanimated', () => {
     useAnimatedStyle: (_fn: any) => ({}),
     withTiming: (v: any) => v,
     withDelay: (_d: any, v: any) => v,
-    withRepeat: (v: any) => v,
+    withRepeat: withRepeatMock,
     withSequence: (...args: any[]) => args[args.length - 1],
     Easing: {
       ease: (t: number) => t,
@@ -26,6 +28,10 @@ jest.mock('react-native-reanimated', () => {
 import { FloatingStars } from '../FloatingStars';
 
 describe('FloatingStars', () => {
+  beforeEach(() => {
+    withRepeatMock.mockClear();
+  });
+
   it('renders without crashing', async () => {
     expect(() => render(<FloatingStars />)).not.toThrow();
     await act(async () => {});
@@ -49,5 +55,24 @@ describe('FloatingStars', () => {
     await act(async () => {});
     const container = getByTestId('floating-stars');
     expect(container.props.pointerEvents).toBe('none');
+  });
+
+  it('does not start animations when prefers-reduced-motion is enabled', async () => {
+    const { AccessibilityInfo } = require('react-native');
+    jest.spyOn(AccessibilityInfo, 'isReduceMotionEnabled').mockResolvedValueOnce(true);
+
+    render(<FloatingStars />);
+    await act(async () => {});
+
+    expect(withRepeatMock).not.toHaveBeenCalled();
+  });
+
+  it('hides decor items from screen readers', async () => {
+    const { getAllByTestId } = render(<FloatingStars />);
+    await act(async () => {});
+    const items = getAllByTestId('floating-decor-item');
+    items.forEach((item) => {
+      expect(item.props.importantForAccessibility).toBe('no-hide-descendants');
+    });
   });
 });

--- a/components/__tests__/HomeScreen.test.tsx
+++ b/components/__tests__/HomeScreen.test.tsx
@@ -34,6 +34,16 @@ jest.mock('../../components/SettingsModal', () => {
   return function SettingsModal() { return <View />; };
 });
 
+jest.mock('../../components/FloatingStars', () => {
+  const { View } = require('react-native');
+  return { FloatingStars: () => <View testID="floating-stars" /> };
+});
+
+jest.mock('../../components/AnimatedHero', () => {
+  const { View } = require('react-native');
+  return { AnimatedHero: () => <View testID="animated-hero" /> };
+});
+
 jest.mock('../../services/ThemeContext', () => ({
   useTheme: () => ({
     colors: {

--- a/components/__tests__/LevelsScreen.test.tsx
+++ b/components/__tests__/LevelsScreen.test.tsx
@@ -52,6 +52,11 @@ jest.mock('../../components/Badge', () => {
   return { Badge: () => <View /> };
 });
 
+jest.mock('../../components/FloatingStars', () => {
+  const { View } = require('react-native');
+  return { FloatingStars: () => <View testID="floating-stars" /> };
+});
+
 import LevelsScreen from '../../app/levels';
 
 const getStarNodes = (UNSAFE_getAllByProps: (props: any) => any[], testID: string) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merke-und-male",
-  "version": "1.4.2",
+  "version": "1.5.1",
   "main": "expo-router/entry",
   "homepage": "https://s540d.github.io/DrawFromMemory/",
   "repository": {


### PR DESCRIPTION
## Summary

Sprint A aus Issue #189: Sofortiger visueller Wow-Effekt auf Home- und Level-Screen.

- **#181 — FloatingStars**: Neue Komponente `components/FloatingStars.tsx` mit 8 absolut-positionierten Dekor-Elementen (★ ✦ ●) in Lila/Rosa-Tönen. Subtile Float-Animation via Reanimated `withRepeat` (4–6 s Loop, unterschiedliche Delays für organischen Effekt). `prefers-reduced-motion`-aware, `pointerEvents="none"`. Eingebunden in `app/index.tsx` + `app/levels.tsx`.
- **#182 — AnimatedHero**: Neue Komponente `components/AnimatedHero.tsx` ersetzt das statische `🧠✏️`-Emoji im HomeScreen. Gehirn pulsiert (Scale 1.0→1.08, 1.8 s), Stift schwingt seitlich (±6 px + ±10°, 1.2 s), Sparkle-Layer fadiert ein/aus. Bei `prefers-reduced-motion`: alle Werte bleiben auf Default → kein sichtbarer Animationseffekt (statisches Fallback).
- **Version**: 1.4.2 → 1.5.1, versionCode 58 → 59

## Definition of Done ✅

- [x] Beide Komponenten respektieren `prefers-reduced-motion`
- [x] `pointerEvents="none"` — keine Interaktion blockiert
- [x] Nur bereits installierte Pakete (Reanimated, kein Lottie) — Bundle-Zuwachs ~0 KB
- [x] Tests für `FloatingStars` + `AnimatedHero` hinzugefügt
- [x] Bestehende HomeScreen- + LevelsScreen-Tests angepasst (neue Komponenten gemockt)
- [x] Kein `console.log` in `app/` oder `components/`
- [x] Keine direkten Web-APIs ohne Guard
- [x] Versionskonsistenz `package.json` ↔ `app.json`

## Test plan

- [ ] `npm test` — alle Tests grün
- [ ] Web: Home-Screen öffnen → FloatingStars schweben im Hintergrund, Gehirn pulsiert, Stift schwingt
- [ ] Web: Level-Screen öffnen → FloatingStars im Hintergrund sichtbar
- [ ] Native: gleiche Prüfung wie Web
- [ ] Accessibility: `prefers-reduced-motion` aktivieren → Dekor-Elemente statisch, Hero-Emojis statisch

Closes #181
Closes #182
Part of #189 (Sprint A)

https://claude.ai/code/session_01PhjpiuoCtjbTnY722TNMRk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhjpiuoCtjbTnY722TNMRk)_