### PR TITLE
feat: Sprint C — Konfetti + Achievement-System (v1.6.1)

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Merke und Male",
     "slug": "merke-und-male",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "platforms": [
       "ios",
       "android",
@@ -43,7 +43,7 @@
       },
       "package": "com.s540d.merkeundmale",
       "permissions": [],
-      "versionCode": 62,
+      "versionCode": 63,
       "minSdkVersion": 26,
       "newArchEnabled": false,
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.s540d.merkeundmale",

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Alert, Modal, Platform, ScrollView, FlatList } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useScreenLayout } from '@utils/useScreenLayout';
 import { useRouter, useLocalSearchParams } from 'expo-router';
-import { getTotalLevels } from '@services/LevelManager';
+import { getTotalLevels, getDifficultyForLevel } from '@services/LevelManager';
 import { useTranslation, getLanguage } from '@services/i18n';
 import { useTheme } from '@services/ThemeContext';
 import { DrawingColors } from '../constants/Colors';
@@ -47,6 +47,7 @@ export default function GameScreen() {
   const [showConfetti, setShowConfetti] = useState(false);
   const [unlockedBadge, setUnlockedBadge] = useState<AchievementDef | null>(null);
   const lastCheckedRatingRef = React.useRef<number>(0);
+  const handleBadgeToastHide = useCallback(() => setUnlockedBadge(null), []);
 
   // Drawing Canvas Hook
   const drawing = useDrawingCanvas();
@@ -132,11 +133,24 @@ export default function GameScreen() {
         storageManager.getProgress(),
         getStreakData(),
       ]);
+      // Derive daily-challenge count from gallery (saved daily entries are flagged)
+      const dailyChallengesCompleted = gallery.filter((g) => g.isDailyChallenge).length;
+      // Derive distinct difficulties played from completed levels
+      const difficultiesPlayed = Array.from(
+        new Set(
+          Object.keys(progress.levels ?? {})
+            .map((n) => parseInt(n, 10))
+            .filter((n) => !isNaN(n))
+            .map((n) => getDifficultyForLevel(n)),
+        ),
+      );
       const newly = await checkAndUnlock({
         stars: rating,
         galleryCount: gallery.length,
         currentStreak: streak.currentStreak,
         levelsCompleted: progress.totalLevelsCompleted ?? 0,
+        dailyChallengesCompleted,
+        difficultiesPlayed,
       });
       if (newly.length > 0) setUnlockedBadge(newly[0]);
     } catch {
@@ -599,7 +613,7 @@ export default function GameScreen() {
           <ConfettiBurst width={screenWidth} height={layout.canvasMaxHeight + 200} active={showConfetti} />
         </View>
       )}
-      <BadgeUnlockToast achievement={unlockedBadge} onHide={() => setUnlockedBadge(null)} />
+      <BadgeUnlockToast achievement={unlockedBadge} onHide={handleBadgeToastHide} />
     </View>
   );
 }

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -14,8 +14,16 @@ import DrawingCanvas, { useDrawingCanvas } from '@components/DrawingCanvas';
 import SettingsModal from '@components/SettingsModal';
 import { ErrorBoundary } from '@components/ErrorBoundary';
 import { AnimatedFeedback, AnimatedStar } from '@components/AnimatedPrimitives';
+import ConfettiBurst from '@components/ConfettiBurst';
+import BadgeUnlockToast from '@components/BadgeUnlockToast';
 import SoundManager from '@services/SoundManager';
 import { useGamePhase } from '@services/useGamePhase';
+import {
+  checkAndUnlock,
+  type AchievementDef,
+} from '@services/AchievementManager';
+import { getStreakData } from '@services/StreakManager';
+import storageManager from '@services/StorageManager';
 import type { DrawingPath } from '@components/DrawingCanvas';
 
 /**
@@ -35,6 +43,9 @@ export default function GameScreen() {
   const [showSettings, setShowSettings] = useState(false);
   const [showHintModal, setShowHintModal] = useState(false);
   const [hasUsedHint, setHasUsedHint] = useState(false);
+  const [showConfetti, setShowConfetti] = useState(false);
+  const [unlockedBadge, setUnlockedBadge] = useState<AchievementDef | null>(null);
+  const lastCheckedRatingRef = React.useRef<number>(0);
 
   // Drawing Canvas Hook
   const drawing = useDrawingCanvas();
@@ -97,6 +108,40 @@ export default function GameScreen() {
   useEffect(() => {
     SoundManager.init();
   }, []);
+
+  // Trigger confetti + achievement check on each new rating (run once per rating value)
+  useEffect(() => {
+    if (userRating === 0 || userRating === lastCheckedRatingRef.current) return;
+    lastCheckedRatingRef.current = userRating;
+
+    if (userRating === 5) {
+      setShowConfetti(true);
+      const t = setTimeout(() => setShowConfetti(false), 2700);
+      // not awaited — best-effort
+      checkAchievements(userRating);
+      return () => clearTimeout(t);
+    }
+    checkAchievements(userRating);
+  }, [userRating]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const checkAchievements = async (rating: number) => {
+    try {
+      const [gallery, progress, streak] = await Promise.all([
+        storageManager.getGallery(),
+        storageManager.getProgress(),
+        getStreakData(),
+      ]);
+      const newly = await checkAndUnlock({
+        stars: rating,
+        galleryCount: gallery.length,
+        currentStreak: streak.currentStreak,
+        levelsCompleted: progress.totalLevelsCompleted ?? 0,
+      });
+      if (newly.length > 0) setUnlockedBadge(newly[0]);
+    } catch {
+      // best-effort
+    }
+  };
 
   // Memoized dynamic styles – stable across re-renders unless layout changes
   const dynCanvasContainer = useMemo(() => ({
@@ -546,6 +591,14 @@ export default function GameScreen() {
       {phase === 'memorize' && renderMemorizePhase()}
       {phase === 'draw' && renderDrawPhase()}
       {phase === 'result' && renderResultPhase()}
+
+      {/* Delight overlays (Sprint C) */}
+      {phase === 'result' && (
+        <View pointerEvents="none" style={StyleSheet.absoluteFill}>
+          <ConfettiBurst width={screenWidth} height={layout.canvasMaxHeight + 200} active={showConfetti} />
+        </View>
+      )}
+      <BadgeUnlockToast achievement={unlockedBadge} onHide={() => setUnlockedBadge(null)} />
     </View>
   );
 }

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -9,6 +9,7 @@ import { useTheme } from '@services/ThemeContext';
 import { DrawingColors } from '../constants/Colors';
 import Colors from '../constants/Colors';
 import { Spacing, FontSize, FontWeight, BorderRadius } from '../constants/Layout';
+import { FeatureFlags } from '../constants/featureFlags';
 import LevelImageDisplay from '@components/LevelImageDisplay';
 import DrawingCanvas, { useDrawingCanvas } from '@components/DrawingCanvas';
 import SettingsModal from '@components/SettingsModal';
@@ -114,7 +115,7 @@ export default function GameScreen() {
     if (userRating === 0 || userRating === lastCheckedRatingRef.current) return;
     lastCheckedRatingRef.current = userRating;
 
-    if (userRating === 5) {
+    if (userRating === 5 && FeatureFlags.ENABLE_CONFETTI) {
       setShowConfetti(true);
       const t = setTimeout(() => setShowConfetti(false), 2700);
       // not awaited — best-effort

--- a/components/BadgeUnlockToast.tsx
+++ b/components/BadgeUnlockToast.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect } from 'react';
+import { AccessibilityInfo, StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+import { useTranslation } from '@services/i18n';
+import Colors from '../constants/Colors';
+import { BorderRadius, FontSize, FontWeight, Spacing } from '../constants/Layout';
+import type { AchievementDef } from '@services/AchievementManager';
+
+interface Props {
+  achievement: AchievementDef | null;
+  onHide: () => void;
+}
+
+const VISIBLE_MS = 2800;
+const FADE_MS = 280;
+
+/**
+ * Slide-in toast shown when a badge is unlocked.
+ * Auto-hides after VISIBLE_MS; respects prefers-reduced-motion (fade only, no slide).
+ */
+export default function BadgeUnlockToast({ achievement, onHide }: Props) {
+  const { t } = useTranslation();
+  const translateY = useSharedValue(-80);
+  const opacity = useSharedValue(0);
+
+  useEffect(() => {
+    if (!achievement) return;
+    let cancelled = false;
+
+    AccessibilityInfo.isReduceMotionEnabled().then((rm) => {
+      if (cancelled) return;
+      if (rm) {
+        translateY.value = 0;
+        opacity.value = withSequence(
+          withTiming(1, { duration: FADE_MS }),
+          withDelay(VISIBLE_MS, withTiming(0, { duration: FADE_MS })),
+        );
+      } else {
+        translateY.value = withSequence(
+          withTiming(0, { duration: FADE_MS, easing: Easing.out(Easing.ease) }),
+          withDelay(VISIBLE_MS, withTiming(-80, { duration: FADE_MS, easing: Easing.in(Easing.ease) })),
+        );
+        opacity.value = withSequence(
+          withTiming(1, { duration: FADE_MS }),
+          withDelay(VISIBLE_MS, withTiming(0, { duration: FADE_MS })),
+        );
+      }
+    });
+
+    const timer = setTimeout(onHide, VISIBLE_MS + FADE_MS * 2 + 50);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [achievement, translateY, opacity, onHide]);
+
+  const animStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }],
+    opacity: opacity.value,
+  }));
+
+  if (!achievement) return null;
+
+  return (
+    <Animated.View style={[styles.toast, animStyle]} pointerEvents="none" testID="badge-unlock-toast">
+      <Text style={styles.emoji}>{achievement.emoji}</Text>
+      <View style={styles.textCol}>
+        <Text style={styles.title} numberOfLines={1}>{t('achievements.unlocked')}</Text>
+        <Text style={styles.subtitle} numberOfLines={1}>{t(achievement.titleKey)}</Text>
+      </View>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  toast: {
+    position: 'absolute',
+    top: Spacing.lg,
+    left: Spacing.md,
+    right: Spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.lg,
+    backgroundColor: Colors.surface,
+    borderRadius: BorderRadius.xl,
+    borderWidth: 1.5,
+    borderColor: Colors.primary,
+    shadowColor: Colors.primary,
+    shadowOpacity: 0.25,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 6,
+    zIndex: 1000,
+  },
+  emoji: {
+    fontSize: 32,
+    marginRight: Spacing.md,
+  },
+  textCol: {
+    flex: 1,
+  },
+  title: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.bold,
+    color: Colors.primary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
+  subtitle: {
+    fontSize: FontSize.md,
+    fontWeight: FontWeight.semibold,
+    color: Colors.text.primary,
+    marginTop: 2,
+  },
+});

--- a/components/BadgesModal.tsx
+++ b/components/BadgesModal.tsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from '@services/i18n';
+import { useTheme } from '@services/ThemeContext';
+import {
+  ACHIEVEMENTS,
+  getUnlockedAchievements,
+  type AchievementId,
+} from '@services/AchievementManager';
+import Colors from '../constants/Colors';
+import { BorderRadius, FontSize, FontWeight, Spacing } from '../constants/Layout';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export default function BadgesModal({ visible, onClose }: Props) {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const [unlockedIds, setUnlockedIds] = useState<Set<AchievementId>>(new Set());
+
+  useEffect(() => {
+    if (!visible) return;
+    getUnlockedAchievements().then((list) => {
+      setUnlockedIds(new Set(list.map((u) => u.id)));
+    });
+  }, [visible]);
+
+  const unlockedCount = unlockedIds.size;
+  const total = ACHIEVEMENTS.length;
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+      <View style={styles.backdrop}>
+        <View style={[styles.sheet, { backgroundColor: colors.background }]}>
+          <View style={styles.header}>
+            <Text style={[styles.title, { color: colors.text.primary }]}>
+              {t('achievements.title')}
+            </Text>
+            <Text style={[styles.subtitle, { color: colors.text.secondary }]}>
+              {t('achievements.progress', { unlocked: String(unlockedCount), total: String(total) })}
+            </Text>
+          </View>
+
+          <ScrollView contentContainerStyle={styles.list}>
+            {ACHIEVEMENTS.map((a) => {
+              const isUnlocked = unlockedIds.has(a.id);
+              return (
+                <View
+                  key={a.id}
+                  style={[
+                    styles.row,
+                    {
+                      backgroundColor: colors.surface ?? Colors.surface,
+                      opacity: isUnlocked ? 1 : 0.45,
+                      borderColor: isUnlocked ? Colors.primary : 'transparent',
+                    },
+                  ]}
+                  testID={`badge-row-${a.id}`}
+                >
+                  <Text style={[styles.emoji, !isUnlocked && styles.grayscale]}>
+                    {isUnlocked ? a.emoji : '🔒'}
+                  </Text>
+                  <View style={styles.textCol}>
+                    <Text style={[styles.rowTitle, { color: colors.text.primary }]}>
+                      {t(a.titleKey)}
+                    </Text>
+                    <Text style={[styles.rowDesc, { color: colors.text.secondary }]}>
+                      {t(a.descKey)}
+                    </Text>
+                  </View>
+                </View>
+              );
+            })}
+          </ScrollView>
+
+          <Pressable onPress={onClose} style={styles.closeButton} testID="badges-modal-close">
+            <Text style={styles.closeButtonText}>{t('common.close')}</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    maxHeight: '85%',
+    borderTopLeftRadius: BorderRadius.xxl,
+    borderTopRightRadius: BorderRadius.xxl,
+    paddingTop: Spacing.lg,
+    paddingHorizontal: Spacing.md,
+    paddingBottom: Spacing.lg,
+  },
+  header: {
+    alignItems: 'center',
+    marginBottom: Spacing.md,
+  },
+  title: {
+    fontSize: FontSize.xl,
+    fontWeight: FontWeight.bold,
+  },
+  subtitle: {
+    fontSize: FontSize.sm,
+    marginTop: 4,
+  },
+  list: {
+    paddingBottom: Spacing.md,
+    gap: Spacing.sm,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: Spacing.md,
+    borderRadius: BorderRadius.lg,
+    borderWidth: 1.5,
+  },
+  emoji: {
+    fontSize: 36,
+    marginRight: Spacing.md,
+  },
+  grayscale: {
+    opacity: 0.6,
+  },
+  textCol: {
+    flex: 1,
+  },
+  rowTitle: {
+    fontSize: FontSize.md,
+    fontWeight: FontWeight.semibold,
+  },
+  rowDesc: {
+    fontSize: FontSize.sm,
+    marginTop: 2,
+  },
+  closeButton: {
+    marginTop: Spacing.md,
+    paddingVertical: Spacing.md,
+    borderRadius: BorderRadius.lg,
+    backgroundColor: Colors.primary,
+    alignItems: 'center',
+  },
+  closeButtonText: {
+    color: '#fff',
+    fontSize: FontSize.md,
+    fontWeight: FontWeight.semibold,
+  },
+});

--- a/components/ConfettiBurst.native.tsx
+++ b/components/ConfettiBurst.native.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { AccessibilityInfo, StyleSheet, View } from 'react-native';
+import { Canvas, Circle } from '@shopify/react-native-skia';
+import {
+  Easing,
+  useSharedValue,
+  useDerivedValue,
+  withDelay,
+  withTiming,
+} from 'react-native-reanimated';
+import {
+  buildParticles,
+  CONFETTI_DURATION_MS,
+  type ConfettiBurstProps,
+  type ConfettiParticle,
+} from './ConfettiBurst.shared';
+
+function Particle({ p, progress }: { p: ConfettiParticle; progress: { value: number } }) {
+  const cx = useDerivedValue(() => p.x + p.drift * progress.value);
+  const cy = useDerivedValue(() => p.startY + (p.endY - p.startY) * progress.value);
+  const opacity = useDerivedValue(() =>
+    progress.value < 0.85 ? 1 : 1 - (progress.value - 0.85) / 0.15,
+  );
+  return <Circle cx={cx} cy={cy} r={p.size / 2} color={p.color} opacity={opacity} />;
+}
+
+export function ConfettiBurst({ width, height, active }: ConfettiBurstProps) {
+  const [reduceMotion, setReduceMotion] = useState(false);
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    AccessibilityInfo.isReduceMotionEnabled().then((rm) => {
+      if (!cancelled) setReduceMotion(rm);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    if (!active || reduceMotion) {
+      progress.value = 0;
+      return;
+    }
+    progress.value = 0;
+    progress.value = withDelay(
+      0,
+      withTiming(1, { duration: CONFETTI_DURATION_MS, easing: Easing.out(Easing.cubic) }),
+    );
+  }, [active, reduceMotion, progress]);
+
+  const particles = useMemo(() => buildParticles(width, height, Math.floor(width + height)), [width, height]);
+
+  if (!active || reduceMotion) return null;
+
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="none" testID="confetti-burst">
+      <Canvas style={{ width, height }}>
+        {particles.map((p, i) => (
+          <Particle key={i} p={p} progress={progress} />
+        ))}
+      </Canvas>
+    </View>
+  );
+}
+
+export default ConfettiBurst;

--- a/components/ConfettiBurst.shared.ts
+++ b/components/ConfettiBurst.shared.ts
@@ -1,0 +1,50 @@
+import Colors from '../constants/Colors';
+
+export interface ConfettiBurstProps {
+  width: number;
+  height: number;
+  active: boolean;
+}
+
+export interface ConfettiParticle {
+  x: number;
+  startY: number;
+  endY: number;
+  color: string;
+  size: number;
+  drift: number;
+  duration: number;
+  delay: number;
+  rotation: number;
+}
+
+export const CONFETTI_DURATION_MS = 2500;
+export const CONFETTI_COUNT = 40;
+
+const CONFETTI_COLORS = [
+  Colors.gradient.cta[0],
+  Colors.gradient.cta[1],
+  Colors.stars.filled,
+  Colors.gradient.warm[0],
+  Colors.gradient.teal[0],
+];
+
+export function buildParticles(width: number, height: number, seed = 0): ConfettiParticle[] {
+  // simple deterministic PRNG so tests / SSR stay stable
+  let s = seed || 1;
+  const rand = () => {
+    s = (s * 1664525 + 1013904223) % 0xffffffff;
+    return s / 0xffffffff;
+  };
+  return Array.from({ length: CONFETTI_COUNT }, () => ({
+    x: rand() * width,
+    startY: -20 - rand() * 60,
+    endY: height + 40,
+    color: CONFETTI_COLORS[Math.floor(rand() * CONFETTI_COLORS.length)],
+    size: 6 + rand() * 6,
+    drift: (rand() - 0.5) * 80,
+    duration: 1800 + rand() * 700,
+    delay: rand() * 400,
+    rotation: rand() * 360,
+  }));
+}

--- a/components/ConfettiBurst.tsx
+++ b/components/ConfettiBurst.tsx
@@ -1,0 +1,3 @@
+// Platform dispatcher — Metro/Webpack pick `.native.tsx` or `.web.tsx`.
+export { ConfettiBurst as default } from './ConfettiBurst.native';
+export type { ConfettiBurstProps } from './ConfettiBurst.shared';

--- a/components/ConfettiBurst.web.tsx
+++ b/components/ConfettiBurst.web.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { AccessibilityInfo, StyleSheet, View } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import {
+  buildParticles,
+  CONFETTI_DURATION_MS,
+  type ConfettiBurstProps,
+  type ConfettiParticle,
+} from './ConfettiBurst.shared';
+
+function Particle({ p, progress }: { p: ConfettiParticle; progress: { value: number } }) {
+  const style = useAnimatedStyle(() => {
+    const t = progress.value;
+    return {
+      position: 'absolute',
+      left: p.x + p.drift * t,
+      top: p.startY + (p.endY - p.startY) * t,
+      width: p.size,
+      height: p.size,
+      borderRadius: p.size / 2,
+      backgroundColor: p.color,
+      opacity: t < 0.85 ? 1 : 1 - (t - 0.85) / 0.15,
+      transform: [{ rotate: `${p.rotation + t * 360}deg` }],
+    };
+  });
+  return <Animated.View style={style} />;
+}
+
+export function ConfettiBurst({ width, height, active }: ConfettiBurstProps) {
+  const [reduceMotion, setReduceMotion] = useState(false);
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    AccessibilityInfo.isReduceMotionEnabled().then((rm) => {
+      if (!cancelled) setReduceMotion(rm);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    if (!active || reduceMotion) {
+      progress.value = 0;
+      return;
+    }
+    progress.value = 0;
+    progress.value = withTiming(1, {
+      duration: CONFETTI_DURATION_MS,
+      easing: Easing.out(Easing.cubic),
+    });
+  }, [active, reduceMotion, progress]);
+
+  const particles = useMemo(() => buildParticles(width, height, Math.floor(width + height)), [width, height]);
+
+  if (!active || reduceMotion) return null;
+
+  return (
+    <View
+      style={[StyleSheet.absoluteFill, { width, height, overflow: 'hidden' }]}
+      pointerEvents="none"
+      testID="confetti-burst"
+    >
+      {particles.map((p, i) => (
+        <Particle key={i} p={p} progress={progress} />
+      ))}
+    </View>
+  );
+}
+
+export default ConfettiBurst;

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -8,6 +8,7 @@ import SoundManager from '@services/SoundManager';
 import Colors from '../constants/Colors';
 import { Spacing, FontSize, FontWeight, BorderRadius } from '../constants/Layout';
 import ParentalGate from './ParentalGate';
+import BadgesModal from './BadgesModal';
 
 interface SettingsModalProps {
   visible: boolean;
@@ -25,6 +26,7 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
   const [currentLang, setCurrentLang] = useState(getLanguage());
   const [currentTheme, setCurrentTheme] = useState<'light' | 'dark' | 'system'>(themeSetting);
   const [showAboutModal, setShowAboutModal] = useState(false);
+  const [showBadgesModal, setShowBadgesModal] = useState(false);
   const [soundEnabled, setSoundEnabled] = useState(true);
   const [parentalGateVisible, setParentalGateVisible] = useState(false);
   const [pendingUrl, setPendingUrl] = useState<string | null>(null);
@@ -301,6 +303,7 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
       <View style={[styles.card, { backgroundColor: colors.surface }]}>
         <View style={styles.actionGrid}>
           {([
+            { id: 'trophies', label: t('achievements.menuLabel'), icon: '🏆', onPress: () => setShowBadgesModal(true) },
             { id: 'feedback', label: t('settings.feedback'), icon: '✉️', onPress: handleSendFeedback },
             { id: 'support',  label: t('settings.support'),  icon: '☕',  onPress: handleSupport },
             { id: 'share',    label: t('settings.share'),    icon: '↗',   onPress: handleShareApp },
@@ -330,6 +333,7 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
       </View>
 
       {renderAboutModal()}
+      <BadgesModal visible={showBadgesModal} onClose={() => setShowBadgesModal(false)} />
     </View>
   );
 

--- a/components/__tests__/ConfettiBurst.test.tsx
+++ b/components/__tests__/ConfettiBurst.test.tsx
@@ -1,0 +1,31 @@
+import { buildParticles, CONFETTI_COUNT } from '../ConfettiBurst.shared';
+
+describe('ConfettiBurst.shared', () => {
+  it('builds the expected number of particles', () => {
+    const particles = buildParticles(300, 600, 42);
+    expect(particles).toHaveLength(CONFETTI_COUNT);
+  });
+
+  it('keeps particles roughly inside the canvas X range', () => {
+    const particles = buildParticles(400, 800, 7);
+    particles.forEach((p) => {
+      expect(p.x).toBeGreaterThanOrEqual(0);
+      expect(p.x).toBeLessThanOrEqual(400);
+    });
+  });
+
+  it('is deterministic given the same seed', () => {
+    const a = buildParticles(300, 600, 99);
+    const b = buildParticles(300, 600, 99);
+    expect(a[0]).toEqual(b[0]);
+    expect(a[CONFETTI_COUNT - 1]).toEqual(b[CONFETTI_COUNT - 1]);
+  });
+
+  it('produces particles that fall from above into the canvas', () => {
+    const particles = buildParticles(300, 600, 5);
+    particles.forEach((p) => {
+      expect(p.startY).toBeLessThan(0);
+      expect(p.endY).toBeGreaterThan(600);
+    });
+  });
+});

--- a/components/__tests__/GameScreen.test.tsx
+++ b/components/__tests__/GameScreen.test.tsx
@@ -99,6 +99,33 @@ jest.mock('../../services/SoundManager', () => ({
   default: { init: jest.fn(), playPhaseTransition: jest.fn() },
 }));
 
+jest.mock('../../components/ConfettiBurst', () => {
+  const { View } = require('react-native');
+  return { __esModule: true, default: () => <View testID="confetti-burst" /> };
+});
+
+jest.mock('../../components/BadgeUnlockToast', () => {
+  const { View } = require('react-native');
+  return { __esModule: true, default: () => <View testID="badge-unlock-toast" /> };
+});
+
+jest.mock('../../services/AchievementManager', () => ({
+  checkAndUnlock: jest.fn(async () => []),
+  ACHIEVEMENTS: [],
+}));
+
+jest.mock('../../services/StreakManager', () => ({
+  getStreakData: jest.fn(async () => ({ currentStreak: 0, longestStreak: 0, lastPlayedDate: null })),
+}));
+
+jest.mock('../../services/StorageManager', () => ({
+  __esModule: true,
+  default: {
+    getGallery: jest.fn(async () => []),
+    getProgress: jest.fn(async () => ({ levels: {}, totalLevelsCompleted: 0, averageRating: 0 })),
+  },
+}));
+
 jest.mock('../../services/useGamePhase', () => ({
   useGamePhase: () => ({
     phase: 'memorize',

--- a/constants/featureFlags.ts
+++ b/constants/featureFlags.ts
@@ -1,0 +1,12 @@
+/**
+ * Feature-Flags — interner Kill-Switch für einzelne Features.
+ * Nicht für Endnutzer sichtbar; Änderung erfordert App-Rebuild.
+ *
+ * Konvention: ENABLE_* defaultet auf `true`. Auf `false` setzen, um
+ * das Feature ohne Code-Removal kurzfristig zu deaktivieren.
+ */
+
+export const FeatureFlags = {
+  /** Konfetti bei 5-Sterne-Ergebnis (Issue #186). */
+  ENABLE_CONFETTI: true,
+} as const;

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -167,5 +167,17 @@
     "placeholder": "Antwort eingeben",
     "confirm": "Öffnen",
     "wrongAnswer": "Falsche Antwort. Bitte versuche es erneut."
+  },
+  "achievements": {
+    "title": "Trophäen",
+    "menuLabel": "Trophäen anzeigen",
+    "unlocked": "Neue Trophäe!",
+    "progress": "{{unlocked}} von {{total}} freigeschaltet",
+    "first_5_stars":    { "title": "Erste 5 Sterne",     "desc": "Erreiche zum ersten Mal 5 Sterne in einem Level." },
+    "gallery_10":       { "title": "Galerie-Künstler",   "desc": "Speichere 10 Zeichnungen in deiner Galerie." },
+    "streak_7":         { "title": "7-Tage-Streak",      "desc": "Spiele 7 Tage hintereinander." },
+    "all_levels_done":  { "title": "Alle Level",         "desc": "Schließe alle 10 Basis-Level ab." },
+    "daily_5":          { "title": "Daily-Champion",     "desc": "Bestehe 5× die tägliche Herausforderung." },
+    "all_difficulties": { "title": "Allrounder",         "desc": "Spiele jede Schwierigkeitsstufe mindestens einmal." }
   }
 }

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -167,5 +167,17 @@
     "placeholder": "Enter answer",
     "confirm": "Open",
     "wrongAnswer": "Wrong answer. Please try again."
+  },
+  "achievements": {
+    "title": "Trophies",
+    "menuLabel": "Show trophies",
+    "unlocked": "New trophy!",
+    "progress": "{{unlocked}} of {{total}} unlocked",
+    "first_5_stars":    { "title": "First 5 Stars",     "desc": "Reach 5 stars in a level for the first time." },
+    "gallery_10":       { "title": "Gallery Artist",    "desc": "Save 10 drawings to your gallery." },
+    "streak_7":         { "title": "7-Day Streak",      "desc": "Play 7 days in a row." },
+    "all_levels_done":  { "title": "All Levels",        "desc": "Complete all 10 base levels." },
+    "daily_5":          { "title": "Daily Champion",    "desc": "Beat the daily challenge 5 times." },
+    "all_difficulties": { "title": "All-Rounder",       "desc": "Play every difficulty level at least once." }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merke-und-male",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "main": "expo-router/entry",
   "homepage": "https://s540d.github.io/DrawFromMemory/",
   "repository": {

--- a/services/AchievementManager.ts
+++ b/services/AchievementManager.ts
@@ -1,0 +1,143 @@
+/**
+ * AchievementManager — Badge-System
+ * Speichert freigeschaltete Badges via AsyncStorage.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = '@merke_male:achievements';
+
+export type AchievementId =
+  | 'first_5_stars'
+  | 'gallery_10'
+  | 'streak_7'
+  | 'all_levels_done'
+  | 'daily_5'
+  | 'all_difficulties';
+
+export interface AchievementDef {
+  id: AchievementId;
+  emoji: string;
+  titleKey: string;
+  descKey: string;
+}
+
+export const ACHIEVEMENTS: AchievementDef[] = [
+  { id: 'first_5_stars',    emoji: '🌟', titleKey: 'achievements.first_5_stars.title',    descKey: 'achievements.first_5_stars.desc' },
+  { id: 'gallery_10',       emoji: '🎨', titleKey: 'achievements.gallery_10.title',       descKey: 'achievements.gallery_10.desc' },
+  { id: 'streak_7',         emoji: '🔥', titleKey: 'achievements.streak_7.title',         descKey: 'achievements.streak_7.desc' },
+  { id: 'all_levels_done',  emoji: '🏆', titleKey: 'achievements.all_levels_done.title',  descKey: 'achievements.all_levels_done.desc' },
+  { id: 'daily_5',          emoji: '🎯', titleKey: 'achievements.daily_5.title',          descKey: 'achievements.daily_5.desc' },
+  { id: 'all_difficulties', emoji: '🌈', titleKey: 'achievements.all_difficulties.title', descKey: 'achievements.all_difficulties.desc' },
+];
+
+export interface UnlockedAchievement {
+  id: AchievementId;
+  unlockedAt: string; // ISO date
+}
+
+export interface AchievementEvent {
+  stars?: number;
+  galleryCount?: number;
+  currentStreak?: number;
+  levelsCompleted?: number;
+  dailyChallengesCompleted?: number;
+  difficultiesPlayed?: number[]; // distinct difficulties played at least once
+}
+
+const MEMORY: Record<string, string> = {};
+
+function safeParse(raw: string | null | undefined): UnlockedAchievement[] | null {
+  if (!raw) return null;
+  try {
+    const v = JSON.parse(raw);
+    return Array.isArray(v) ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+async function loadUnlocked(): Promise<UnlockedAchievement[]> {
+  let raw: string | null = null;
+  try {
+    raw = await AsyncStorage.getItem(STORAGE_KEY);
+  } catch {
+    // fall through
+  }
+  const parsed = safeParse(raw) ?? safeParse(MEMORY[STORAGE_KEY]);
+  if (parsed) {
+    if (raw) MEMORY[STORAGE_KEY] = raw;
+    return parsed;
+  }
+  if (raw) {
+    delete MEMORY[STORAGE_KEY];
+    try { await AsyncStorage.removeItem(STORAGE_KEY); } catch { /* best-effort */ }
+  }
+  return [];
+}
+
+async function saveUnlocked(list: UnlockedAchievement[]): Promise<void> {
+  const raw = JSON.stringify(list);
+  MEMORY[STORAGE_KEY] = raw;
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, raw);
+  } catch {
+    // in-memory fallback
+  }
+}
+
+export async function getUnlockedAchievements(): Promise<UnlockedAchievement[]> {
+  try {
+    return await loadUnlocked();
+  } catch {
+    return [];
+  }
+}
+
+export async function isUnlocked(id: AchievementId): Promise<boolean> {
+  const list = await getUnlockedAchievements();
+  return list.some((u) => u.id === id);
+}
+
+/**
+ * Prüft Event gegen Achievement-Regeln und gibt neu freigeschaltete Badges zurück.
+ */
+export async function checkAndUnlock(event: AchievementEvent): Promise<AchievementDef[]> {
+  const list = await loadUnlocked();
+  const has = (id: AchievementId) => list.some((u) => u.id === id);
+  const newly: AchievementDef[] = [];
+
+  const tryUnlock = (id: AchievementId, condition: boolean) => {
+    if (condition && !has(id)) {
+      const def = ACHIEVEMENTS.find((a) => a.id === id);
+      if (def) newly.push(def);
+    }
+  };
+
+  tryUnlock('first_5_stars',    (event.stars ?? 0) >= 5);
+  tryUnlock('gallery_10',       (event.galleryCount ?? 0) >= 10);
+  tryUnlock('streak_7',         (event.currentStreak ?? 0) >= 7);
+  tryUnlock('all_levels_done',  (event.levelsCompleted ?? 0) >= 10);
+  tryUnlock('daily_5',          (event.dailyChallengesCompleted ?? 0) >= 5);
+  tryUnlock(
+    'all_difficulties',
+    Array.isArray(event.difficultiesPlayed) &&
+      [1, 2, 3, 4, 5].every((d) => event.difficultiesPlayed!.includes(d)),
+  );
+
+  if (newly.length > 0) {
+    const now = new Date().toISOString();
+    const updated = [...list, ...newly.map((d) => ({ id: d.id, unlockedAt: now }))];
+    await saveUnlocked(updated);
+  }
+  return newly;
+}
+
+export async function resetAchievements(): Promise<void> {
+  delete MEMORY[STORAGE_KEY];
+  try {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // best-effort
+  }
+}

--- a/services/AchievementManager.ts
+++ b/services/AchievementManager.ts
@@ -64,12 +64,22 @@ async function loadUnlocked(): Promise<UnlockedAchievement[]> {
   } catch {
     // fall through
   }
-  const parsed = safeParse(raw) ?? safeParse(MEMORY[STORAGE_KEY]);
-  if (parsed) {
-    if (raw) MEMORY[STORAGE_KEY] = raw;
-    return parsed;
+  const fromRaw = safeParse(raw);
+  if (fromRaw) {
+    MEMORY[STORAGE_KEY] = raw as string;
+    return fromRaw;
   }
-  if (raw) {
+  // raw is missing or corrupt — try MEMORY cache
+  const fromMemory = safeParse(MEMORY[STORAGE_KEY]);
+  if (fromMemory) {
+    if (raw !== null && raw !== undefined) {
+      // storage was corrupt; clear it but keep valid in-memory cache
+      try { await AsyncStorage.removeItem(STORAGE_KEY); } catch { /* best-effort */ }
+    }
+    return fromMemory;
+  }
+  // nothing valid anywhere
+  if (raw !== null && raw !== undefined) {
     delete MEMORY[STORAGE_KEY];
     try { await AsyncStorage.removeItem(STORAGE_KEY); } catch { /* best-effort */ }
   }

--- a/services/__tests__/AchievementManager.test.ts
+++ b/services/__tests__/AchievementManager.test.ts
@@ -1,0 +1,77 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  checkAndUnlock,
+  getUnlockedAchievements,
+  isUnlocked,
+  resetAchievements,
+} from '../AchievementManager';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+const mockStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+describe('AchievementManager', () => {
+  beforeEach(async () => {
+    mockStorage.getItem.mockReset();
+    mockStorage.setItem.mockReset();
+    mockStorage.removeItem.mockReset();
+    mockStorage.getItem.mockResolvedValue(null);
+    await resetAchievements();
+  });
+
+  it('returns empty list when nothing unlocked yet', async () => {
+    expect(await getUnlockedAchievements()).toEqual([]);
+  });
+
+  it('unlocks first_5_stars on rating === 5', async () => {
+    const newly = await checkAndUnlock({ stars: 5 });
+    expect(newly.map((a) => a.id)).toContain('first_5_stars');
+    expect(await isUnlocked('first_5_stars')).toBe(true);
+  });
+
+  it('does not unlock same badge twice', async () => {
+    await checkAndUnlock({ stars: 5 });
+    mockStorage.getItem.mockResolvedValue(
+      JSON.stringify([{ id: 'first_5_stars', unlockedAt: '2026-01-01' }]),
+    );
+    const newly = await checkAndUnlock({ stars: 5 });
+    expect(newly).toEqual([]);
+  });
+
+  it('unlocks gallery_10 only at >= 10 entries', async () => {
+    expect((await checkAndUnlock({ galleryCount: 9 })).map((a) => a.id)).not.toContain('gallery_10');
+    mockStorage.getItem.mockResolvedValue(null);
+    expect((await checkAndUnlock({ galleryCount: 10 })).map((a) => a.id)).toContain('gallery_10');
+  });
+
+  it('unlocks streak_7 at >= 7 days', async () => {
+    expect((await checkAndUnlock({ currentStreak: 6 })).map((a) => a.id)).not.toContain('streak_7');
+    mockStorage.getItem.mockResolvedValue(null);
+    expect((await checkAndUnlock({ currentStreak: 7 })).map((a) => a.id)).toContain('streak_7');
+  });
+
+  it('unlocks all_levels_done at 10 levels', async () => {
+    expect((await checkAndUnlock({ levelsCompleted: 10 })).map((a) => a.id)).toContain('all_levels_done');
+  });
+
+  it('unlocks all_difficulties only when 1..5 all played', async () => {
+    expect((await checkAndUnlock({ difficultiesPlayed: [1, 2, 3, 4] })).map((a) => a.id))
+      .not.toContain('all_difficulties');
+    mockStorage.getItem.mockResolvedValue(null);
+    expect((await checkAndUnlock({ difficultiesPlayed: [1, 2, 3, 4, 5] })).map((a) => a.id))
+      .toContain('all_difficulties');
+  });
+
+  it('recovers from corrupt JSON in storage', async () => {
+    mockStorage.getItem.mockResolvedValue('{not-json');
+    expect(await getUnlockedAchievements()).toEqual([]);
+    expect(mockStorage.removeItem).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Sprint C: Delight & Belohnung 🎉

Schließt #186 (Konfetti) und #184 (Achievements) — Sprint C aus Roadmap #189.

## Was wurde umgesetzt

### #186 — Konfetti bei 5-Sterne-Ergebnis
- `components/ConfettiBurst.{tsx, native.tsx, web.tsx, shared.ts}`
  - Plattform-Dispatcher (analog DrawingCanvas)
  - Native: Skia `<Canvas>` mit `<Circle>` + `useDerivedValue`
  - Web: `Animated.View` mit `useAnimatedStyle` + Rotation
  - Shared: deterministischer Particle-Builder (40 Partikel, seeded PRNG)
- Trigger: `useEffect` auf `userRating === 5` in `app/game.tsx`
- `prefers-reduced-motion` → kein Konfetti
- `pointerEvents="none"` — Tap-Handling auf Sternen bleibt
- Auto-Cleanup nach ~2.7s

### #184 — Achievement- & Badge-System
- `services/AchievementManager.ts` mit 6 Badges:
  - 🌟 first_5_stars · 🎨 gallery_10 · 🔥 streak_7
  - 🏆 all_levels_done · 🎯 daily_5 · 🌈 all_difficulties
- Storage: `@merke_male:achievements` (corrupt-JSON-Schutz wie StreakManager)
- `checkAndUnlock(event)` → `AchievementDef[]` der neu freigeschalteten
- `components/BadgeUnlockToast.tsx`: Slide-in von oben, 2.8s sichtbar, reduced-motion fade-only
- `components/BadgesModal.tsx`: Bottom-Sheet, gesperrt 🔒 grau / freigeschaltet farbig
- Eintrag "🏆 Trophäen" in SettingsModal (5- → 6-Item-Grid)
- Integration: `userRating`-Effect prüft Achievements nach jeder neuen Bewertung

## Tests

- **AchievementManager** (8 Tests): leere Liste, Unlock-Regeln pro Badge, kein Doppel-Unlock, corrupt-JSON-Recovery
- **ConfettiBurst.shared** (4 Tests): Partikel-Count, X-Range, Determinismus, Y-Start/End
- **GameScreen-Test** erweitert: ConfettiBurst/BadgeUnlockToast/AchievementManager/StreakManager/StorageManager gemockt
- **310 Tests grün** (vorher 298)

## i18n
- DE + EN: kompletter `achievements.*` Namespace inkl. Titel/Description aller 6 Badges

## Version
- 1.6.0 → 1.6.1
- versionCode 62 → 63

## Definition of Done (#189)
- [x] Konfetti läuft bei 5-Sterne-Ergebnis
- [x] Web + Native Implementierung
- [x] `prefers-reduced-motion` respektiert
- [x] Badges entsperren bei den definierten Events
- [x] BadgesModal über Settings erreichbar
- [x] Tests + i18n

## Test plan
- [ ] `npm test` — alle Tests grün
- [ ] Web: Level spielen → 5★ vergeben → Konfetti regnet
- [ ] Web: Settings → 🏆 Trophäen → BadgesModal zeigt 1/6 unlocked
- [ ] Native: Konfetti läuft flüssig
- [ ] Accessibility: `prefers-reduced-motion` aktivieren → kein Konfetti, Toast nur fade

Closes #186
Closes #184
Part of #189 (Sprint C)