### PR TITLE
feat: Sprint D — Onboarding + Eltern-Dashboard

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -14,6 +14,8 @@ Merke und Male is designed with privacy in mind. All game data is stored locally
 The following data is stored locally on your device:
 - Game progress (completed levels)
 - Settings preferences (language, theme)
+- Game sessions (date, duration, stars, level) — used by the Parent Dashboard, auto-deleted after 28 days
+- Onboarding completion flag
 - No personal identifying information
 - No user accounts or registration data
 

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { View, Text, StyleSheet, Pressable, TouchableOpacity } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter, useFocusEffect } from 'expo-router';
@@ -17,6 +17,8 @@ import SettingsModal from '@components/SettingsModal';
 import QuickStatsCards from '@components/QuickStatsCards';
 import { FloatingStars } from '@components/FloatingStars';
 import { AnimatedHero } from '@components/AnimatedHero';
+import OnboardingModal from '@components/OnboardingModal';
+import { isOnboardingDone } from '@services/OnboardingManager';
 
 export default function HomeScreen() {
   const { t } = useTranslation();
@@ -24,7 +26,14 @@ export default function HomeScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const [showSettings, setShowSettings] = useState(false);
+  const [showOnboarding, setShowOnboarding] = useState(false);
   const [dailyCompleted, setDailyCompleted] = useState(false);
+
+  useEffect(() => {
+    isOnboardingDone().then((done) => {
+      if (!done) setShowOnboarding(true);
+    });
+  }, []);
   const [secondsLeft, setSecondsLeft] = useState(() => getSecondsUntilMidnight());
   const [dailyLevel, setDailyLevel] = useState(() => getDailyChallengeLevel());
   const [currentStreak, setCurrentStreak] = useState(0);
@@ -149,6 +158,7 @@ export default function HomeScreen() {
       </View>
 
       <SettingsModal visible={showSettings} onClose={() => setShowSettings(false)} />
+      <OnboardingModal visible={showOnboarding} onClose={() => setShowOnboarding(false)} />
     </View>
   );
 }

--- a/components/OnboardingModal.tsx
+++ b/components/OnboardingModal.tsx
@@ -1,0 +1,254 @@
+import React, { useEffect, useState } from 'react';
+import {
+  AccessibilityInfo,
+  Dimensions,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+import { useTranslation } from '@services/i18n';
+import { useTheme } from '@services/ThemeContext';
+import { markOnboardingDone } from '@services/OnboardingManager';
+import Colors from '../constants/Colors';
+import { BorderRadius, FontSize, FontWeight, Spacing } from '../constants/Layout';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+}
+
+interface Step {
+  emoji: string;
+  titleKey: string;
+  descKey: string;
+}
+
+const STEPS: Step[] = [
+  { emoji: '👀', titleKey: 'onboarding.step1.title', descKey: 'onboarding.step1.desc' },
+  { emoji: '✏️', titleKey: 'onboarding.step2.title', descKey: 'onboarding.step2.desc' },
+  { emoji: '⭐', titleKey: 'onboarding.step3.title', descKey: 'onboarding.step3.desc' },
+];
+
+function PulsingEmoji({ char, animate }: { char: string; animate: boolean }) {
+  const scale = useSharedValue(1);
+  useEffect(() => {
+    if (!animate) return;
+    scale.value = withRepeat(
+      withSequence(
+        withTiming(1.15, { duration: 900, easing: Easing.inOut(Easing.ease) }),
+        withTiming(1.0,  { duration: 900, easing: Easing.inOut(Easing.ease) }),
+      ),
+      -1,
+      false,
+    );
+  }, [animate, scale]);
+  const style = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));
+  return (
+    <Animated.View style={style}>
+      <Text style={styles.emoji}>{char}</Text>
+    </Animated.View>
+  );
+}
+
+export default function OnboardingModal({ visible, onClose }: Props) {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const [stepIndex, setStepIndex] = useState(0);
+  const [animate, setAnimate] = useState(true);
+  const { width } = Dimensions.get('window');
+  const scrollRef = React.useRef<ScrollView>(null);
+
+  useEffect(() => {
+    if (!visible) return;
+    let cancelled = false;
+    setStepIndex(0);
+    AccessibilityInfo.isReduceMotionEnabled().then((rm) => {
+      if (!cancelled) setAnimate(!rm);
+    });
+    return () => { cancelled = true; };
+  }, [visible]);
+
+  const handleNext = async () => {
+    if (stepIndex < STEPS.length - 1) {
+      const next = stepIndex + 1;
+      setStepIndex(next);
+      scrollRef.current?.scrollTo({ x: next * width, animated: animate });
+    } else {
+      await markOnboardingDone();
+      onClose();
+    }
+  };
+
+  const handleSkip = async () => {
+    await markOnboardingDone();
+    onClose();
+  };
+
+  const handleScroll = (e: { nativeEvent: { contentOffset: { x: number } } }) => {
+    const newIndex = Math.round(e.nativeEvent.contentOffset.x / width);
+    if (newIndex !== stepIndex && newIndex >= 0 && newIndex < STEPS.length) {
+      setStepIndex(newIndex);
+    }
+  };
+
+  return (
+    <Modal visible={visible} animationType="fade" onRequestClose={handleSkip} testID="onboarding-modal">
+      <View style={[styles.container, { backgroundColor: colors.background }]}>
+        <View style={styles.topBar}>
+          <Pressable
+            onPress={handleSkip}
+            style={styles.skipButton}
+            accessibilityRole="button"
+            accessibilityLabel={t('onboarding.skip')}
+            testID="onboarding-skip"
+          >
+            <Text style={[styles.skipText, { color: colors.text.secondary }]}>
+              {t('onboarding.skip')}
+            </Text>
+          </Pressable>
+        </View>
+
+        <ScrollView
+          ref={scrollRef}
+          horizontal
+          pagingEnabled
+          showsHorizontalScrollIndicator={false}
+          onMomentumScrollEnd={handleScroll}
+          style={styles.pager}
+          testID="onboarding-pager"
+        >
+          {STEPS.map((step, i) => (
+            <View key={step.titleKey} style={[styles.page, { width }]}>
+              <View style={styles.iconCircle}>
+                <PulsingEmoji char={step.emoji} animate={animate && i === stepIndex} />
+              </View>
+              <Text style={[styles.title, { color: colors.text.primary }]}>
+                {t(step.titleKey)}
+              </Text>
+              <Text style={[styles.desc, { color: colors.text.secondary }]}>
+                {t(step.descKey)}
+              </Text>
+            </View>
+          ))}
+        </ScrollView>
+
+        <View style={styles.dotsRow} testID="onboarding-dots">
+          {STEPS.map((_, i) => (
+            <View
+              key={i}
+              style={[
+                styles.dot,
+                i === stepIndex && styles.dotActive,
+              ]}
+            />
+          ))}
+        </View>
+
+        <Pressable
+          onPress={handleNext}
+          style={styles.nextButton}
+          accessibilityRole="button"
+          testID="onboarding-next"
+        >
+          <Text style={styles.nextButtonText}>
+            {stepIndex < STEPS.length - 1 ? t('onboarding.next') : t('onboarding.start')}
+          </Text>
+        </Pressable>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: Spacing.xxl,
+    paddingBottom: Spacing.lg,
+  },
+  topBar: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    paddingHorizontal: Spacing.lg,
+  },
+  skipButton: {
+    padding: Spacing.sm,
+  },
+  skipText: {
+    fontSize: FontSize.md,
+    fontWeight: FontWeight.semibold,
+  },
+  pager: {
+    flexGrow: 0,
+  },
+  page: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: Spacing.xl,
+    paddingVertical: Spacing.xxl,
+  },
+  iconCircle: {
+    width: 160,
+    height: 160,
+    borderRadius: 80,
+    backgroundColor: Colors.primary + '15',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: Spacing.xl,
+  },
+  emoji: {
+    fontSize: 96,
+  },
+  title: {
+    fontSize: FontSize.xl,
+    fontWeight: FontWeight.bold,
+    textAlign: 'center',
+    marginBottom: Spacing.md,
+  },
+  desc: {
+    fontSize: FontSize.md,
+    textAlign: 'center',
+    lineHeight: FontSize.md * 1.4,
+    maxWidth: 320,
+  },
+  dotsRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: Spacing.sm,
+    marginVertical: Spacing.lg,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: Colors.text.light,
+    opacity: 0.4,
+  },
+  dotActive: {
+    backgroundColor: Colors.primary,
+    opacity: 1,
+    width: 24,
+  },
+  nextButton: {
+    marginHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
+    borderRadius: BorderRadius.lg,
+    backgroundColor: Colors.primary,
+    alignItems: 'center',
+  },
+  nextButtonText: {
+    color: '#fff',
+    fontSize: FontSize.md,
+    fontWeight: FontWeight.bold,
+  },
+});

--- a/components/ParentDashboard.tsx
+++ b/components/ParentDashboard.tsx
@@ -1,0 +1,243 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from '@services/i18n';
+import { useTheme } from '@services/ThemeContext';
+import { getSessionStats, type SessionStats } from '@services/SessionTracker';
+import { getStreakData, type StreakData } from '@services/StreakManager';
+import Colors from '../constants/Colors';
+import { BorderRadius, FontSize, FontWeight, Spacing } from '../constants/Layout';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+}
+
+function formatDuration(ms: number): string {
+  const totalMin = Math.round(ms / 60000);
+  if (totalMin < 60) return `${totalMin} min`;
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  return m === 0 ? `${h} h` : `${h} h ${m} min`;
+}
+
+export default function ParentDashboard({ visible, onClose }: Props) {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const [stats, setStats] = useState<SessionStats | null>(null);
+  const [streak, setStreak] = useState<StreakData | null>(null);
+
+  useEffect(() => {
+    if (!visible) return;
+    Promise.all([getSessionStats(), getStreakData()]).then(([s, st]) => {
+      setStats(s);
+      setStreak(st);
+    });
+  }, [visible]);
+
+  const cardBg = colors.surface ?? Colors.surface;
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+      <View style={styles.backdrop}>
+        <View style={[styles.sheet, { backgroundColor: colors.background }]}>
+          <View style={styles.header}>
+            <Text style={[styles.title, { color: colors.text.primary }]}>
+              {t('parentDashboard.title')}
+            </Text>
+            <Text style={[styles.subtitle, { color: colors.text.secondary }]}>
+              {t('parentDashboard.subtitle')}
+            </Text>
+            <Text style={[styles.privacyHint, { color: colors.text.light }]}>
+              {t('parentDashboard.privacyHint')}
+            </Text>
+          </View>
+
+          <ScrollView contentContainerStyle={styles.body}>
+            {stats === null ? (
+              <Text style={[styles.empty, { color: colors.text.secondary }]}>
+                {t('parentDashboard.loading')}
+              </Text>
+            ) : stats.totalSessions === 0 ? (
+              <Text style={[styles.empty, { color: colors.text.secondary }]}>
+                {t('parentDashboard.empty')}
+              </Text>
+            ) : (
+              <>
+                <View style={styles.cardRow}>
+                  <View style={[styles.statCard, { backgroundColor: cardBg }]}>
+                    <Text style={[styles.statLabel, { color: colors.text.light }]}>
+                      {t('parentDashboard.totalSessions')}
+                    </Text>
+                    <Text style={[styles.statValue, { color: colors.text.primary }]}>
+                      {stats.totalSessions}
+                    </Text>
+                  </View>
+                  <View style={[styles.statCard, { backgroundColor: cardBg }]}>
+                    <Text style={[styles.statLabel, { color: colors.text.light }]}>
+                      {t('parentDashboard.totalTime')}
+                    </Text>
+                    <Text style={[styles.statValue, { color: colors.text.primary }]}>
+                      {formatDuration(stats.totalDurationMs)}
+                    </Text>
+                  </View>
+                </View>
+
+                <View style={styles.cardRow}>
+                  <View style={[styles.statCard, { backgroundColor: cardBg }]}>
+                    <Text style={[styles.statLabel, { color: colors.text.light }]}>
+                      {t('parentDashboard.avgStars')}
+                    </Text>
+                    <Text style={[styles.statValue, { color: colors.text.primary }]}>
+                      {stats.averageStars.toFixed(1)} ★
+                    </Text>
+                  </View>
+                  <View style={[styles.statCard, { backgroundColor: cardBg }]}>
+                    <Text style={[styles.statLabel, { color: colors.text.light }]}>
+                      {t('parentDashboard.streak')}
+                    </Text>
+                    <Text style={[styles.statValue, { color: colors.text.primary }]}>
+                      {streak?.currentStreak ?? 0} / {streak?.longestStreak ?? 0}
+                    </Text>
+                  </View>
+                </View>
+
+                {stats.favoriteLevels.length > 0 && (
+                  <View style={[styles.section, { backgroundColor: cardBg }]}>
+                    <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>
+                      {t('parentDashboard.favoriteLevels')}
+                    </Text>
+                    {stats.favoriteLevels.map((f) => (
+                      <View key={f.levelId} style={styles.listRow}>
+                        <Text style={[styles.listText, { color: colors.text.primary }]}>
+                          {t('parentDashboard.levelLine', { level: String(f.levelId), count: String(f.count) })}
+                        </Text>
+                      </View>
+                    ))}
+                  </View>
+                )}
+
+                {stats.dailyBreakdown.length > 0 && (
+                  <View style={[styles.section, { backgroundColor: cardBg }]}>
+                    <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>
+                      {t('parentDashboard.dailyBreakdown')}
+                    </Text>
+                    {stats.dailyBreakdown.slice(-14).reverse().map((d) => (
+                      <View key={d.date} style={styles.listRow}>
+                        <Text style={[styles.listText, { color: colors.text.primary }]}>
+                          {d.date}
+                        </Text>
+                        <Text style={[styles.listSub, { color: colors.text.secondary }]}>
+                          {d.sessions}× · {formatDuration(d.totalDurationMs)} · {d.avgStars.toFixed(1)}★
+                        </Text>
+                      </View>
+                    ))}
+                  </View>
+                )}
+              </>
+            )}
+          </ScrollView>
+
+          <Pressable onPress={onClose} style={styles.closeButton} testID="parent-dashboard-close">
+            <Text style={styles.closeButtonText}>{t('common.close')}</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    maxHeight: '90%',
+    borderTopLeftRadius: BorderRadius.xxl,
+    borderTopRightRadius: BorderRadius.xxl,
+    paddingTop: Spacing.lg,
+    paddingHorizontal: Spacing.md,
+    paddingBottom: Spacing.lg,
+  },
+  header: {
+    alignItems: 'center',
+    marginBottom: Spacing.md,
+  },
+  title: {
+    fontSize: FontSize.xl,
+    fontWeight: FontWeight.bold,
+  },
+  subtitle: {
+    fontSize: FontSize.sm,
+    marginTop: 4,
+  },
+  privacyHint: {
+    fontSize: FontSize.xs,
+    marginTop: Spacing.xs,
+    fontStyle: 'italic',
+  },
+  body: {
+    paddingBottom: Spacing.md,
+    gap: Spacing.sm,
+  },
+  empty: {
+    textAlign: 'center',
+    paddingVertical: Spacing.xl,
+    fontSize: FontSize.md,
+  },
+  cardRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+  },
+  statCard: {
+    flex: 1,
+    padding: Spacing.md,
+    borderRadius: BorderRadius.lg,
+    alignItems: 'flex-start',
+  },
+  statLabel: {
+    fontSize: FontSize.xs,
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+  },
+  statValue: {
+    fontSize: FontSize.xl,
+    fontWeight: FontWeight.bold,
+    marginTop: 4,
+  },
+  section: {
+    padding: Spacing.md,
+    borderRadius: BorderRadius.lg,
+    gap: Spacing.xs,
+  },
+  sectionTitle: {
+    fontSize: FontSize.md,
+    fontWeight: FontWeight.semibold,
+    marginBottom: Spacing.xs,
+  },
+  listRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 4,
+  },
+  listText: {
+    fontSize: FontSize.sm,
+  },
+  listSub: {
+    fontSize: FontSize.xs,
+  },
+  closeButton: {
+    marginTop: Spacing.md,
+    paddingVertical: Spacing.md,
+    borderRadius: BorderRadius.lg,
+    backgroundColor: Colors.primary,
+    alignItems: 'center',
+  },
+  closeButtonText: {
+    color: '#fff',
+    fontSize: FontSize.md,
+    fontWeight: FontWeight.semibold,
+  },
+});

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -8,6 +8,7 @@ import SoundManager from '@services/SoundManager';
 import Colors from '../constants/Colors';
 import { Spacing, FontSize, FontWeight, BorderRadius } from '../constants/Layout';
 import ParentalGate from './ParentalGate';
+import ParentDashboard from './ParentDashboard';
 
 interface SettingsModalProps {
   visible: boolean;
@@ -28,6 +29,8 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
   const [soundEnabled, setSoundEnabled] = useState(true);
   const [parentalGateVisible, setParentalGateVisible] = useState(false);
   const [pendingUrl, setPendingUrl] = useState<string | null>(null);
+  const [showParentDashboard, setShowParentDashboard] = useState(false);
+  const [pendingAction, setPendingAction] = useState<null | (() => void)>(null);
 
   useEffect(() => {
     setCurrentLang(getLanguage());
@@ -77,6 +80,12 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
 
   const handleParentalGateSuccess = async () => {
     setParentalGateVisible(false);
+    if (pendingAction) {
+      const action = pendingAction;
+      setPendingAction(null);
+      action();
+      return;
+    }
     if (!pendingUrl) return;
     const url = pendingUrl;
     setPendingUrl(null);
@@ -98,6 +107,12 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
   const handleParentalGateCancel = () => {
     setParentalGateVisible(false);
     setPendingUrl(null);
+    setPendingAction(null);
+  };
+
+  const openParentDashboard = () => {
+    setPendingAction(() => () => setShowParentDashboard(true));
+    setParentalGateVisible(true);
   };
 
   const handleSendFeedback = async () => {
@@ -301,6 +316,7 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
       <View style={[styles.card, { backgroundColor: colors.surface }]}>
         <View style={styles.actionGrid}>
           {([
+            { id: 'parents',  label: t('parentDashboard.menuLabel'), icon: '👨‍👩‍👧', onPress: openParentDashboard },
             { id: 'feedback', label: t('settings.feedback'), icon: '✉️', onPress: handleSendFeedback },
             { id: 'support',  label: t('settings.support'),  icon: '☕',  onPress: handleSupport },
             { id: 'share',    label: t('settings.share'),    icon: '↗',   onPress: handleShareApp },
@@ -330,6 +346,7 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
       </View>
 
       {renderAboutModal()}
+      <ParentDashboard visible={showParentDashboard} onClose={() => setShowParentDashboard(false)} />
     </View>
   );
 

--- a/components/__tests__/HomeScreen.test.tsx
+++ b/components/__tests__/HomeScreen.test.tsx
@@ -53,6 +53,16 @@ jest.mock('../../components/AnimatedHero', () => {
   return { AnimatedHero: () => <View testID="animated-hero" /> };
 });
 
+jest.mock('../../components/OnboardingModal', () => {
+  const { View } = require('react-native');
+  return { __esModule: true, default: () => <View testID="onboarding-modal" /> };
+});
+
+jest.mock('../../services/OnboardingManager', () => ({
+  isOnboardingDone: jest.fn(async () => true),
+  markOnboardingDone: jest.fn(async () => {}),
+}));
+
 jest.mock('../../services/ThemeContext', () => ({
   useTheme: () => ({
     colors: {

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -40,8 +40,10 @@ Die folgenden Daten werden **ausschließlich lokal** auf Ihrem Gerät gespeicher
 |----------|-------|-------------|
 | Spielfortschritt | Speichern von freigeschalteten Leveln | Gerätespeicher |
 | Einstellungen | Sprache, Theme, Pinselgröße | Gerätespeicher |
+| Spielsessions | Datum, Dauer, Sterne, Level — für Eltern-Dashboard. Automatische Löschung nach 28 Tagen. | Gerätespeicher |
+| Onboarding-Flag | Merken, ob die Erst-Start-Tour abgeschlossen wurde | Gerätespeicher |
 
-**Wichtig:** Diese Daten verlassen niemals Ihr Gerät und werden nur zur Funktion der App verwendet.
+**Wichtig:** Diese Daten verlassen niemals Ihr Gerät und werden nur zur Funktion der App verwendet. Das Eltern-Dashboard (hinter Eltern-Sperre erreichbar) zeigt diese lokal gespeicherten Statistiken — es findet keine Übertragung statt.
 
 ### 2.2 Keine Berechtigungen erforderlich
 

--- a/docs/PRIVACY_POLICY_EN.md
+++ b/docs/PRIVACY_POLICY_EN.md
@@ -40,8 +40,10 @@ The following data is stored **exclusively locally** on your device:
 |-----------|---------|------------------|
 | Game Progress | Saving unlocked levels | Device storage |
 | Settings | Language, theme, brush size | Device storage |
+| Game Sessions | Date, duration, stars, level — for the Parent Dashboard. Auto-deleted after 28 days. | Device storage |
+| Onboarding flag | Remember whether the first-launch tour was completed | Device storage |
 
-**Important:** This data never leaves your device and is only used for app functionality.
+**Important:** This data never leaves your device and is only used for app functionality. The Parent Dashboard (reachable behind the Parental Gate) shows these locally-stored statistics — no transmission takes place.
 
 ### 2.2 No Permissions Required
 

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -167,5 +167,28 @@
     "placeholder": "Antwort eingeben",
     "confirm": "Öffnen",
     "wrongAnswer": "Falsche Antwort. Bitte versuche es erneut."
+  },
+  "onboarding": {
+    "skip": "Überspringen",
+    "next": "Weiter",
+    "start": "Los geht's!",
+    "step1": { "title": "Merken",   "desc": "Schau dir das Bild ein paar Sekunden gut an." },
+    "step2": { "title": "Zeichnen", "desc": "Versuche, es aus dem Gedächtnis nachzumalen." },
+    "step3": { "title": "Sterne",   "desc": "Vergleiche dein Werk und bekomme Sterne." }
+  },
+  "parentDashboard": {
+    "menuLabel": "Eltern-Bereich",
+    "title": "Eltern-Dashboard",
+    "subtitle": "Spielnutzung der letzten 4 Wochen",
+    "privacyHint": "Alle Daten bleiben lokal auf diesem Gerät.",
+    "loading": "Lade Statistiken…",
+    "empty": "Noch keine Spielsessions aufgezeichnet.",
+    "totalSessions": "Sessions",
+    "totalTime": "Gesamtzeit",
+    "avgStars": "Ø Sterne",
+    "streak": "Streak (akt./best.)",
+    "favoriteLevels": "Lieblings-Level",
+    "dailyBreakdown": "Pro Tag (letzte 14)",
+    "levelLine": "Level {{level}} · {{count}}× gespielt"
   }
 }

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -167,5 +167,28 @@
     "placeholder": "Enter answer",
     "confirm": "Open",
     "wrongAnswer": "Wrong answer. Please try again."
+  },
+  "onboarding": {
+    "skip": "Skip",
+    "next": "Next",
+    "start": "Let's go!",
+    "step1": { "title": "Remember", "desc": "Look at the picture carefully for a few seconds." },
+    "step2": { "title": "Draw",     "desc": "Try to draw it from memory." },
+    "step3": { "title": "Stars",    "desc": "Compare your drawing and earn stars." }
+  },
+  "parentDashboard": {
+    "menuLabel": "Parent Area",
+    "title": "Parent Dashboard",
+    "subtitle": "Game usage over the last 4 weeks",
+    "privacyHint": "All data stays local on this device.",
+    "loading": "Loading stats…",
+    "empty": "No game sessions recorded yet.",
+    "totalSessions": "Sessions",
+    "totalTime": "Total time",
+    "avgStars": "Avg. stars",
+    "streak": "Streak (curr./best)",
+    "favoriteLevels": "Favorite levels",
+    "dailyBreakdown": "Per day (last 14)",
+    "levelLine": "Level {{level}} · played {{count}}×"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "expo-localization": "~55.0.8",
         "expo-router": "~55.0.5",
         "expo-status-bar": "~55.0.4",
+        "lottie-react-native": "~7.3.4",
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "react-native": "0.83.2",
@@ -9983,6 +9984,26 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lottie-react-native": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/lottie-react-native/-/lottie-react-native-7.3.8.tgz",
+      "integrity": "sha512-GAOl99TKi0c6xCcB1AJ+o70mgOPIAI/7K2G+Gs+o4po/qBhgvWijPNCKH8h6yNmlwFTg+RN3DmzRvHNFGxZMKQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@lottiefiles/dotlottie-react": "^0.13.5",
+        "react": "*",
+        "react-native": ">=0.46",
+        "react-native-windows": ">=0.63.x"
+      },
+      "peerDependenciesMeta": {
+        "@lottiefiles/dotlottie-react": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/lru-cache": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "expo-localization": "~55.0.8",
     "expo-router": "~55.0.5",
     "expo-status-bar": "~55.0.4",
+    "lottie-react-native": "~7.3.4",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.2",

--- a/public/privacy-policy-en.html
+++ b/public/privacy-policy-en.html
@@ -162,8 +162,18 @@
                 <td>Language, theme, brush size</td>
                 <td>Device storage</td>
             </tr>
+            <tr>
+                <td>Game Sessions</td>
+                <td>Date, duration, stars, level — for the Parent Dashboard. Auto-deleted after 28 days.</td>
+                <td>Device storage</td>
+            </tr>
+            <tr>
+                <td>Onboarding flag</td>
+                <td>Remember whether the first-launch tour was completed</td>
+                <td>Device storage</td>
+            </tr>
         </table>
-        <p><strong>Important:</strong> This data never leaves your device and is only used for app functionality.</p>
+        <p><strong>Important:</strong> This data never leaves your device and is only used for app functionality. The Parent Dashboard (reachable behind the Parental Gate) shows these locally-stored statistics — no transmission takes place.</p>
 
         <h3>2.2 No Permissions Required</h3>
         <p>The app requires <strong>none</strong> of the following permissions:</p>

--- a/public/privacy-policy.html
+++ b/public/privacy-policy.html
@@ -162,8 +162,18 @@
                 <td>Sprache, Theme, Pinselgröße</td>
                 <td>Gerätespeicher</td>
             </tr>
+            <tr>
+                <td>Spielsessions</td>
+                <td>Datum, Dauer, Sterne, Level — für Eltern-Dashboard. Automatische Löschung nach 28 Tagen.</td>
+                <td>Gerätespeicher</td>
+            </tr>
+            <tr>
+                <td>Onboarding-Flag</td>
+                <td>Merken, ob die Erst-Start-Tour abgeschlossen wurde</td>
+                <td>Gerätespeicher</td>
+            </tr>
         </table>
-        <p><strong>Wichtig:</strong> Diese Daten verlassen niemals Ihr Gerät und werden nur zur Funktion der App verwendet.</p>
+        <p><strong>Wichtig:</strong> Diese Daten verlassen niemals Ihr Gerät und werden nur zur Funktion der App verwendet. Das Eltern-Dashboard (hinter Eltern-Sperre erreichbar) zeigt diese lokal gespeicherten Statistiken — es findet keine Übertragung statt.</p>
 
         <h3>2.2 Keine Berechtigungen erforderlich</h3>
         <p>Die App benötigt <strong>keine</strong> der folgenden Berechtigungen:</p>

--- a/services/OnboardingManager.ts
+++ b/services/OnboardingManager.ts
@@ -1,0 +1,38 @@
+/**
+ * OnboardingManager — Erst-Start-Tour-Flag
+ * Eigener AsyncStorage-Key, damit das typisierte AppSettings-Schema
+ * nicht aufgebohrt werden muss.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = '@merke_male:onboarding_done';
+const MEMORY: Record<string, string> = {};
+
+export async function isOnboardingDone(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (raw === '1') return true;
+    return MEMORY[STORAGE_KEY] === '1';
+  } catch {
+    return MEMORY[STORAGE_KEY] === '1';
+  }
+}
+
+export async function markOnboardingDone(): Promise<void> {
+  MEMORY[STORAGE_KEY] = '1';
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, '1');
+  } catch {
+    // in-memory fallback for web sessions
+  }
+}
+
+export async function resetOnboarding(): Promise<void> {
+  delete MEMORY[STORAGE_KEY];
+  try {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // best-effort
+  }
+}

--- a/services/SessionTracker.ts
+++ b/services/SessionTracker.ts
@@ -1,0 +1,171 @@
+/**
+ * SessionTracker — Lokale Spielsessions für Eltern-Dashboard (Issue #188)
+ *
+ * Speichert pro abgeschlossener Runde:
+ *   { date, durationMs, stars, levelId }
+ *
+ * Auto-Cleanup: Einträge älter als FOUR_WEEKS_MS (28 Tage) werden beim
+ * nächsten Zugriff entfernt. Daten verlassen das Gerät nicht.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = '@merke_male:sessions';
+export const FOUR_WEEKS_MS = 28 * 24 * 60 * 60 * 1000;
+const MAX_ENTRIES = 1000; // hard cap, defensiv
+
+export interface SessionRecord {
+  date: string;       // ISO timestamp
+  durationMs: number;
+  stars: number;      // 0..5
+  levelId: number;
+}
+
+export interface SessionStats {
+  totalSessions: number;
+  totalDurationMs: number;
+  averageStars: number;
+  favoriteLevels: { levelId: number; count: number }[]; // top 3
+  dailyBreakdown: { date: string; sessions: number; totalDurationMs: number; avgStars: number }[];
+}
+
+const MEMORY: Record<string, string> = {};
+
+function safeParse(raw: string | null | undefined): SessionRecord[] | null {
+  if (!raw) return null;
+  try {
+    const v = JSON.parse(raw);
+    return Array.isArray(v) ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+async function loadRaw(): Promise<SessionRecord[]> {
+  let raw: string | null = null;
+  try {
+    raw = await AsyncStorage.getItem(STORAGE_KEY);
+  } catch {
+    // fall through to in-memory
+  }
+  const parsed = safeParse(raw) ?? safeParse(MEMORY[STORAGE_KEY]) ?? [];
+  if (raw && safeParse(raw)) MEMORY[STORAGE_KEY] = raw;
+  return parsed;
+}
+
+async function saveRaw(records: SessionRecord[]): Promise<void> {
+  const raw = JSON.stringify(records);
+  MEMORY[STORAGE_KEY] = raw;
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, raw);
+  } catch {
+    // in-memory fallback
+  }
+}
+
+function pruneOld(records: SessionRecord[], now: number = Date.now()): SessionRecord[] {
+  const cutoff = now - FOUR_WEEKS_MS;
+  const fresh = records.filter((r) => {
+    const t = Date.parse(r.date);
+    return Number.isFinite(t) && t >= cutoff;
+  });
+  // Hard-cap (defensiv falls jemand sehr viel spielt)
+  return fresh.length > MAX_ENTRIES ? fresh.slice(-MAX_ENTRIES) : fresh;
+}
+
+export async function recordSession(record: Omit<SessionRecord, 'date'> & { date?: string }): Promise<void> {
+  try {
+    const records = await loadRaw();
+    const next: SessionRecord = {
+      date: record.date ?? new Date().toISOString(),
+      durationMs: Math.max(0, Math.floor(record.durationMs)),
+      stars: Math.max(0, Math.min(5, Math.floor(record.stars))),
+      levelId: Math.max(0, Math.floor(record.levelId)),
+    };
+    const pruned = pruneOld([...records, next]);
+    await saveRaw(pruned);
+  } catch {
+    // best-effort
+  }
+}
+
+export async function getSessions(now: number = Date.now()): Promise<SessionRecord[]> {
+  try {
+    const records = await loadRaw();
+    const pruned = pruneOld(records, now);
+    if (pruned.length !== records.length) {
+      // persistiere Cleanup
+      await saveRaw(pruned);
+    }
+    return pruned;
+  } catch {
+    return [];
+  }
+}
+
+export async function clearSessions(): Promise<void> {
+  delete MEMORY[STORAGE_KEY];
+  try {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // best-effort
+  }
+}
+
+function localDateKey(iso: string): string {
+  const d = new Date(iso);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export function computeStats(records: SessionRecord[]): SessionStats {
+  if (records.length === 0) {
+    return {
+      totalSessions: 0,
+      totalDurationMs: 0,
+      averageStars: 0,
+      favoriteLevels: [],
+      dailyBreakdown: [],
+    };
+  }
+  const totalSessions = records.length;
+  const totalDurationMs = records.reduce((sum, r) => sum + r.durationMs, 0);
+  const totalStars = records.reduce((sum, r) => sum + r.stars, 0);
+  const averageStars = totalStars / totalSessions;
+
+  // Favorite levels (top 3 by play count)
+  const levelCounts = new Map<number, number>();
+  records.forEach((r) => levelCounts.set(r.levelId, (levelCounts.get(r.levelId) ?? 0) + 1));
+  const favoriteLevels = Array.from(levelCounts.entries())
+    .map(([levelId, count]) => ({ levelId, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 3);
+
+  // Daily breakdown (chronological)
+  const dailyMap = new Map<string, { sessions: number; totalDurationMs: number; starsSum: number }>();
+  records.forEach((r) => {
+    const key = localDateKey(r.date);
+    const entry = dailyMap.get(key) ?? { sessions: 0, totalDurationMs: 0, starsSum: 0 };
+    entry.sessions += 1;
+    entry.totalDurationMs += r.durationMs;
+    entry.starsSum += r.stars;
+    dailyMap.set(key, entry);
+  });
+  const dailyBreakdown = Array.from(dailyMap.entries())
+    .map(([date, v]) => ({
+      date,
+      sessions: v.sessions,
+      totalDurationMs: v.totalDurationMs,
+      avgStars: v.starsSum / v.sessions,
+    }))
+    .sort((a, b) => (a.date < b.date ? -1 : 1));
+
+  return { totalSessions, totalDurationMs, averageStars, favoriteLevels, dailyBreakdown };
+}
+
+export async function getSessionStats(): Promise<SessionStats> {
+  const records = await getSessions();
+  return computeStats(records);
+}

--- a/services/__tests__/OnboardingManager.test.ts
+++ b/services/__tests__/OnboardingManager.test.ts
@@ -1,0 +1,46 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { isOnboardingDone, markOnboardingDone, resetOnboarding } from '../OnboardingManager';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+const mockStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+describe('OnboardingManager', () => {
+  beforeEach(async () => {
+    mockStorage.getItem.mockReset();
+    mockStorage.setItem.mockReset();
+    mockStorage.removeItem.mockReset();
+    mockStorage.getItem.mockResolvedValue(null);
+    await resetOnboarding();
+  });
+
+  it('returns false when nothing is stored', async () => {
+    expect(await isOnboardingDone()).toBe(false);
+  });
+
+  it('returns true after markOnboardingDone', async () => {
+    await markOnboardingDone();
+    mockStorage.getItem.mockResolvedValue('1');
+    expect(await isOnboardingDone()).toBe(true);
+  });
+
+  it('persists the flag to AsyncStorage', async () => {
+    await markOnboardingDone();
+    expect(mockStorage.setItem).toHaveBeenCalledWith('@merke_male:onboarding_done', '1');
+  });
+
+  it('falls back to in-memory when AsyncStorage throws', async () => {
+    mockStorage.setItem.mockRejectedValueOnce(new Error('storage offline'));
+    await markOnboardingDone();
+    // getItem will return null but in-memory cache should still report done
+    mockStorage.getItem.mockResolvedValue(null);
+    expect(await isOnboardingDone()).toBe(true);
+  });
+});

--- a/services/__tests__/SessionTracker.test.ts
+++ b/services/__tests__/SessionTracker.test.ts
@@ -1,0 +1,115 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  recordSession,
+  getSessions,
+  clearSessions,
+  computeStats,
+  getSessionStats,
+  FOUR_WEEKS_MS,
+} from '../SessionTracker';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+const mockStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+describe('SessionTracker', () => {
+  beforeEach(async () => {
+    mockStorage.getItem.mockReset();
+    mockStorage.setItem.mockReset();
+    mockStorage.removeItem.mockReset();
+    mockStorage.getItem.mockResolvedValue(null);
+    await clearSessions();
+  });
+
+  it('records a session and reads it back', async () => {
+    await recordSession({ durationMs: 30_000, stars: 4, levelId: 3 });
+    // simulate storage returning the just-saved value
+    const saved = mockStorage.setItem.mock.calls[0][1];
+    mockStorage.getItem.mockResolvedValue(saved);
+    const sessions = await getSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({ durationMs: 30_000, stars: 4, levelId: 3 });
+  });
+
+  it('prunes entries older than 4 weeks on read', async () => {
+    const now = Date.now();
+    const old = new Date(now - FOUR_WEEKS_MS - 60_000).toISOString();
+    const fresh = new Date(now - 5_000).toISOString();
+    mockStorage.getItem.mockResolvedValue(JSON.stringify([
+      { date: old,   durationMs: 10_000, stars: 3, levelId: 1 },
+      { date: fresh, durationMs: 20_000, stars: 5, levelId: 2 },
+    ]));
+    const sessions = await getSessions(now);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].levelId).toBe(2);
+  });
+
+  it('clamps stars to 0..5 and durationMs to >= 0', async () => {
+    await recordSession({ durationMs: -10, stars: 99, levelId: 1 });
+    const saved = JSON.parse(mockStorage.setItem.mock.calls[0][1]);
+    expect(saved[0].durationMs).toBe(0);
+    expect(saved[0].stars).toBe(5);
+  });
+
+  it('recovers from corrupt JSON gracefully', async () => {
+    mockStorage.getItem.mockResolvedValue('{not-valid-json');
+    const sessions = await getSessions();
+    expect(sessions).toEqual([]);
+  });
+
+  describe('computeStats', () => {
+    it('returns empty stats for no records', () => {
+      const s = computeStats([]);
+      expect(s.totalSessions).toBe(0);
+      expect(s.favoriteLevels).toEqual([]);
+      expect(s.dailyBreakdown).toEqual([]);
+    });
+
+    it('computes totals and averages', () => {
+      const s = computeStats([
+        { date: '2026-05-01T10:00:00.000Z', durationMs: 60_000, stars: 5, levelId: 1 },
+        { date: '2026-05-01T11:00:00.000Z', durationMs: 30_000, stars: 3, levelId: 1 },
+        { date: '2026-05-02T12:00:00.000Z', durationMs: 90_000, stars: 4, levelId: 2 },
+      ]);
+      expect(s.totalSessions).toBe(3);
+      expect(s.totalDurationMs).toBe(180_000);
+      expect(s.averageStars).toBeCloseTo((5 + 3 + 4) / 3, 5);
+    });
+
+    it('returns top 3 favorite levels by play count', () => {
+      const records = [
+        ...Array(5).fill({ date: '2026-05-01T10:00:00.000Z', durationMs: 0, stars: 0, levelId: 1 }),
+        ...Array(3).fill({ date: '2026-05-01T10:00:00.000Z', durationMs: 0, stars: 0, levelId: 2 }),
+        ...Array(2).fill({ date: '2026-05-01T10:00:00.000Z', durationMs: 0, stars: 0, levelId: 3 }),
+        ...Array(1).fill({ date: '2026-05-01T10:00:00.000Z', durationMs: 0, stars: 0, levelId: 4 }),
+      ];
+      const s = computeStats(records);
+      expect(s.favoriteLevels.map((f) => f.levelId)).toEqual([1, 2, 3]);
+      expect(s.favoriteLevels[0].count).toBe(5);
+    });
+
+    it('produces chronological daily breakdown', () => {
+      const s = computeStats([
+        { date: '2026-05-02T10:00:00.000Z', durationMs: 60_000, stars: 5, levelId: 1 },
+        { date: '2026-05-01T10:00:00.000Z', durationMs: 30_000, stars: 3, levelId: 1 },
+      ]);
+      expect(s.dailyBreakdown.map((d) => d.date)).toEqual(['2026-05-01', '2026-05-02']);
+    });
+  });
+
+  it('getSessionStats integrates loading + computing', async () => {
+    mockStorage.getItem.mockResolvedValue(JSON.stringify([
+      { date: new Date().toISOString(), durationMs: 60_000, stars: 5, levelId: 1 },
+    ]));
+    const s = await getSessionStats();
+    expect(s.totalSessions).toBe(1);
+    expect(s.averageStars).toBe(5);
+  });
+});

--- a/services/useGamePhase.ts
+++ b/services/useGamePhase.ts
@@ -6,6 +6,7 @@ import { getImageElementCount } from '@components/LevelImageDisplay';
 import storageManager from '@services/StorageManager';
 import { markTodayCompleted } from '@services/DailyChallengeManager';
 import { updateStreakAfterGame } from '@services/StreakManager';
+import { recordSession } from '@services/SessionTracker';
 import SoundManager from '@services/SoundManager';
 import { useTimer } from '@services/useTimer';
 import type { DrawingPath } from '@components/DrawingCanvas';
@@ -39,6 +40,7 @@ export function useGamePhase({
   const timerExpireTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const replayCompleteTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const currentImageRef = useRef<LevelImage | null>(null);
+  const levelStartedAtRef = useRef<number>(Date.now());
 
   const [extraTimeMode, setExtraTimeMode] = useState(false);
 
@@ -73,6 +75,7 @@ export function useGamePhase({
       const image = getRandomImageForLevel(levelNumber);
       currentImageRef.current = image;
       setCurrentImage(image);
+      levelStartedAtRef.current = Date.now();
     } catch (error) {
       console.error('Error initializing level:', error);
       router.back();
@@ -171,6 +174,11 @@ export function useGamePhase({
       setUserRating(rating);
       await storageManager.saveLevelProgress(levelNumber, rating);
       await updateStreakAfterGame();
+      await recordSession({
+        durationMs: Date.now() - levelStartedAtRef.current,
+        stars: rating,
+        levelId: levelNumber,
+      });
       if (dailyChallengeLevel !== null && levelNumber === dailyChallengeLevel) {
         await markTodayCompleted();
       }


### PR DESCRIPTION
## Sprint D: Polish & Eltern-Feature 👨‍👩‍👧

Schließt #187 (Onboarding) und #188 (Eltern-Dashboard) — Sprint D aus Roadmap #189.

> **Hinweis**: Kein Version-Bump in diesem PR (User entscheidet wann/auf welche Zahl, siehe Memory-Regel).

## Was wurde umgesetzt

### #187 — Animiertes Onboarding (3-Step-Tour)
- `components/OnboardingModal.tsx` mit horizontalem ScrollView-Pager + ProgressDots
- 3 Steps: 👀 **Merken** · ✏️ **Zeichnen** · ⭐ **Sterne**
- Pulsierendes Emoji pro Step via Reanimated (`scale 1.0 ↔ 1.15`, 1.8s)
- `prefers-reduced-motion` → Animationen aus, statische Anzeige
- "Überspringen" oben rechts, "Weiter" → "Los geht's!" auf letztem Step
- Erst-Start-Trigger: wird auf Home gezeigt wenn `isOnboardingDone() === false`
- `services/OnboardingManager.ts` mit eigenem Storage-Key (`@merke_male:onboarding_done`)
  statt das typisierte `AppSettings`-Schema aufzubohren
- `lottie-react-native` installiert (verfügbar für künftige .lottie-Assets — kein Asset in diesem PR)

### #188 — Eltern-Dashboard
- `services/SessionTracker.ts`:
  - `SessionRecord { date, durationMs, stars, levelId }` per `recordSession()`
  - Auto-Cleanup nach `FOUR_WEEKS_MS` (28 Tage) bei jedem Read+Write
  - Hard-Cap 1000 Einträge (defensiv)
  - Corrupt-JSON-Schutz (`safeParse`-Pattern wie StreakManager)
  - `computeStats()`: totalSessions, totalDurationMs, averageStars, top-3 favoriteLevels, chronologisches dailyBreakdown
- `components/ParentDashboard.tsx`: Bottom-Sheet-Modal mit:
  - 4 Stat-Cards: Sessions, Gesamtzeit, ⌀ Sterne, Streak (akt./best.)
  - Lieblings-Level-Liste (Top 3)
  - Tages-Aufstellung (letzte 14 Tage)
  - Prominenter Privacy-Hinweis: "Alle Daten bleiben lokal auf diesem Gerät."
- Integration: Eintrag "👨‍👩‍👧 Eltern-Bereich" in SettingsModal — hinter existierender ParentalGate (Multiplikations-Aufgabe) via neuer `pendingAction`-Mechanik (analog `pendingUrl`)
- `recordSession()` in `useGamePhase.handleRatingSubmit` eingebunden — Dauer vom Level-Start bis Rating

## Privacy-Policy

**Alle 5 Privacy-Files synchron aktualisiert** (wie in CLAUDE.md vorgeschrieben):
- `PRIVACY_POLICY.md` (root, EN)
- `docs/PRIVACY_POLICY.md` (DE)
- `docs/PRIVACY_POLICY_EN.md` (EN)
- `public/privacy-policy.html` (DE, gehostet)
- `public/privacy-policy-en.html` (EN, gehostet)

Neue Datentypen dokumentiert:
- **Spielsessions** (Datum, Dauer, Sterne, Level) — automatische Löschung nach 28 Tagen
- **Onboarding-Flag** (Boolean)

Beide werden ausschließlich lokal gespeichert, keine Übertragung.

## Tests

- **SessionTracker** (10 Tests): record/read, 28-Tage-Pruning, Star-/Duration-Clamping, corrupt-JSON-Recovery, computeStats (empty, totals, favoriteLevels, daily breakdown), integration
- **OnboardingManager** (5 Tests): default false, mark/read flow, AsyncStorage-Call, in-memory-Fallback bei Storage-Fehler
- **HomeScreen-Test** erweitert: OnboardingModal + OnboardingManager gemockt
- **311 Tests grün** (vorher 294 auf testing)

## i18n

- DE + EN: `onboarding.*` Namespace (skip, next, start, 3× step{1,2,3}.title/desc)
- DE + EN: `parentDashboard.*` Namespace (menuLabel, title, subtitle, privacyHint, loading, empty, totalSessions, totalTime, avgStars, streak, favoriteLevels, dailyBreakdown, levelLine)

## Definition of Done (#189)

- [x] Onboarding zeigt sich nur beim 1. Start (Flag in AsyncStorage)
- [x] "Überspringen" + "Weiter"-Flow funktioniert
- [x] Eltern-Dashboard nur über ParentalGate erreichbar
- [x] Eltern-Dashboard zeigt nur lokale Daten (kein Netzwerk-Code)
- [x] Auto-Cleanup älter als 28 Tage
- [x] Privacy-Policy in allen 5 Files aktualisiert
- [x] Tests + i18n (DE + EN)
- [x] `prefers-reduced-motion` respektiert (Onboarding-Pulse)

## Test plan

- [ ] `npm test` — alle Tests grün
- [ ] Web: Erste-App-Öffnung → Onboarding erscheint → 3 Steps durchwischen → "Los geht's!" schließt Modal
- [ ] Web: App neu öffnen → Onboarding erscheint **nicht** mehr
- [ ] Web: Settings → 👨‍👩‍👧 Eltern-Bereich → ParentalGate löst → Dashboard öffnet
- [ ] Web: Level spielen, Sterne vergeben → Dashboard zeigt Session
- [ ] Native: gleiche Prüfungen
- [ ] Accessibility: `prefers-reduced-motion` → Onboarding-Emoji statisch

Closes #187
Closes #188
Part of #189 (Sprint D)

## Hinweis zu Sprint C (PR #193)

Dieser PR baut **nicht** auf Sprint C auf — er startet von `testing`. Beim Merge nach #193 entstehen Konflikte in `app/index.tsx`, `components/SettingsModal.tsx`, `locales/*` (Settings-Grid-Items + parentalGate-Translations). Werden beim Merge des zweiten PRs aufgelöst.