### PR TITLE
feat: Sprint B — Streak-Tracker & Quick-Stats-Cards (#183, #185)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,8 @@ npm run deploy:ghpages             # Deployment auf GitHub Pages
 **Branch-Strategie:** Feature-Branches → PR → `testing` (QA) → `staging` (Pre-Production) → `main` (Produktion).
 Die drei Branches `main`, `staging`, `testing` müssen immer existieren und dürfen nie gelöscht werden.
 
+> **⚠️ REGEL FÜR AI-ASSISTENTEN:** Merges auf `main` sind VERBOTEN ohne explizite schriftliche Freigabe durch den Nutzer in der aktuellen Konversation. Das gilt auch für `staging → main`. Immer nach `testing → staging` stoppen und auf Freigabe warten. `main` ist production — nur der Nutzer entscheidet, wann etwas dort landet.
+
 ---
 
 ## CI/CD (`.github/workflows/ci-cd.yml`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,26 +5,32 @@
 **Merke und Male** — Gedächtnistraining-App für Kinder (React Native / Expo).
 Spieler sehen ein Bild kurz, zeichnen es aus dem Gedächtnis, vergleichen das Ergebnis.
 
-- **Aktuell: v1.4.2** — Play-Store-ready, keine offenen Blocker
-- **Mindestanforderung Android: API 26 (Android 8.0 Oreo)** — Nexus 6 (max. API 25) wird nicht mehr unterstützt (Issue #172)
+- **Aktuell: v1.4.2** (package.json + app.json; versionCode 58)
+- **Mindestanforderung Android: API 26 (Android 8.0 Oreo)** — Nexus 6 (max. API 25) wird nicht mehr unterstützt (Issue #172, geschlossen)
 - **Live Demo:** https://s540d.github.io/DrawFromMemory/
 - **Repo:** https://github.com/S540d/DrawFromMemory
+- **Play Store:** `com.s540d.merkeundmale`
 
 ---
 
 ## Tech Stack
 
-| Bereich | Technologie |
+| Bereich | Technologie / Version |
 |---|---|
-| Framework | React Native + Expo (SDK 55) |
-| Navigation | Expo Router (file-based) |
-| Native Drawing | `@shopify/react-native-skia` |
+| Framework | React Native 0.83.2 + Expo SDK 55 |
+| React | 19.2.0 |
+| Navigation | Expo Router ~55.0.5 (file-based) |
+| Native Drawing | `@shopify/react-native-skia` 2.4.18 |
 | Web Drawing | Canvas API (`DrawingCanvas.web.tsx`) |
+| Animationen | `react-native-reanimated` ~4.2.2 |
 | State | React Hooks + AsyncStorage |
-| i18n | custom `services/i18n.ts` (de/en) |
-| Tests | Jest + jest-expo (241 Tests) |
-| CI | GitHub Actions (`ci-cd.yml`) |
-| Crash Reporting | Sentry (optional via `EXPO_PUBLIC_SENTRY_DSN`) |
+| Theming | ThemeContext (light / dark / system) |
+| Sound | Web Audio API (web) + `expo-haptics` (native) |
+| i18n | Custom `services/i18n.ts` (de/en), Locales in `locales/` |
+| Tests | Jest 29 + jest-expo ~55 (241 Tests, jsdom-Environment) |
+| CI | GitHub Actions (`.github/workflows/ci-cd.yml`) |
+| Build (Native) | EAS Build (`eas.json`) |
+| Crash Reporting | Sentry via `EXPO_PUBLIC_SENTRY_DSN` (optional, no-op on Web) |
 
 ---
 
@@ -32,80 +38,233 @@ Spieler sehen ein Bild kurz, zeichnen es aus dem Gedächtnis, vergleichen das Er
 
 ```
 app/
+  _layout.tsx           # Root-Layout, ThemeProvider, SafeAreaProvider, SentryService
+  index.tsx             # Home Screen (Startseite)
   game.tsx              # Haupt-Spielschirm (Merken → Zeichnen → Ergebnis)
   gallery.tsx           # Galerie gespeicherter Zeichnungen
-  levels.tsx            # Level-Auswahl
-  settings.tsx          # Einstellungen
+  levels.tsx            # Level-Auswahl (10 Level, Difficulty 1-5)
+  settings.tsx          # Einstellungen (via ParentalGate geschützt)
 
 components/
-  DrawingCanvas.tsx          # Web-Implementierung
+  DrawingCanvas.tsx          # Re-Export + öffentliches API (useDrawingCanvas)
+  DrawingCanvas.hooks.ts     # useDrawingCanvas Hook (color, strokeWidth, tool, paths, undo, clear)
+  DrawingCanvas.shared.ts    # Gemeinsame Typen (DrawingPath) und Styles
   DrawingCanvas.native.tsx   # Native Skia-Implementierung (Flood-Fill via Rect-Spans)
   DrawingCanvas.web.tsx      # Web Canvas-Implementierung
-  LevelImageDisplay.tsx      # SVG-Bild mit schrittweisem Aufdecken
+  LevelImageDisplay.tsx      # SVG-Bild mit schrittweisem Aufdecken (revealStep)
   ParentalGate.tsx           # Eltern-Sperre für Einstellungen
+  SettingsModal.tsx          # Einstellungen-Modal (In-Game)
+  ErrorBoundary.tsx          # Fehlerbehandlung für Render-Fehler
+  AnimatedPrimitives.tsx     # AnimatedFeedback, AnimatedNumber, etc.
+  AnimatedSplashScreen.tsx   # Animierter Splash Screen
+  Badge.tsx                  # UI-Primitiv: Badge
+  Chip.tsx                   # UI-Primitiv: Chip
+  Button.tsx                 # UI-Primitiv: Button
+  SkeletonLoader.tsx         # Skeleton Placeholder
 
 services/
   FloodFillService.ts        # Flood-Fill-Algorithmus (Scanline, 1-Bit-Palette)
   SoftwareRasterizer.ts      # CPU-Rasterizer für native Fill-Grenzenerkennung
   NativeFillLayerService.ts  # Konvertiert DrawingPath[] → native Skia Rect-Spans
-  LevelManager.ts            # Level-Definitionen und -Verwaltung
-  StorageManager.ts          # AsyncStorage-Wrapper
-  useGamePhase.ts            # Spielphasen-Hook (Merken/Zeichnen/Ergebnis)
-  useTimer.ts                # Timer-Hook mit Pause/Resume
+  ImagePoolManager.ts        # Bilderpool: wählt zufällige Bilder nach Schwierigkeit
+  LevelManager.ts            # Level-Definitionen (10 Level, Anzeigedauer, Difficulty)
+  StorageManager.ts          # AsyncStorage-Wrapper mit In-Memory-Fallback für Web
+  RatingManager.ts           # Stern-Bewertungen und rotierende Motivations-Nachrichten
+  SoundManager.ts            # Web Audio API (Web) + expo-haptics (Native)
+  SentryService.ts           # Sentry-Wrapper (init, captureException, etc.)
+  ThemeContext.tsx            # ThemeProvider + useTheme Hook (light/dark/system)
+  i18n.ts                    # Übersetzungs-Service (de/en) mit listener-basiertem Reload
+  useGamePhase.ts            # Spielphasen-Hook: memorize / draw / result + Replay
+  useTimer.ts                # Timer-Hook (Countdown, pause/resume via phase)
+
+constants/
+  Colors.ts                  # Design-Tokens: Primärfarben, Gradienten, Drawing-Farben
+  Layout.ts                  # Spacing, FontSize, FontWeight, BorderRadius
+  WebAccessibility.ts        # Web-spezifische Accessibility-Konstanten
+
+utils/
+  platform.ts                # isWeb/isIOS/isAndroid, safeWebAPI(), Storage-Adapter
+  useScreenLayout.ts         # Responsiver Layout-Hook (xs/sm/md/lg nach nutzbarer Höhe)
+
+types/
+  index.ts                   # Globale TypeScript-Typen (LevelImage, GamePhase, AppSettings, …)
+
+locales/
+  de/translations.json       # Deutsche Übersetzungen
+  en/translations.json       # Englische Übersetzungen
+
+assets/images/levels/        # Kanonische SVG-Bilder (level-01-sun.svg … extra-04-bird.svg)
+assets/images/levels-{1-5}/  # Level-sortierte Kopien der gleichen SVGs
 ```
+
+---
+
+## Path-Aliase (tsconfig.json)
+
+```jsonc
+"@/*"           → "./*"
+"@services/*"   → "./services/*"
+"@components/*" → "./components/*"
+"@utils/*"      → "./utils/*"
+```
+
+App- und Produktionscode verwendet diese Aliase (`@services/LevelManager`, nicht `../services/LevelManager`). Testdateien in `__tests__/` nutzen weiterhin relative Imports, da Jest die Babel-Aliase nicht auflöst.
 
 ---
 
 ## Entwicklungs-Workflow
 
 ```bash
-npm start          # Expo Dev Server
-npm test           # Jest (--runInBand für stabile Ergebnisse)
-npm run lint       # ESLint
-npm run build:web  # Web-Build (gh-pages)
-npx tsc --noEmit   # TypeScript-Check
+npm start                          # Expo Dev Server
+npm run android                    # Android-Emulator
+npm run ios                        # iOS-Simulator
+npm run web                        # Web-Dev-Server
+npm test                           # Jest (alle Tests)
+npm run test:watch                 # Jest Watch Mode
+npm run test:coverage              # Testabdeckung
+npm run lint                       # ESLint
+npm run validate:svg-counts        # Prüft SVG-Element-Counts in LevelImageDisplay.tsx
+npx tsc --noEmit                   # TypeScript-Check
+npm run build:web                  # Web-Build für gh-pages (expo export --platform web)
+npm run build:android              # EAS Build (Android, Production)
+npm run build:android:preview      # EAS Build (Android, Preview APK)
+npm run build:android:local        # Lokaler EAS-Build (preview)
+npm run build:android:local:production  # Lokaler EAS-Build (production)
+npm run prepare-release            # Vorbereitungs-Script für Release
+npm run validate                   # Vollständige Release-Validierung
+npm run deploy:ghpages             # Deployment auf GitHub Pages
 ```
 
-**Branch-Strategie:** Feature-Branches → PR → `testing` (QA) → `staging` (Pre-Production) → `main` (Produktion). Alle drei Branches (`main`, `staging`, `testing`) müssen immer existieren und dürfen nie gelöscht werden.
+**Branch-Strategie:** Feature-Branches → PR → `testing` (QA) → `staging` (Pre-Production) → `main` (Produktion).
+Die drei Branches `main`, `staging`, `testing` müssen immer existieren und dürfen nie gelöscht werden.
 
 ---
 
 ## CI/CD (`.github/workflows/ci-cd.yml`)
 
-Jobs:
-1. **Code Quality & Linting** — ESLint
-2. **Unit Tests & Coverage** — Jest
-3. **Build Web** — Expo Web Build
-4. **Security Audit** — `npm audit --audit-level=high` (blockiert bei high/critical)
-5. **Credential Scan** — Keystore & sensible Dateien
-6. **Docs Privacy Check** — prüft `docs/private/` auf versehentliche Commits
-7. **Platform Compatibility** — React Native Kompatibilitätsprüfung
+Läuft auf `push` und `pull_request` gegen `main` und `staging`.
+
+| Job | Name | Inhalt |
+|---|---|---|
+| 1 | Code Quality & Linting | ESLint, kein `console.log` in `app/`/`components/`, Web-API-Guards prüfen, AsyncStorage-Usage, `validate:svg-counts`, TypeScript-Check (`npx tsc --noEmit \|\| true`, non-blocking) |
+| 2 | Unit Tests & Coverage | `npm run test:ci` (Coverage-Artefakt wird hochgeladen) |
+| 3 | Build Web | `expo export --platform web` |
+| 4 | Platform Checks | Versionskonsistenz: `package.json` vs. `app.json` müssen identische Version haben |
+| 5 | Security Audit | `npm audit --audit-level=high` — blockiert bei high/critical |
+| 6 | Docs Privacy Check | `docs/private/` darf nicht committed sein |
+| 7 | Keystore & Credential Scan | Keine `.keystore`/`.jks` Dateien, keine hardcodierten Passwörter |
+| 8 | Release Readiness Report | Nur bei Push auf `main`; generiert manuelles Checklist-Summary |
+
+**Coverage-Schwellenwerte (jest.config.js):** branches 15 %, functions 25 %, lines 25 %, statements 25 %.
+
+---
+
+## Spielmechanik & Phasen
+
+```
+memorize  →  draw  →  result
+```
+
+1. **Memorize**: SVG-Bild wird 3 Sekunden angezeigt (progressiver Aufdeckeffekt via `revealStep`). Timer läuft via `useTimer`.
+2. **Draw**: Zeichnen auf `DrawingCanvas` (Pinsel + Flood-Fill). Tool wechselt nach Fill automatisch zu Brush zurück (Issue #45).
+3. **Result**: Sternbewertung (1–5), Replay-Animation, Speichern in Galerie möglich.
+
+Level-Anzahl: 10 (Difficulty 1–5). Alle Level haben 3 s Anzeigezeit.
+Bilderpool: `ImagePoolManager.ts` wählt zufällig nach Difficulty-Klasse aus.
+
+---
+
+## DrawingCanvas-Architektur
+
+| Datei | Zweck |
+|---|---|
+| `DrawingCanvas.tsx` | Re-Export, öffentliches API (`DrawingCanvas`, `useDrawingCanvas`) |
+| `DrawingCanvas.hooks.ts` | `useDrawingCanvas()` Hook: color, strokeWidth, tool, paths, undo, clearCanvas |
+| `DrawingCanvas.shared.ts` | `DrawingPath` Interface, Shared-Styles |
+| `DrawingCanvas.native.tsx` | Skia-Implementierung: `<Path>` für Strokes, `<Rect>`-Spans für Fills |
+| `DrawingCanvas.web.tsx` | HTML5-Canvas-Implementierung |
+
+**DrawingPath-Typ:**
+```typescript
+interface DrawingPath {
+  points: { x: number; y: number }[];
+  color: string;
+  strokeWidth: number;
+  type?: 'stroke' | 'fill'; // default = 'stroke'
+}
+```
 
 ---
 
 ## Flood-Fill Architektur (Native)
 
-Das größte technische Thema der letzten Entwicklungsphase war die Flood-Fill auf alten Android-Geräten (Nexus 6 / Adreno 420). Die GPU-Pipeline (`readPixels` / `MakeImage`) ist dort unzuverlässig.
+CPU-Flood-Fill auf alten Android-Geräten (Nexus 6 / Adreno 420) — die GPU-Pipeline (`readPixels` / `MakeImage`) ist dort unzuverlässig.
 
-**Aktueller Ansatz (v1.3.4):**
-- CPU-Flood-Fill via `floodFillPixels()` (Scanline-Algorithmus, 1-Bit-Palette)
-- Ergebnis wird als horizontale Rect-Spans (`FloodFillSpan[]`) ausgegeben
-- Native rendering via Skia `<Rect>` Elemente (kein Image-Roundtrip)
+- CPU-Flood-Fill via `floodFillPixels()` (Scanline-Algorithmus, 1-Bit-Palette → ~20× weniger RAM als RGBA)
+- Ergebnis: horizontale `FloodFillSpan[]` (Run-Length-Encoding)
+- Native Rendering via Skia `<Rect>` Elemente — kein Image-Roundtrip
 - Strokes werden IMMER als `<Path>` Komponenten gerendert — kein Mode-Switching
 - `NativeFillLayerService` konvertiert `DrawingPath[]` → renderfähige Layers
+- `SoftwareRasterizer` rastert bisherige Strokes für die Grenzenerkennung des Fill-Algorithmus
+
+---
+
+## Theming
+
+`ThemeContext.tsx` stellt `useTheme()` bereit:
+- `theme`: aktuell aktives Schema (`'light' | 'dark'`)
+- `themeSetting`: gespeicherte Präferenz (`'light' | 'dark' | 'system'`)
+- `colors`: typisiertes `ThemeColors`-Objekt (primary, background, text, drawing, difficulty, stars, …)
+- `setTheme(theme)`: persistiert in `StorageManager`
+
+Beim SSR/Hydration startet die App immer mit `'light'` (verhindert Hydration-Mismatch).
+
+---
+
+## Speicherung (StorageManager)
+
+AsyncStorage-Wrapper mit In-Memory-Fallback für Web (GitHub Pages).
+Storage-Keys beginnen mit `@merke_male:`.
+
+Gespeicherte Felder: `progress`, `theme`, `language`, `sound_enabled`, `music_enabled`, `extra_time_mode`, `gallery`.
+
+---
+
+## Konventionen für AI-Assistenten
+
+### Verboten (wird von CI geprüft)
+- `console.log` / `console.debug` in `app/` oder `components/`
+- `window.*` ohne `Platform.OS === 'web'`-Guard oder `// platform-safe`-Kommentar
+- `localStorage.*` ohne Platform-Check (AsyncStorage verwenden)
+- `.keystore` / `.jks` Dateien committen
+
+### Pflicht bei neuen SVG-Bildern
+`IMAGE_ELEMENT_COUNTS` in `LevelImageDisplay.tsx` muss um den neuen Dateinamen ergänzt werden, sonst schlägt `npm run validate:svg-counts` fehl.
+
+### Imports
+Path-Aliase nutzen: `@services/...`, `@components/...`, `@utils/...`.
+
+### Plattform-spezifischer Code
+Web-APIs über `utils/platform.ts` absichern (`safeWebAPI`, `isWeb`-Guard). Für Storage stets `StorageManager` nutzen — nicht direkt `AsyncStorage` oder `localStorage`.
+
+### Tests
+- Test-Dateien liegen bei `services/__tests__/`, `components/__tests__/`, `utils/__tests__/`, `__tests__/`
+- Jest-Umgebung: `jsdom`; Skia wird gemockt via `__mocks__/@shopify/react-native-skia.js`
+- `npm test` (kein `--runInBand` nötig, aber stabil)
 
 ---
 
 ## Security
 
 - `npm audit --audit-level=high` in CI — Pipeline blockiert bei high/critical
-- Verbleibende 5 low-Findings: `@tootallnate/once` via jest-expo-Chain — fix erfordert breaking jest-expo Major-Upgrade, intentionally excluded
+- Verbleibende 5 low-Findings: `@tootallnate/once` via jest-expo-Chain — Fix würde ein Breaking-Major-Upgrade von jest-expo erfordern (aktuell `~55.0.9`), intentionally excluded
 - Alle high/critical Vulnerabilities zuletzt gefixt: 2026-04-21 via PR #144
 
 ---
 
 ## Offene Issues / Bekannte Einschränkungen
 
-- **jest-expo → @tootallnate/once** (low severity): Fix erfordert `jest-expo@47` — breaking change, noch nicht gemacht
-- **Nexus 6**: EOL — ab React Native 0.83.x / Skia 2.x ist `minSdkVersion` ≥ 26; Nexus 6 endet bei API 25 (geschlossen via Issue #172)
+- **jest-expo → @tootallnate/once** (low severity): Fix würde Breaking-Major-Upgrade von jest-expo erfordern (aktuell `~55.0.9`) — noch nicht gemacht
+- **Nexus 6**: EOL — `minSdkVersion` = 26; Nexus 6 endet bei API 25 (geschlossen via Issue #172)
 - **iOS**: Nicht primär getestet (Fokus auf Web + Android)
+- **iOS App Store**: Bundle ID `com.s540d.merkeundmale`, App Store URL noch TBD

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@
 **Merke und Male** — Gedächtnistraining-App für Kinder (React Native / Expo).
 Spieler sehen ein Bild kurz, zeichnen es aus dem Gedächtnis, vergleichen das Ergebnis.
 
-- **Aktuell: v1.3.4** — Play-Store-ready, keine offenen Blocker
-- **In staging (seit 2026-05-08):** PR #164 — i18n-Fix: hardcodierte App-Titel in HomeScreen & GameScreen durch `t('app.name')` ersetzt
+- **Aktuell: v1.4.2** — Play-Store-ready, keine offenen Blocker
+- **Mindestanforderung Android: API 26 (Android 8.0 Oreo)** — Nexus 6 (max. API 25) wird nicht mehr unterstützt (Issue #172)
 - **Live Demo:** https://s540d.github.io/DrawFromMemory/
 - **Repo:** https://github.com/S540d/DrawFromMemory
 
@@ -107,5 +107,5 @@ Das größte technische Thema der letzten Entwicklungsphase war die Flood-Fill a
 ## Offene Issues / Bekannte Einschränkungen
 
 - **jest-expo → @tootallnate/once** (low severity): Fix erfordert `jest-expo@47` — breaking change, noch nicht gemacht
-- **Nexus 6 Flood-Fill**: Implementierung fertig, aber kein Gerät für manuelle Tests vorhanden
+- **Nexus 6**: EOL — ab React Native 0.83.x / Skia 2.x ist `minSdkVersion` ≥ 26; Nexus 6 endet bei API 25 (geschlossen via Issue #172)
 - **iOS**: Nicht primär getestet (Fokus auf Web + Android)

--- a/app.json
+++ b/app.json
@@ -44,6 +44,7 @@
       "package": "com.s540d.merkeundmale",
       "permissions": [],
       "versionCode": 58,
+      "minSdkVersion": 26,
       "newArchEnabled": false,
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.s540d.merkeundmale",
       "privacyPolicy": "https://s540d.github.io/DrawFromMemory/PRIVACY_POLICY.html"

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Merke und Male",
     "slug": "merke-und-male",
-    "version": "1.4.2",
+    "version": "1.6.0",
     "platforms": [
       "ios",
       "android",

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -10,9 +10,11 @@ import {
   getSecondsUntilMidnight,
   isTodayCompleted,
 } from '@services/DailyChallengeManager';
+import { getStreakData } from '@services/StreakManager';
 import Colors from '../constants/Colors';
 import { Spacing, FontSize, FontWeight, FontFamily, BorderRadius } from '../constants/Layout';
 import SettingsModal from '@components/SettingsModal';
+import QuickStatsCards from '@components/QuickStatsCards';
 
 export default function HomeScreen() {
   const { t } = useTranslation();
@@ -23,6 +25,7 @@ export default function HomeScreen() {
   const [dailyCompleted, setDailyCompleted] = useState(false);
   const [secondsLeft, setSecondsLeft] = useState(() => getSecondsUntilMidnight());
   const [dailyLevel, setDailyLevel] = useState(() => getDailyChallengeLevel());
+  const [currentStreak, setCurrentStreak] = useState(0);
 
   // On focus: refresh all daily state and start countdown interval.
   // Interval also re-checks state every minute to handle midnight rollover
@@ -32,7 +35,12 @@ export default function HomeScreen() {
       const refresh = async () => {
         setSecondsLeft(getSecondsUntilMidnight());
         setDailyLevel(getDailyChallengeLevel());
-        setDailyCompleted(await isTodayCompleted());
+        const [completed, streakData] = await Promise.all([
+          isTodayCompleted(),
+          getStreakData(),
+        ]);
+        setDailyCompleted(completed);
+        setCurrentStreak(streakData.currentStreak);
       };
       refresh();
 
@@ -53,13 +61,20 @@ export default function HomeScreen() {
           <Text style={[styles.appTitle, { color: colors.text.primary }]}>{t('app.name')}</Text>
           <Text style={[styles.appTagline, { color: colors.text.secondary }]}>{t('home.subtitle')}</Text>
         </View>
-        <Pressable
-          onPress={() => setShowSettings(true)}
-          style={styles.settingsButton}
-          aria-label="Settings"
-        >
-          <Text style={[styles.settingsIcon, { color: colors.text.primary }]}>⋮</Text>
-        </Pressable>
+        <View style={styles.topBarRight}>
+          {currentStreak >= 2 && (
+            <View style={styles.streakBadge}>
+              <Text style={styles.streakBadgeText}>{t('home.streakBadge', { count: String(currentStreak) })}</Text>
+            </View>
+          )}
+          <Pressable
+            onPress={() => setShowSettings(true)}
+            style={styles.settingsButton}
+            aria-label="Settings"
+          >
+            <Text style={[styles.settingsIcon, { color: colors.text.primary }]}>⋮</Text>
+          </Pressable>
+        </View>
       </View>
 
       {/* Center hero */}
@@ -67,6 +82,9 @@ export default function HomeScreen() {
         <Text style={styles.heroEmoji}>🧠✏️</Text>
         <Text style={[styles.heroTitle, { color: colors.text.primary }]}>{t('home.title')}</Text>
       </View>
+
+      {/* Quick Stats */}
+      <QuickStatsCards />
 
       {/* Buttons */}
       <View style={styles.buttonContainer}>
@@ -142,6 +160,23 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'flex-start',
+  },
+  topBarRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xs,
+  },
+  streakBadge: {
+    backgroundColor: '#FF6B35',
+    borderRadius: BorderRadius.round,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 3,
+  },
+  streakBadgeText: {
+    color: '#fff',
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.bold,
+    fontFamily: FontFamily.bold,
   },
   appTitle: {
     fontSize: FontSize.xl,

--- a/components/QuickStatsCards.tsx
+++ b/components/QuickStatsCards.tsx
@@ -1,0 +1,160 @@
+import React, { useState, useCallback } from 'react';
+import { View, Text, StyleSheet, useWindowDimensions } from 'react-native';
+import { useRouter, useFocusEffect } from 'expo-router';
+import { GlassCard } from '@components/AnimatedPrimitives';
+import { useTheme } from '@services/ThemeContext';
+import { useTranslation } from '@services/i18n';
+import storageManager from '@services/StorageManager';
+import { getStreakData } from '@services/StreakManager';
+import { getTotalLevels } from '@services/LevelManager';
+import Colors from '../constants/Colors';
+import { Spacing, FontSize, FontWeight, FontFamily, BorderRadius } from '../constants/Layout';
+
+interface Stats {
+  totalStars: number;
+  currentStreak: number;
+  levelsCompleted: number;
+}
+
+export default function QuickStatsCards() {
+  const { t } = useTranslation();
+  const { theme, colors } = useTheme();
+  const router = useRouter();
+  const { width } = useWindowDimensions();
+  const [stats, setStats] = useState<Stats>({ totalStars: 0, currentStreak: 0, levelsCompleted: 0 });
+
+  const glassSurface = theme === 'dark' ? Colors.glass.darkSurface : Colors.glass.lightSurface;
+  const glassBorder  = theme === 'dark' ? Colors.glass.darkBorder  : Colors.glass.lightBorder;
+  const glassShadow  = theme === 'dark' ? Colors.glass.darkShadow  : Colors.glass.lightShadow;
+
+  useFocusEffect(
+    useCallback(() => {
+      let mounted = true;
+      const load = async () => {
+        const [progress, streakData] = await Promise.all([
+          storageManager.getProgress(),
+          getStreakData(),
+        ]);
+        if (!mounted) return;
+        const totalStars = Object.values(progress.levels).reduce(
+          (sum, l) => sum + l.bestRating,
+          0
+        );
+        setStats({
+          totalStars,
+          currentStreak: streakData.currentStreak,
+          levelsCompleted: progress.totalLevelsCompleted,
+        });
+      };
+      load();
+      return () => { mounted = false; };
+    }, [])
+  );
+
+  // Below 340px: wrap into 2 rows; otherwise all 3 in one row
+  const narrow = width < 340;
+  const totalLevels = getTotalLevels();
+
+  const cardStyle = [
+    styles.card,
+    { backgroundColor: glassSurface, borderColor: glassBorder, borderWidth: 1.5 },
+    glassShadow,
+    narrow ? styles.cardNarrow : styles.cardWide,
+  ];
+
+  const cards = [
+    {
+      emoji: '⭐',
+      label: t('home.stats.stars'),
+      value: String(stats.totalStars),
+      sub: null,
+      onPress: () => router.push('/gallery'),
+      index: 0,
+    },
+    {
+      emoji: '🔥',
+      label: t('home.stats.streak'),
+      value: String(stats.currentStreak),
+      sub: stats.currentStreak > 0 ? t('home.stats.streakDays') : null,
+      onPress: () => router.push('/levels'),
+      index: 1,
+    },
+    {
+      emoji: '🏆',
+      label: t('home.stats.levels'),
+      value: String(stats.levelsCompleted),
+      sub: t('home.stats.levelOf', { total: String(totalLevels) }),
+      onPress: () => router.push('/levels'),
+      index: 2,
+    },
+  ];
+
+  return (
+    <View style={[styles.row, narrow && styles.rowWrap]}>
+      {cards.map((card) => (
+        <GlassCard
+          key={card.label}
+          index={card.index}
+          onPress={card.onPress}
+          style={cardStyle}
+          accessibilityLabel={`${card.label}: ${card.value}${card.sub ? ' ' + card.sub : ''}`}
+        >
+          <Text style={styles.emoji}>{card.emoji}</Text>
+          <Text style={[styles.value, { color: colors.text.primary }]}>{card.value}</Text>
+          <Text style={[styles.label, { color: colors.text.secondary }]}>{card.label}</Text>
+          {card.sub !== null && (
+            <Text style={[styles.sub, { color: colors.text.secondary }]}>{card.sub}</Text>
+          )}
+        </GlassCard>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    justifyContent: 'space-between',
+  },
+  rowWrap: {
+    flexWrap: 'wrap',
+  },
+  card: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.xs,
+    borderRadius: BorderRadius.xl,
+    minWidth: 80,
+    gap: 2,
+  },
+  cardWide: {
+    minWidth: 0,
+  },
+  cardNarrow: {
+    minWidth: '45%',
+    flexGrow: 1,
+  },
+  emoji: {
+    fontSize: 22,
+  },
+  value: {
+    fontSize: FontSize.lg,
+    fontWeight: FontWeight.bold,
+    fontFamily: FontFamily.bold,
+    lineHeight: 26,
+  },
+  label: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.semibold,
+    fontFamily: FontFamily.semibold,
+    textAlign: 'center',
+  },
+  sub: {
+    fontSize: 10,
+    textAlign: 'center',
+    marginTop: 1,
+  },
+});

--- a/components/__tests__/HomeScreen.test.tsx
+++ b/components/__tests__/HomeScreen.test.tsx
@@ -18,6 +18,15 @@ jest.mock('../../services/DailyChallengeManager', () => ({
   isTodayCompleted: () => Promise.resolve(false),
 }));
 
+jest.mock('../../services/StreakManager', () => ({
+  getStreakData: () => Promise.resolve({ currentStreak: 0, longestStreak: 0, lastPlayedDate: null }),
+}));
+
+jest.mock('../../components/QuickStatsCards', () => {
+  const { View } = require('react-native');
+  return function QuickStatsCards() { return <View />; };
+});
+
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));

--- a/components/__tests__/QuickStatsCards.test.tsx
+++ b/components/__tests__/QuickStatsCards.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+import { Text } from 'react-native';
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  useFocusEffect: (cb: () => (() => void) | void) => {
+    const { useEffect } = require('react');
+    useEffect(() => {
+      const cleanup = cb();
+      return typeof cleanup === 'function' ? cleanup : undefined;
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  },
+}));
+
+jest.mock('../../services/StorageManager', () => ({
+  __esModule: true,
+  default: {
+    getProgress: () =>
+      Promise.resolve({
+        levels: {
+          1: { levelNumber: 1, rating: 4, completedAt: '', bestRating: 4 },
+          2: { levelNumber: 2, rating: 3, completedAt: '', bestRating: 3 },
+        },
+        lastPlayedLevel: 2,
+        totalLevelsCompleted: 2,
+        averageRating: 3.5,
+      }),
+  },
+}));
+
+jest.mock('../../services/StreakManager', () => ({
+  getStreakData: () =>
+    Promise.resolve({ currentStreak: 5, longestStreak: 7, lastPlayedDate: '2026-05-23' }),
+}));
+
+jest.mock('../../services/LevelManager', () => ({
+  getTotalLevels: () => 10,
+}));
+
+jest.mock('../../services/ThemeContext', () => ({
+  useTheme: () => ({
+    theme: 'light',
+    colors: {
+      text: { primary: '#000', secondary: '#666' },
+    },
+  }),
+}));
+
+jest.mock('../../services/i18n', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      if (params) {
+        return Object.entries(params).reduce(
+          (s, [k, v]) => s.replace(`{{${k}}}`, v),
+          key
+        );
+      }
+      return key;
+    },
+  }),
+}));
+
+jest.mock('react-native-reanimated', () => {
+  const { View, Text: RNText } = require('react-native');
+  return {
+    __esModule: true,
+    default: {
+      View,
+      Text: RNText,
+      createAnimatedComponent: (c: any) => c,
+      call: () => {},
+    },
+    useSharedValue: (v: any) => ({ value: v }),
+    useAnimatedStyle: (_fn: any) => ({}),
+    withSpring: (v: any) => v,
+    withTiming: (v: any) => v,
+    withDelay: (_d: any, v: any) => v,
+    withSequence: (...args: any[]) => args[args.length - 1],
+    Easing: { out: () => () => {}, ease: {} },
+    runOnJS: (fn: any) => fn,
+  };
+});
+
+const getAllTexts = (getAllByType: (type: any) => any[]) =>
+  getAllByType(Text).map((n: any) => n.props.children).flat();
+
+import QuickStatsCards from '../QuickStatsCards';
+
+describe('QuickStatsCards', () => {
+  it('renders stat labels for stars, streak, and levels', async () => {
+    const { UNSAFE_getAllByType } = render(<QuickStatsCards />);
+    await act(async () => {});
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain('home.stats.stars');
+    expect(texts).toContain('home.stats.streak');
+    expect(texts).toContain('home.stats.levels');
+  });
+
+  it('displays correct values after data load', async () => {
+    const { UNSAFE_getAllByType } = render(<QuickStatsCards />);
+    await act(async () => {});
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    // Total stars: 4 + 3 = 7
+    expect(texts).toContain('7');
+    // Current streak = 5
+    expect(texts).toContain('5');
+    // Levels completed = 2
+    expect(texts).toContain('2');
+  });
+
+  it('shows streak days label when streak > 0', async () => {
+    const { UNSAFE_getAllByType } = render(<QuickStatsCards />);
+    await act(async () => {});
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain('home.stats.streakDays');
+  });
+
+  it('shows level-of sub label for the levels card', async () => {
+    const { UNSAFE_getAllByType } = render(<QuickStatsCards />);
+    await act(async () => {});
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    // t('home.stats.levelOf', { total: '10' }) → key unchanged since key has no {{total}} placeholder
+    expect(texts).toContain('home.stats.levelOf');
+  });
+});

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -9,7 +9,15 @@
     "continueButton": "Weiterspielen",
     "levelsButton": "Level auswählen",
     "galleryButton": "Meine Galerie",
-    "settingsButton": "Einstellungen"
+    "settingsButton": "Einstellungen",
+    "streakBadge": "🔥 {{count}}",
+    "stats": {
+      "stars": "Sterne",
+      "streak": "Streak",
+      "levels": "Level",
+      "streakDays": "Tage",
+      "levelOf": "von {{total}}"
+    }
   },
   "levels": {
     "title": "Level auswählen",

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -9,7 +9,15 @@
     "continueButton": "Continue",
     "levelsButton": "Select Level",
     "galleryButton": "My Gallery",
-    "settingsButton": "Settings"
+    "settingsButton": "Settings",
+    "streakBadge": "🔥 {{count}}",
+    "stats": {
+      "stars": "Stars",
+      "streak": "Streak",
+      "levels": "Levels",
+      "streakDays": "days",
+      "levelOf": "of {{total}}"
+    }
   },
   "levels": {
     "title": "Select Level",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "merke-und-male",
-  "version": "1.4.2",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "merke-und-male",
-      "version": "1.4.2",
+      "version": "1.6.0",
       "dependencies": {
         "@expo-google-fonts/nunito": "^0.4.2",
         "@expo/metro-runtime": "~55.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merke-und-male",
-  "version": "1.4.2",
+  "version": "1.6.0",
   "main": "expo-router/entry",
   "homepage": "https://s540d.github.io/DrawFromMemory/",
   "repository": {

--- a/services/StreakManager.ts
+++ b/services/StreakManager.ts
@@ -1,0 +1,110 @@
+/**
+ * StreakManager - Täglicher Streak-Tracker
+ * Zählt aufeinanderfolgende Tage mit ≥1 Spielrunde.
+ * DST-sicher via lokale YYYY-MM-DD-Strings (kein UTC).
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = '@merke_male:streak';
+
+export interface StreakData {
+  currentStreak: number;
+  longestStreak: number;
+  lastPlayedDate: string | null; // YYYY-MM-DD (local)
+}
+
+const MEMORY: Record<string, string> = {};
+
+async function loadState(): Promise<StreakData> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      MEMORY[STORAGE_KEY] = raw;
+      return JSON.parse(raw);
+    }
+  } catch {
+    const raw = MEMORY[STORAGE_KEY];
+    if (raw) return JSON.parse(raw);
+  }
+  return { currentStreak: 0, longestStreak: 0, lastPlayedDate: null };
+}
+
+async function saveState(state: StreakData): Promise<void> {
+  const raw = JSON.stringify(state);
+  MEMORY[STORAGE_KEY] = raw;
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, raw);
+  } catch {
+    // in-memory fallback is sufficient for web sessions
+  }
+}
+
+/**
+ * Gibt das Datum als lokalen YYYY-MM-DD-String zurück (DST-sicher).
+ */
+export function getLocalDateKey(date: Date = new Date()): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * Lädt die aktuellen Streak-Daten.
+ */
+export async function getStreakData(): Promise<StreakData> {
+  return loadState();
+}
+
+/**
+ * Wird nach jeder abgeschlossenen Spielrunde aufgerufen.
+ * Aktualisiert currentStreak, longestStreak und lastPlayedDate.
+ */
+export async function updateStreakAfterGame(date: Date = new Date()): Promise<void> {
+  try {
+    const state = await loadState();
+    const today = getLocalDateKey(date);
+
+    if (state.lastPlayedDate === today) {
+      // Bereits heute gespielt — kein Update nötig
+      return;
+    }
+
+    let newStreak: number;
+
+    if (state.lastPlayedDate !== null) {
+      const yesterday = getLocalDateKey(new Date(date.getFullYear(), date.getMonth(), date.getDate() - 1));
+      if (state.lastPlayedDate === yesterday) {
+        // Gestern gespielt → Streak verlängern
+        newStreak = state.currentStreak + 1;
+      } else {
+        // Mehr als 1 Tag Pause → Streak zurücksetzen
+        newStreak = 1;
+      }
+    } else {
+      // Erster Spieltag überhaupt
+      newStreak = 1;
+    }
+
+    await saveState({
+      currentStreak: newStreak,
+      longestStreak: Math.max(state.longestStreak, newStreak),
+      lastPlayedDate: today,
+    });
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Setzt alle Streak-Daten zurück (nur für Tests / Reset-Funktion).
+ */
+export async function resetStreakData(): Promise<void> {
+  delete MEMORY[STORAGE_KEY];
+  try {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // best-effort
+  }
+}

--- a/services/__tests__/StreakManager.test.ts
+++ b/services/__tests__/StreakManager.test.ts
@@ -1,0 +1,132 @@
+/**
+ * StreakManager Tests
+ * Prüft Streak-Logik: Tag-Übergang, DST-Wechsel, Streak-Bruch nach Pause
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  getLocalDateKey,
+  getStreakData,
+  updateStreakAfterGame,
+  resetStreakData,
+} from '../StreakManager';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+describe('StreakManager', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    await resetStreakData();
+  });
+
+  describe('getLocalDateKey', () => {
+    it('formats date as YYYY-MM-DD in local time', () => {
+      const date = new Date(2026, 4, 23); // May 23, 2026
+      expect(getLocalDateKey(date)).toBe('2026-05-23');
+    });
+
+    it('pads month and day with leading zeros', () => {
+      const date = new Date(2026, 0, 5); // January 5, 2026
+      expect(getLocalDateKey(date)).toBe('2026-01-05');
+    });
+  });
+
+  describe('initial state', () => {
+    it('starts with zero streak and no lastPlayedDate', async () => {
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(0);
+      expect(data.longestStreak).toBe(0);
+      expect(data.lastPlayedDate).toBeNull();
+    });
+  });
+
+  describe('updateStreakAfterGame', () => {
+    it('sets streak to 1 on first game', async () => {
+      await updateStreakAfterGame(new Date(2026, 4, 1));
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(1);
+      expect(data.longestStreak).toBe(1);
+      expect(data.lastPlayedDate).toBe('2026-05-01');
+    });
+
+    it('does not increment streak when playing twice the same day', async () => {
+      await updateStreakAfterGame(new Date(2026, 4, 1));
+      await updateStreakAfterGame(new Date(2026, 4, 1));
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(1);
+    });
+
+    it('increments streak on consecutive day', async () => {
+      await updateStreakAfterGame(new Date(2026, 4, 1));
+      await updateStreakAfterGame(new Date(2026, 4, 2));
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(2);
+      expect(data.longestStreak).toBe(2);
+    });
+
+    it('builds streak across multiple consecutive days', async () => {
+      for (let day = 10; day <= 14; day++) {
+        await updateStreakAfterGame(new Date(2026, 4, day));
+      }
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(5);
+      expect(data.longestStreak).toBe(5);
+    });
+
+    it('resets streak to 1 after a 1-day gap', async () => {
+      await updateStreakAfterGame(new Date(2026, 4, 1));
+      await updateStreakAfterGame(new Date(2026, 4, 3)); // skip day 2
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(1);
+    });
+
+    it('resets streak to 1 after 2 days pause', async () => {
+      await updateStreakAfterGame(new Date(2026, 4, 1));
+      await updateStreakAfterGame(new Date(2026, 4, 2));
+      await updateStreakAfterGame(new Date(2026, 4, 3));
+      // 2-day pause
+      await updateStreakAfterGame(new Date(2026, 4, 6));
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(1);
+    });
+
+    it('preserves longestStreak after reset', async () => {
+      // Build streak of 3
+      await updateStreakAfterGame(new Date(2026, 4, 1));
+      await updateStreakAfterGame(new Date(2026, 4, 2));
+      await updateStreakAfterGame(new Date(2026, 4, 3));
+      // Break streak
+      await updateStreakAfterGame(new Date(2026, 4, 5));
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(1);
+      expect(data.longestStreak).toBe(3);
+    });
+
+    it('handles month boundary correctly', async () => {
+      await updateStreakAfterGame(new Date(2026, 3, 30)); // Apr 30
+      await updateStreakAfterGame(new Date(2026, 4, 1));  // May 1
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(2);
+    });
+
+    it('handles year boundary correctly', async () => {
+      await updateStreakAfterGame(new Date(2025, 11, 31)); // Dec 31
+      await updateStreakAfterGame(new Date(2026, 0, 1));   // Jan 1
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(2);
+    });
+
+    it('DST spring-forward: treats local days correctly (Apr 1 → Apr 2)', async () => {
+      // Simulate playing on consecutive local days near DST change
+      // Local date strings are used, so DST does not affect the result
+      const day1 = new Date(2026, 2, 29); // March 29 (near DST in Europe)
+      const day2 = new Date(2026, 2, 30); // March 30
+      await updateStreakAfterGame(day1);
+      await updateStreakAfterGame(day2);
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(2);
+    });
+  });
+});

--- a/services/useGamePhase.ts
+++ b/services/useGamePhase.ts
@@ -5,6 +5,7 @@ import { getDisplayDuration, getTotalLevels } from '@services/LevelManager';
 import { getImageElementCount } from '@components/LevelImageDisplay';
 import storageManager from '@services/StorageManager';
 import { markTodayCompleted } from '@services/DailyChallengeManager';
+import { updateStreakAfterGame } from '@services/StreakManager';
 import SoundManager from '@services/SoundManager';
 import { useTimer } from '@services/useTimer';
 import type { DrawingPath } from '@components/DrawingCanvas';
@@ -169,6 +170,7 @@ export function useGamePhase({
       SoundManager.playStarTap(rating);
       setUserRating(rating);
       await storageManager.saveLevelProgress(levelNumber, rating);
+      await updateStreakAfterGame();
       if (dailyChallengeLevel !== null && levelNumber === dailyChallengeLevel) {
         await markTodayCompleted();
       }


### PR DESCRIPTION
## Sprint B: Belohnungs-Loop & Motivation 🔥

Schließt #183 und #185 als Teil von Sprint B aus der Roadmap #189.

## Was wurde umgesetzt

### services/StreakManager.ts (neu — Issue #183)
- `StreakData { currentStreak, longestStreak, lastPlayedDate }` — persistiert via AsyncStorage (`@merke_male:streak`)
- `updateStreakAfterGame(date?)` — DST-sicherer Vergleich über lokale `YYYY-MM-DD`-Strings (kein UTC)
  - Gleicher Tag → kein Update
  - Gestern gespielt → Streak +1
  - >1 Tag Pause → Reset auf 1
- `getStreakData()`, `resetStreakData()` für Lesezugriff und Tests

### services/useGamePhase.ts (geändert — Issue #183)
- `updateStreakAfterGame()` wird in `handleRatingSubmit()` nach `saveLevelProgress()` aufgerufen

### components/QuickStatsCards.tsx (neu — Issue #185)
- 3× `GlassCard` (⭐ Sterne gesamt, 🔥 aktueller Streak, 🏆 Level abgeschlossen)
- `useFocusEffect` — Daten werden bei jedem Screen-Fokus neu geladen
- Tap auf Karte navigiert: Sterne → `/gallery`, Streak/Level → `/levels`
- Responsiv: unter 340 px Breite 2-zeilig umgebrochen
- Vollständige i18n (`home.stats.*`)

### app/index.tsx (geändert — Issue #185)
- `QuickStatsCards` zwischen Hero-Bereich und Buttons eingefügt
- 🔥-Badge im Top-Bar (nur ab `currentStreak ≥ 2`)
- `useFocusEffect` lädt jetzt auch Streak-Daten beim Focus-Refresh

### Übersetzungen (de + en)
- `home.streakBadge`, `home.stats.stars`, `home.stats.streak`, `home.stats.levels`, `home.stats.streakDays`, `home.stats.levelOf`

## Tests

- **13 neue StreakManager-Tests:** Erster Spieltag, gleicher Tag, aufeinanderfolgende Tage, Monatsgrenze, Jahreswechsel, 1-Tages-Lücke, 2-Tage-Pause, longestStreak-Persistenz nach Reset, DST-Wechsel
- **4 neue QuickStatsCards-Tests:** Labels, Werte nach Datenload, Streak-Tage-Label, Level-Sub-Label
- HomeScreen-Test erweitert: QuickStatsCards und StreakManager werden gemockt

Alle 289 Tests grün, ESLint sauber, Pre-Commit-Hooks bestanden.

## Definition of Done (Issue #189)

- [x] Streak überlebt App-Neustart (AsyncStorage-Persistenz)
- [x] DST-sicherer Vergleich via lokale YYYY-MM-DD-Strings
- [x] Stats laden via `useFocusEffect`
- [x] Tap auf Card navigiert zum jeweiligen Screen
- [x] Tests: DST-Wechsel, Tag-Übergang, Streak-Bruch nach 2 Tagen Pause
- [x] i18n (DE + EN)
- [x] Version: 1.4.2 → 1.6.0

## Bezug

- Schließt: #183 (Streak-Tracker)
- Schließt: #185 (Quick-Stats-Cards)
- Teil von Sprint B aus: #189
- Übergeordneter Tracker: #176

https://claude.ai/code/session_01PqBv6BaF1EVVoTsnRQE2s2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqBv6BaF1EVVoTsnRQE2s2)_