### PR TITLE
release: testing → staging (Sprints A–D + CI-Trigger)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,9 +2,9 @@ name: CI/CD - Automated Quality Checks
 
 on:
   push:
-    branches: [main, staging]
+    branches: [main, staging, testing]
   pull_request:
-    branches: [main, staging]
+    branches: [main, staging, testing]
 
 # Security: Explicitly set minimal permissions
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 **Merke und Male** — Gedächtnistraining-App für Kinder (React Native / Expo).
 Spieler sehen ein Bild kurz, zeichnen es aus dem Gedächtnis, vergleichen das Ergebnis.
 
-- **Aktuell: v1.4.2** (package.json + app.json; versionCode 58)
+- **Aktuell: v1.5.1** (package.json + app.json; versionCode 59)
 - **Mindestanforderung Android: API 26 (Android 8.0 Oreo)** — Nexus 6 (max. API 25) wird nicht mehr unterstützt (Issue #172, geschlossen)
 - **Live Demo:** https://s540d.github.io/DrawFromMemory/
 - **Repo:** https://github.com/S540d/DrawFromMemory
@@ -139,6 +139,8 @@ npm run deploy:ghpages             # Deployment auf GitHub Pages
 
 **Branch-Strategie:** Feature-Branches → PR → `testing` (QA) → `staging` (Pre-Production) → `main` (Produktion).
 Die drei Branches `main`, `staging`, `testing` müssen immer existieren und dürfen nie gelöscht werden.
+
+> **⚠️ REGEL FÜR AI-ASSISTENTEN:** Merges auf `main` sind VERBOTEN ohne explizite schriftliche Freigabe durch den Nutzer in der aktuellen Konversation. Das gilt auch für `staging → main`. Immer nach `testing → staging` stoppen und auf Freigabe warten. `main` ist production — nur der Nutzer entscheidet, wann etwas dort landet.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 **Merke und Male** — Gedächtnistraining-App für Kinder (React Native / Expo).
 Spieler sehen ein Bild kurz, zeichnen es aus dem Gedächtnis, vergleichen das Ergebnis.
 
-- **Aktuell: v1.5.1** (package.json + app.json; versionCode 59)
+- **Aktuell: v1.6.1** (package.json + app.json; versionCode 63)
 - **Mindestanforderung Android: API 26 (Android 8.0 Oreo)** — Nexus 6 (max. API 25) wird nicht mehr unterstützt (Issue #172, geschlossen)
 - **Live Demo:** https://s540d.github.io/DrawFromMemory/
 - **Repo:** https://github.com/S540d/DrawFromMemory

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -14,6 +14,8 @@ Merke und Male is designed with privacy in mind. All game data is stored locally
 The following data is stored locally on your device:
 - Game progress (completed levels)
 - Settings preferences (language, theme)
+- Game sessions (date, duration, stars, level) — used by the Parent Dashboard, auto-deleted after 28 days
+- Onboarding completion flag
 - No personal identifying information
 - No user accounts or registration data
 

--- a/app.json
+++ b/app.json
@@ -43,7 +43,7 @@
       },
       "package": "com.s540d.merkeundmale",
       "permissions": [],
-      "versionCode": 59,
+      "versionCode": 60,
       "minSdkVersion": 26,
       "newArchEnabled": false,
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.s540d.merkeundmale",

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Merke und Male",
     "slug": "merke-und-male",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "platforms": [
       "ios",
       "android",
@@ -43,7 +43,7 @@
       },
       "package": "com.s540d.merkeundmale",
       "permissions": [],
-      "versionCode": 60,
+      "versionCode": 61,
       "minSdkVersion": 26,
       "newArchEnabled": false,
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.s540d.merkeundmale",

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Merke und Male",
     "slug": "merke-und-male",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "platforms": [
       "ios",
       "android",
@@ -43,7 +43,7 @@
       },
       "package": "com.s540d.merkeundmale",
       "permissions": [],
-      "versionCode": 62,
+      "versionCode": 63,
       "minSdkVersion": 26,
       "newArchEnabled": false,
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.s540d.merkeundmale",

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Merke und Male",
     "slug": "merke-und-male",
-    "version": "1.5.1",
+    "version": "1.6.0",
     "platforms": [
       "ios",
       "android",
@@ -43,7 +43,7 @@
       },
       "package": "com.s540d.merkeundmale",
       "permissions": [],
-      "versionCode": 61,
+      "versionCode": 62,
       "minSdkVersion": 26,
       "newArchEnabled": false,
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.s540d.merkeundmale",

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Merke und Male",
     "slug": "merke-und-male",
-    "version": "1.4.2",
+    "version": "1.5.0",
     "platforms": [
       "ios",
       "android",
@@ -43,7 +43,7 @@
       },
       "package": "com.s540d.merkeundmale",
       "permissions": [],
-      "versionCode": 58,
+      "versionCode": 59,
       "minSdkVersion": 26,
       "newArchEnabled": false,
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.s540d.merkeundmale",

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -1,21 +1,30 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Alert, Modal, Platform, ScrollView, FlatList } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useScreenLayout } from '@utils/useScreenLayout';
 import { useRouter, useLocalSearchParams } from 'expo-router';
-import { getTotalLevels } from '@services/LevelManager';
+import { getTotalLevels, getDifficultyForLevel } from '@services/LevelManager';
 import { useTranslation, getLanguage } from '@services/i18n';
 import { useTheme } from '@services/ThemeContext';
 import { DrawingColors } from '../constants/Colors';
 import Colors from '../constants/Colors';
 import { Spacing, FontSize, FontWeight, BorderRadius } from '../constants/Layout';
+import { FeatureFlags } from '../constants/featureFlags';
 import LevelImageDisplay from '@components/LevelImageDisplay';
 import DrawingCanvas, { useDrawingCanvas } from '@components/DrawingCanvas';
 import SettingsModal from '@components/SettingsModal';
 import { ErrorBoundary } from '@components/ErrorBoundary';
 import { AnimatedFeedback, AnimatedStar } from '@components/AnimatedPrimitives';
+import ConfettiBurst from '@components/ConfettiBurst';
+import BadgeUnlockToast from '@components/BadgeUnlockToast';
 import SoundManager from '@services/SoundManager';
 import { useGamePhase } from '@services/useGamePhase';
+import {
+  checkAndUnlock,
+  type AchievementDef,
+} from '@services/AchievementManager';
+import { getStreakData } from '@services/StreakManager';
+import storageManager from '@services/StorageManager';
 import type { DrawingPath } from '@components/DrawingCanvas';
 
 /**
@@ -35,6 +44,10 @@ export default function GameScreen() {
   const [showSettings, setShowSettings] = useState(false);
   const [showHintModal, setShowHintModal] = useState(false);
   const [hasUsedHint, setHasUsedHint] = useState(false);
+  const [showConfetti, setShowConfetti] = useState(false);
+  const [unlockedBadge, setUnlockedBadge] = useState<AchievementDef | null>(null);
+  const lastCheckedRatingRef = React.useRef<number>(0);
+  const handleBadgeToastHide = useCallback(() => setUnlockedBadge(null), []);
 
   // Drawing Canvas Hook
   const drawing = useDrawingCanvas();
@@ -97,6 +110,53 @@ export default function GameScreen() {
   useEffect(() => {
     SoundManager.init();
   }, []);
+
+  // Trigger confetti + achievement check on each new rating (run once per rating value)
+  useEffect(() => {
+    if (userRating === 0 || userRating === lastCheckedRatingRef.current) return;
+    lastCheckedRatingRef.current = userRating;
+
+    if (userRating === 5 && FeatureFlags.ENABLE_CONFETTI) {
+      setShowConfetti(true);
+      const t = setTimeout(() => setShowConfetti(false), 2700);
+      // not awaited — best-effort
+      checkAchievements(userRating);
+      return () => clearTimeout(t);
+    }
+    checkAchievements(userRating);
+  }, [userRating]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const checkAchievements = async (rating: number) => {
+    try {
+      const [gallery, progress, streak] = await Promise.all([
+        storageManager.getGallery(),
+        storageManager.getProgress(),
+        getStreakData(),
+      ]);
+      // Derive daily-challenge count from gallery (saved daily entries are flagged)
+      const dailyChallengesCompleted = gallery.filter((g) => g.isDailyChallenge).length;
+      // Derive distinct difficulties played from completed levels
+      const difficultiesPlayed = Array.from(
+        new Set(
+          Object.keys(progress.levels ?? {})
+            .map((n) => parseInt(n, 10))
+            .filter((n) => !isNaN(n))
+            .map((n) => getDifficultyForLevel(n)),
+        ),
+      );
+      const newly = await checkAndUnlock({
+        stars: rating,
+        galleryCount: gallery.length,
+        currentStreak: streak.currentStreak,
+        levelsCompleted: progress.totalLevelsCompleted ?? 0,
+        dailyChallengesCompleted,
+        difficultiesPlayed,
+      });
+      if (newly.length > 0) setUnlockedBadge(newly[0]);
+    } catch {
+      // best-effort
+    }
+  };
 
   // Memoized dynamic styles – stable across re-renders unless layout changes
   const dynCanvasContainer = useMemo(() => ({
@@ -546,6 +606,14 @@ export default function GameScreen() {
       {phase === 'memorize' && renderMemorizePhase()}
       {phase === 'draw' && renderDrawPhase()}
       {phase === 'result' && renderResultPhase()}
+
+      {/* Delight overlays (Sprint C) */}
+      {phase === 'result' && (
+        <View pointerEvents="none" style={StyleSheet.absoluteFill}>
+          <ConfettiBurst width={screenWidth} height={layout.canvasMaxHeight + 200} active={showConfetti} />
+        </View>
+      )}
+      <BadgeUnlockToast achievement={unlockedBadge} onHide={handleBadgeToastHide} />
     </View>
   );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -10,9 +10,11 @@ import {
   getSecondsUntilMidnight,
   isTodayCompleted,
 } from '@services/DailyChallengeManager';
+import { getStreakData } from '@services/StreakManager';
 import Colors from '../constants/Colors';
 import { Spacing, FontSize, FontWeight, FontFamily, BorderRadius } from '../constants/Layout';
 import SettingsModal from '@components/SettingsModal';
+import QuickStatsCards from '@components/QuickStatsCards';
 import { FloatingStars } from '@components/FloatingStars';
 import { AnimatedHero } from '@components/AnimatedHero';
 
@@ -25,6 +27,7 @@ export default function HomeScreen() {
   const [dailyCompleted, setDailyCompleted] = useState(false);
   const [secondsLeft, setSecondsLeft] = useState(() => getSecondsUntilMidnight());
   const [dailyLevel, setDailyLevel] = useState(() => getDailyChallengeLevel());
+  const [currentStreak, setCurrentStreak] = useState(0);
 
   // On focus: refresh all daily state and start countdown interval.
   // Interval also re-checks state every minute to handle midnight rollover
@@ -34,7 +37,12 @@ export default function HomeScreen() {
       const refresh = async () => {
         setSecondsLeft(getSecondsUntilMidnight());
         setDailyLevel(getDailyChallengeLevel());
-        setDailyCompleted(await isTodayCompleted());
+        const [completed, streakData] = await Promise.all([
+          isTodayCompleted(),
+          getStreakData(),
+        ]);
+        setDailyCompleted(completed);
+        setCurrentStreak(streakData.currentStreak);
       };
       refresh();
 
@@ -56,13 +64,20 @@ export default function HomeScreen() {
           <Text style={[styles.appTitle, { color: colors.text.primary }]}>{t('app.name')}</Text>
           <Text style={[styles.appTagline, { color: colors.text.secondary }]}>{t('home.subtitle')}</Text>
         </View>
-        <Pressable
-          onPress={() => setShowSettings(true)}
-          style={styles.settingsButton}
-          aria-label="Settings"
-        >
-          <Text style={[styles.settingsIcon, { color: colors.text.primary }]}>⋮</Text>
-        </Pressable>
+        <View style={styles.topBarRight}>
+          {currentStreak >= 2 && (
+            <View style={styles.streakBadge}>
+              <Text style={styles.streakBadgeText}>{t('home.streakBadge', { count: String(currentStreak) })}</Text>
+            </View>
+          )}
+          <Pressable
+            onPress={() => setShowSettings(true)}
+            style={styles.settingsButton}
+            aria-label="Settings"
+          >
+            <Text style={[styles.settingsIcon, { color: colors.text.primary }]}>⋮</Text>
+          </Pressable>
+        </View>
       </View>
 
       {/* Center hero */}
@@ -70,6 +85,9 @@ export default function HomeScreen() {
         <AnimatedHero />
         <Text style={[styles.heroTitle, { color: colors.text.primary }]}>{t('home.title')}</Text>
       </View>
+
+      {/* Quick Stats */}
+      <QuickStatsCards />
 
       {/* Buttons */}
       <View style={styles.buttonContainer}>
@@ -145,6 +163,23 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'flex-start',
+  },
+  topBarRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xs,
+  },
+  streakBadge: {
+    backgroundColor: '#FF6B35',
+    borderRadius: BorderRadius.round,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 3,
+  },
+  streakBadgeText: {
+    color: '#fff',
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.bold,
+    fontFamily: FontFamily.bold,
   },
   appTitle: {
     fontSize: FontSize.xl,

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { View, Text, StyleSheet, Pressable, TouchableOpacity } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter, useFocusEffect } from 'expo-router';
@@ -17,6 +17,8 @@ import SettingsModal from '@components/SettingsModal';
 import QuickStatsCards from '@components/QuickStatsCards';
 import { FloatingStars } from '@components/FloatingStars';
 import { AnimatedHero } from '@components/AnimatedHero';
+import OnboardingModal from '@components/OnboardingModal';
+import { isOnboardingDone } from '@services/OnboardingManager';
 
 export default function HomeScreen() {
   const { t } = useTranslation();
@@ -24,7 +26,14 @@ export default function HomeScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const [showSettings, setShowSettings] = useState(false);
+  const [showOnboarding, setShowOnboarding] = useState(false);
   const [dailyCompleted, setDailyCompleted] = useState(false);
+
+  useEffect(() => {
+    isOnboardingDone().then((done) => {
+      if (!done) setShowOnboarding(true);
+    });
+  }, []);
   const [secondsLeft, setSecondsLeft] = useState(() => getSecondsUntilMidnight());
   const [dailyLevel, setDailyLevel] = useState(() => getDailyChallengeLevel());
   const [currentStreak, setCurrentStreak] = useState(0);
@@ -149,6 +158,7 @@ export default function HomeScreen() {
       </View>
 
       <SettingsModal visible={showSettings} onClose={() => setShowSettings(false)} />
+      <OnboardingModal visible={showOnboarding} onClose={() => setShowOnboarding(false)} />
     </View>
   );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -13,6 +13,8 @@ import {
 import Colors from '../constants/Colors';
 import { Spacing, FontSize, FontWeight, FontFamily, BorderRadius } from '../constants/Layout';
 import SettingsModal from '@components/SettingsModal';
+import { FloatingStars } from '@components/FloatingStars';
+import { AnimatedHero } from '@components/AnimatedHero';
 
 export default function HomeScreen() {
   const { t } = useTranslation();
@@ -46,6 +48,7 @@ export default function HomeScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top + Spacing.sm, paddingBottom: insets.bottom + Spacing.lg }]}>
+      <FloatingStars />
 
       {/* Top bar */}
       <View style={styles.topBar}>
@@ -64,7 +67,7 @@ export default function HomeScreen() {
 
       {/* Center hero */}
       <View style={styles.hero}>
-        <Text style={styles.heroEmoji}>🧠✏️</Text>
+        <AnimatedHero />
         <Text style={[styles.heroTitle, { color: colors.text.primary }]}>{t('home.title')}</Text>
       </View>
 
@@ -169,9 +172,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     gap: Spacing.lg,
-  },
-  heroEmoji: {
-    fontSize: 72,
   },
   heroTitle: {
     fontSize: FontSize.display,

--- a/app/levels.tsx
+++ b/app/levels.tsx
@@ -9,6 +9,7 @@ import Colors from '../constants/Colors';
 import { Spacing, FontSize, FontWeight, FontFamily, BorderRadius } from '../constants/Layout';
 import { GlassCard } from '@components/AnimatedPrimitives';
 import { Badge } from '@components/Badge';
+import { FloatingStars } from '@components/FloatingStars';
 
 // Default card width for SSR (will be recalculated on client)
 const DEFAULT_CARD_WIDTH = 150;
@@ -98,6 +99,7 @@ export default function LevelsScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <FloatingStars />
       {/* Header */}
       <View style={[styles.header, { borderBottomColor: colors.surface }]}>
         <TouchableOpacity onPress={() => router.back()}>

--- a/components/AnimatedHero.tsx
+++ b/components/AnimatedHero.tsx
@@ -1,0 +1,127 @@
+import React, { useEffect } from 'react';
+import { AccessibilityInfo, StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+
+/**
+ * Animated hero element for the Home Screen.
+ * Shows brain + pencil emojis with looping animations.
+ * Respects prefers-reduced-motion: static emoji fallback when enabled.
+ */
+export function AnimatedHero() {
+  const brainScale       = useSharedValue(1);
+  const pencilRotate     = useSharedValue(0);
+  const pencilTranslateX = useSharedValue(0);
+  const sparkleOpacity   = useSharedValue(0.2);
+
+  useEffect(() => {
+    let cancelled = false;
+    AccessibilityInfo.isReduceMotionEnabled().then((rm) => {
+      if (cancelled || rm) return;
+
+      brainScale.value = withRepeat(
+        withSequence(
+          withTiming(1.08, { duration: 900, easing: Easing.inOut(Easing.ease) }),
+          withTiming(1.0,  { duration: 900, easing: Easing.inOut(Easing.ease) }),
+        ),
+        -1,
+        false
+      );
+
+      pencilRotate.value = withRepeat(
+        withSequence(
+          withTiming(-10, { duration: 600, easing: Easing.inOut(Easing.ease) }),
+          withTiming( 10, { duration: 600, easing: Easing.inOut(Easing.ease) }),
+        ),
+        -1,
+        false
+      );
+
+      pencilTranslateX.value = withRepeat(
+        withSequence(
+          withTiming(-6, { duration: 600, easing: Easing.inOut(Easing.ease) }),
+          withTiming( 6, { duration: 600, easing: Easing.inOut(Easing.ease) }),
+        ),
+        -1,
+        false
+      );
+
+      sparkleOpacity.value = withRepeat(
+        withSequence(
+          withTiming(1,   { duration: 1200, easing: Easing.inOut(Easing.ease) }),
+          withTiming(0.2, { duration: 1200, easing: Easing.inOut(Easing.ease) }),
+        ),
+        -1,
+        false
+      );
+    });
+    return () => { cancelled = true; };
+  }, [brainScale, pencilRotate, pencilTranslateX, sparkleOpacity]);
+
+  const brainAnimStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: brainScale.value }],
+  }));
+
+  const pencilAnimStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: pencilTranslateX.value },
+      { rotate: `${pencilRotate.value}deg` },
+    ],
+  }));
+
+  const sparkleAnimStyle = useAnimatedStyle(() => ({
+    opacity: sparkleOpacity.value,
+  }));
+
+  return (
+    <View
+      style={styles.container}
+      testID="animated-hero"
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+    >
+      <View style={styles.row}>
+        <Animated.View style={brainAnimStyle}>
+          <Text style={styles.emoji}>🧠</Text>
+        </Animated.View>
+        <Animated.View style={pencilAnimStyle}>
+          <Text style={styles.emoji}>✏️</Text>
+        </Animated.View>
+      </View>
+      <Animated.View style={[styles.sparkleRow, sparkleAnimStyle]} pointerEvents="none">
+        <Text style={styles.sparkle}>✨</Text>
+        <Text style={styles.sparkle}>  </Text>
+        <Text style={styles.sparkle}>✨</Text>
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  emoji: {
+    fontSize: 68,
+  },
+  sparkleRow: {
+    flexDirection: 'row',
+    marginTop: 6,
+  },
+  sparkle: {
+    fontSize: 20,
+  },
+});
+
+export default AnimatedHero;

--- a/components/BadgeUnlockToast.tsx
+++ b/components/BadgeUnlockToast.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect } from 'react';
+import { AccessibilityInfo, StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+import { useTranslation } from '@services/i18n';
+import Colors from '../constants/Colors';
+import { BorderRadius, FontSize, FontWeight, Spacing } from '../constants/Layout';
+import type { AchievementDef } from '@services/AchievementManager';
+
+interface Props {
+  achievement: AchievementDef | null;
+  onHide: () => void;
+}
+
+const VISIBLE_MS = 2800;
+const FADE_MS = 280;
+
+/**
+ * Slide-in toast shown when a badge is unlocked.
+ * Auto-hides after VISIBLE_MS; respects prefers-reduced-motion (fade only, no slide).
+ */
+export default function BadgeUnlockToast({ achievement, onHide }: Props) {
+  const { t } = useTranslation();
+  const translateY = useSharedValue(-80);
+  const opacity = useSharedValue(0);
+
+  useEffect(() => {
+    if (!achievement) return;
+    let cancelled = false;
+
+    AccessibilityInfo.isReduceMotionEnabled().then((rm) => {
+      if (cancelled) return;
+      if (rm) {
+        translateY.value = 0;
+        opacity.value = withSequence(
+          withTiming(1, { duration: FADE_MS }),
+          withDelay(VISIBLE_MS, withTiming(0, { duration: FADE_MS })),
+        );
+      } else {
+        translateY.value = withSequence(
+          withTiming(0, { duration: FADE_MS, easing: Easing.out(Easing.ease) }),
+          withDelay(VISIBLE_MS, withTiming(-80, { duration: FADE_MS, easing: Easing.in(Easing.ease) })),
+        );
+        opacity.value = withSequence(
+          withTiming(1, { duration: FADE_MS }),
+          withDelay(VISIBLE_MS, withTiming(0, { duration: FADE_MS })),
+        );
+      }
+    });
+
+    const timer = setTimeout(onHide, VISIBLE_MS + FADE_MS * 2 + 50);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [achievement, translateY, opacity, onHide]);
+
+  const animStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }],
+    opacity: opacity.value,
+  }));
+
+  if (!achievement) return null;
+
+  return (
+    <Animated.View style={[styles.toast, animStyle]} pointerEvents="none" testID="badge-unlock-toast">
+      <Text style={styles.emoji}>{achievement.emoji}</Text>
+      <View style={styles.textCol}>
+        <Text style={styles.title} numberOfLines={1}>{t('achievements.unlocked')}</Text>
+        <Text style={styles.subtitle} numberOfLines={1}>{t(achievement.titleKey)}</Text>
+      </View>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  toast: {
+    position: 'absolute',
+    top: Spacing.lg,
+    left: Spacing.md,
+    right: Spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.lg,
+    backgroundColor: Colors.surface,
+    borderRadius: BorderRadius.xl,
+    borderWidth: 1.5,
+    borderColor: Colors.primary,
+    shadowColor: Colors.primary,
+    shadowOpacity: 0.25,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 6,
+    zIndex: 1000,
+  },
+  emoji: {
+    fontSize: 32,
+    marginRight: Spacing.md,
+  },
+  textCol: {
+    flex: 1,
+  },
+  title: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.bold,
+    color: Colors.primary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
+  subtitle: {
+    fontSize: FontSize.md,
+    fontWeight: FontWeight.semibold,
+    color: Colors.text.primary,
+    marginTop: 2,
+  },
+});

--- a/components/BadgesModal.tsx
+++ b/components/BadgesModal.tsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from '@services/i18n';
+import { useTheme } from '@services/ThemeContext';
+import {
+  ACHIEVEMENTS,
+  getUnlockedAchievements,
+  type AchievementId,
+} from '@services/AchievementManager';
+import Colors from '../constants/Colors';
+import { BorderRadius, FontSize, FontWeight, Spacing } from '../constants/Layout';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export default function BadgesModal({ visible, onClose }: Props) {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const [unlockedIds, setUnlockedIds] = useState<Set<AchievementId>>(new Set());
+
+  useEffect(() => {
+    if (!visible) return;
+    getUnlockedAchievements().then((list) => {
+      setUnlockedIds(new Set(list.map((u) => u.id)));
+    });
+  }, [visible]);
+
+  const unlockedCount = unlockedIds.size;
+  const total = ACHIEVEMENTS.length;
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+      <View style={styles.backdrop}>
+        <View style={[styles.sheet, { backgroundColor: colors.background }]}>
+          <View style={styles.header}>
+            <Text style={[styles.title, { color: colors.text.primary }]}>
+              {t('achievements.title')}
+            </Text>
+            <Text style={[styles.subtitle, { color: colors.text.secondary }]}>
+              {t('achievements.progress', { unlocked: String(unlockedCount), total: String(total) })}
+            </Text>
+          </View>
+
+          <ScrollView contentContainerStyle={styles.list}>
+            {ACHIEVEMENTS.map((a) => {
+              const isUnlocked = unlockedIds.has(a.id);
+              return (
+                <View
+                  key={a.id}
+                  style={[
+                    styles.row,
+                    {
+                      backgroundColor: colors.surface ?? Colors.surface,
+                      opacity: isUnlocked ? 1 : 0.45,
+                      borderColor: isUnlocked ? Colors.primary : 'transparent',
+                    },
+                  ]}
+                  testID={`badge-row-${a.id}`}
+                >
+                  <Text style={[styles.emoji, !isUnlocked && styles.grayscale]}>
+                    {isUnlocked ? a.emoji : '🔒'}
+                  </Text>
+                  <View style={styles.textCol}>
+                    <Text style={[styles.rowTitle, { color: colors.text.primary }]}>
+                      {t(a.titleKey)}
+                    </Text>
+                    <Text style={[styles.rowDesc, { color: colors.text.secondary }]}>
+                      {t(a.descKey)}
+                    </Text>
+                  </View>
+                </View>
+              );
+            })}
+          </ScrollView>
+
+          <Pressable onPress={onClose} style={styles.closeButton} testID="badges-modal-close">
+            <Text style={styles.closeButtonText}>{t('common.close')}</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    maxHeight: '85%',
+    borderTopLeftRadius: BorderRadius.xxl,
+    borderTopRightRadius: BorderRadius.xxl,
+    paddingTop: Spacing.lg,
+    paddingHorizontal: Spacing.md,
+    paddingBottom: Spacing.lg,
+  },
+  header: {
+    alignItems: 'center',
+    marginBottom: Spacing.md,
+  },
+  title: {
+    fontSize: FontSize.xl,
+    fontWeight: FontWeight.bold,
+  },
+  subtitle: {
+    fontSize: FontSize.sm,
+    marginTop: 4,
+  },
+  list: {
+    paddingBottom: Spacing.md,
+    gap: Spacing.sm,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: Spacing.md,
+    borderRadius: BorderRadius.lg,
+    borderWidth: 1.5,
+  },
+  emoji: {
+    fontSize: 36,
+    marginRight: Spacing.md,
+  },
+  grayscale: {
+    opacity: 0.6,
+  },
+  textCol: {
+    flex: 1,
+  },
+  rowTitle: {
+    fontSize: FontSize.md,
+    fontWeight: FontWeight.semibold,
+  },
+  rowDesc: {
+    fontSize: FontSize.sm,
+    marginTop: 2,
+  },
+  closeButton: {
+    marginTop: Spacing.md,
+    paddingVertical: Spacing.md,
+    borderRadius: BorderRadius.lg,
+    backgroundColor: Colors.primary,
+    alignItems: 'center',
+  },
+  closeButtonText: {
+    color: '#fff',
+    fontSize: FontSize.md,
+    fontWeight: FontWeight.semibold,
+  },
+});

--- a/components/ConfettiBurst.native.tsx
+++ b/components/ConfettiBurst.native.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { AccessibilityInfo, StyleSheet, View } from 'react-native';
+import { Canvas, Circle } from '@shopify/react-native-skia';
+import {
+  Easing,
+  useSharedValue,
+  useDerivedValue,
+  withDelay,
+  withTiming,
+} from 'react-native-reanimated';
+import {
+  buildParticles,
+  CONFETTI_DURATION_MS,
+  type ConfettiBurstProps,
+  type ConfettiParticle,
+} from './ConfettiBurst.shared';
+
+function Particle({ p, progress }: { p: ConfettiParticle; progress: { value: number } }) {
+  const cx = useDerivedValue(() => p.x + p.drift * progress.value);
+  const cy = useDerivedValue(() => p.startY + (p.endY - p.startY) * progress.value);
+  const opacity = useDerivedValue(() =>
+    progress.value < 0.85 ? 1 : 1 - (progress.value - 0.85) / 0.15,
+  );
+  return <Circle cx={cx} cy={cy} r={p.size / 2} color={p.color} opacity={opacity} />;
+}
+
+export function ConfettiBurst({ width, height, active }: ConfettiBurstProps) {
+  const [reduceMotion, setReduceMotion] = useState(false);
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    AccessibilityInfo.isReduceMotionEnabled().then((rm) => {
+      if (!cancelled) setReduceMotion(rm);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    if (!active || reduceMotion) {
+      progress.value = 0;
+      return;
+    }
+    progress.value = 0;
+    progress.value = withDelay(
+      0,
+      withTiming(1, { duration: CONFETTI_DURATION_MS, easing: Easing.out(Easing.cubic) }),
+    );
+  }, [active, reduceMotion, progress]);
+
+  const particles = useMemo(() => buildParticles(width, height, Math.floor(width + height)), [width, height]);
+
+  if (!active || reduceMotion) return null;
+
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="none" testID="confetti-burst">
+      <Canvas style={{ width, height }}>
+        {particles.map((p, i) => (
+          <Particle key={i} p={p} progress={progress} />
+        ))}
+      </Canvas>
+    </View>
+  );
+}
+
+export default ConfettiBurst;

--- a/components/ConfettiBurst.shared.ts
+++ b/components/ConfettiBurst.shared.ts
@@ -1,0 +1,50 @@
+import Colors from '../constants/Colors';
+
+export interface ConfettiBurstProps {
+  width: number;
+  height: number;
+  active: boolean;
+}
+
+export interface ConfettiParticle {
+  x: number;
+  startY: number;
+  endY: number;
+  color: string;
+  size: number;
+  drift: number;
+  duration: number;
+  delay: number;
+  rotation: number;
+}
+
+export const CONFETTI_DURATION_MS = 2500;
+export const CONFETTI_COUNT = 40;
+
+const CONFETTI_COLORS = [
+  Colors.gradient.cta[0],
+  Colors.gradient.cta[1],
+  Colors.stars.filled,
+  Colors.gradient.warm[0],
+  Colors.gradient.teal[0],
+];
+
+export function buildParticles(width: number, height: number, seed = 0): ConfettiParticle[] {
+  // simple deterministic PRNG so tests / SSR stay stable
+  let s = seed || 1;
+  const rand = () => {
+    s = (s * 1664525 + 1013904223) % 0xffffffff;
+    return s / 0xffffffff;
+  };
+  return Array.from({ length: CONFETTI_COUNT }, () => ({
+    x: rand() * width,
+    startY: -20 - rand() * 60,
+    endY: height + 40,
+    color: CONFETTI_COLORS[Math.floor(rand() * CONFETTI_COLORS.length)],
+    size: 6 + rand() * 6,
+    drift: (rand() - 0.5) * 80,
+    duration: 1800 + rand() * 700,
+    delay: rand() * 400,
+    rotation: rand() * 360,
+  }));
+}

--- a/components/ConfettiBurst.tsx
+++ b/components/ConfettiBurst.tsx
@@ -1,0 +1,3 @@
+// Platform dispatcher — Metro/Webpack pick `.native.tsx` or `.web.tsx`.
+export { ConfettiBurst as default } from './ConfettiBurst.native';
+export type { ConfettiBurstProps } from './ConfettiBurst.shared';

--- a/components/ConfettiBurst.web.tsx
+++ b/components/ConfettiBurst.web.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { AccessibilityInfo, StyleSheet, View } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import {
+  buildParticles,
+  CONFETTI_DURATION_MS,
+  type ConfettiBurstProps,
+  type ConfettiParticle,
+} from './ConfettiBurst.shared';
+
+function Particle({ p, progress }: { p: ConfettiParticle; progress: { value: number } }) {
+  const style = useAnimatedStyle(() => {
+    const t = progress.value;
+    return {
+      position: 'absolute',
+      left: p.x + p.drift * t,
+      top: p.startY + (p.endY - p.startY) * t,
+      width: p.size,
+      height: p.size,
+      borderRadius: p.size / 2,
+      backgroundColor: p.color,
+      opacity: t < 0.85 ? 1 : 1 - (t - 0.85) / 0.15,
+      transform: [{ rotate: `${p.rotation + t * 360}deg` }],
+    };
+  });
+  return <Animated.View style={style} />;
+}
+
+export function ConfettiBurst({ width, height, active }: ConfettiBurstProps) {
+  const [reduceMotion, setReduceMotion] = useState(false);
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    AccessibilityInfo.isReduceMotionEnabled().then((rm) => {
+      if (!cancelled) setReduceMotion(rm);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    if (!active || reduceMotion) {
+      progress.value = 0;
+      return;
+    }
+    progress.value = 0;
+    progress.value = withTiming(1, {
+      duration: CONFETTI_DURATION_MS,
+      easing: Easing.out(Easing.cubic),
+    });
+  }, [active, reduceMotion, progress]);
+
+  const particles = useMemo(() => buildParticles(width, height, Math.floor(width + height)), [width, height]);
+
+  if (!active || reduceMotion) return null;
+
+  return (
+    <View
+      style={[StyleSheet.absoluteFill, { width, height, overflow: 'hidden' }]}
+      pointerEvents="none"
+      testID="confetti-burst"
+    >
+      {particles.map((p, i) => (
+        <Particle key={i} p={p} progress={progress} />
+      ))}
+    </View>
+  );
+}
+
+export default ConfettiBurst;

--- a/components/FloatingStars.tsx
+++ b/components/FloatingStars.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from 'react';
+import { AccessibilityInfo, StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+import Colors from '../constants/Colors';
+
+interface DecorItem {
+  top: string;
+  left: string;
+  char: string;
+  size: number;
+  color: string;
+  opacity: number;
+  delay: number;
+  duration: number;
+  drift: number;
+}
+
+const DECOR_ITEMS: DecorItem[] = [
+  { top: '7%',  left: '4%',  char: '★', size: 18, color: Colors.primary,  opacity: 0.18, delay: 0,    duration: 4200, drift: 12 },
+  { top: '13%', left: '88%', char: '✦', size: 14, color: Colors.secondary, opacity: 0.15, delay: 700,  duration: 5100, drift: 8  },
+  { top: '32%', left: '3%',  char: '★', size: 12, color: Colors.primary,  opacity: 0.13, delay: 1400, duration: 4500, drift: 15 },
+  { top: '51%', left: '90%', char: '●', size: 10, color: Colors.secondary, opacity: 0.12, delay: 300,  duration: 5800, drift: 10 },
+  { top: '67%', left: '5%',  char: '✦', size: 16, color: Colors.primary,  opacity: 0.16, delay: 1100, duration: 4800, drift: 12 },
+  { top: '78%', left: '85%', char: '★', size: 14, color: Colors.secondary, opacity: 0.14, delay: 600,  duration: 5300, drift: 9  },
+  { top: '23%', left: '87%', char: '●', size: 9,  color: Colors.primary,  opacity: 0.11, delay: 1800, duration: 4000, drift: 14 },
+  { top: '61%', left: '77%', char: '★', size: 11, color: Colors.secondary, opacity: 0.13, delay: 900,  duration: 5600, drift: 11 },
+];
+
+function DecorElement({ item, animate }: { item: DecorItem; animate: boolean }) {
+  const translateY = useSharedValue(0);
+
+  useEffect(() => {
+    if (!animate) return;
+    translateY.value = withDelay(
+      item.delay,
+      withRepeat(
+        withSequence(
+          withTiming(-item.drift, { duration: item.duration / 2, easing: Easing.inOut(Easing.ease) }),
+          withTiming(0,           { duration: item.duration / 2, easing: Easing.inOut(Easing.ease) }),
+        ),
+        -1,
+        false
+      )
+    );
+  }, [animate, item, translateY]);
+
+  const animStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }],
+  }));
+
+  return (
+    <Animated.View
+      style={[
+        styles.item,
+        { top: item.top, left: item.left, opacity: item.opacity },
+        animStyle,
+      ]}
+      pointerEvents="none"
+      testID="floating-decor-item"
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+    >
+      <Text style={{ fontSize: item.size, color: item.color }} accessible={false}>
+        {item.char}
+      </Text>
+    </Animated.View>
+  );
+}
+
+export function FloatingStars() {
+  const [animate, setAnimate] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    AccessibilityInfo.isReduceMotionEnabled().then((rm) => {
+      if (!cancelled) setAnimate(!rm);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="none" testID="floating-stars">
+      {DECOR_ITEMS.map((item, i) => (
+        <DecorElement key={i} item={item} animate={animate} />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  item: {
+    position: 'absolute',
+  },
+});
+
+export default FloatingStars;

--- a/components/OnboardingModal.tsx
+++ b/components/OnboardingModal.tsx
@@ -1,0 +1,263 @@
+import React, { useEffect, useState } from 'react';
+import {
+  AccessibilityInfo,
+  Dimensions,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import Animated, {
+  cancelAnimation,
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+import { useTranslation } from '@services/i18n';
+import { useTheme } from '@services/ThemeContext';
+import { markOnboardingDone } from '@services/OnboardingManager';
+import Colors from '../constants/Colors';
+import { BorderRadius, FontSize, FontWeight, Spacing } from '../constants/Layout';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+}
+
+interface Step {
+  emoji: string;
+  titleKey: string;
+  descKey: string;
+}
+
+const STEPS: Step[] = [
+  { emoji: '👀', titleKey: 'onboarding.step1.title', descKey: 'onboarding.step1.desc' },
+  { emoji: '✏️', titleKey: 'onboarding.step2.title', descKey: 'onboarding.step2.desc' },
+  { emoji: '⭐', titleKey: 'onboarding.step3.title', descKey: 'onboarding.step3.desc' },
+];
+
+function PulsingEmoji({ char, animate }: { char: string; animate: boolean }) {
+  const scale = useSharedValue(1);
+  useEffect(() => {
+    if (!animate) {
+      cancelAnimation(scale);
+      scale.value = 1;
+      return;
+    }
+    scale.value = withRepeat(
+      withSequence(
+        withTiming(1.15, { duration: 900, easing: Easing.inOut(Easing.ease) }),
+        withTiming(1.0,  { duration: 900, easing: Easing.inOut(Easing.ease) }),
+      ),
+      -1,
+      false,
+    );
+    return () => {
+      cancelAnimation(scale);
+      scale.value = 1;
+    };
+  }, [animate, scale]);
+  const style = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));
+  return (
+    <Animated.View style={style}>
+      <Text style={styles.emoji}>{char}</Text>
+    </Animated.View>
+  );
+}
+
+export default function OnboardingModal({ visible, onClose }: Props) {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const [stepIndex, setStepIndex] = useState(0);
+  const [animate, setAnimate] = useState(true);
+  const { width } = Dimensions.get('window');
+  const scrollRef = React.useRef<ScrollView>(null);
+
+  useEffect(() => {
+    if (!visible) return;
+    let cancelled = false;
+    setStepIndex(0);
+    AccessibilityInfo.isReduceMotionEnabled().then((rm) => {
+      if (!cancelled) setAnimate(!rm);
+    });
+    return () => { cancelled = true; };
+  }, [visible]);
+
+  const handleNext = async () => {
+    if (stepIndex < STEPS.length - 1) {
+      const next = stepIndex + 1;
+      setStepIndex(next);
+      scrollRef.current?.scrollTo({ x: next * width, animated: animate });
+    } else {
+      await markOnboardingDone();
+      onClose();
+    }
+  };
+
+  const handleSkip = async () => {
+    await markOnboardingDone();
+    onClose();
+  };
+
+  const handleScroll = (e: { nativeEvent: { contentOffset: { x: number } } }) => {
+    const newIndex = Math.round(e.nativeEvent.contentOffset.x / width);
+    if (newIndex !== stepIndex && newIndex >= 0 && newIndex < STEPS.length) {
+      setStepIndex(newIndex);
+    }
+  };
+
+  return (
+    <Modal visible={visible} animationType="fade" onRequestClose={handleSkip} testID="onboarding-modal">
+      <View style={[styles.container, { backgroundColor: colors.background }]}>
+        <View style={styles.topBar}>
+          <Pressable
+            onPress={handleSkip}
+            style={styles.skipButton}
+            accessibilityRole="button"
+            accessibilityLabel={t('onboarding.skip')}
+            testID="onboarding-skip"
+          >
+            <Text style={[styles.skipText, { color: colors.text.secondary }]}>
+              {t('onboarding.skip')}
+            </Text>
+          </Pressable>
+        </View>
+
+        <ScrollView
+          ref={scrollRef}
+          horizontal
+          pagingEnabled
+          showsHorizontalScrollIndicator={false}
+          onMomentumScrollEnd={handleScroll}
+          style={styles.pager}
+          testID="onboarding-pager"
+        >
+          {STEPS.map((step, i) => (
+            <View key={step.titleKey} style={[styles.page, { width }]}>
+              <View style={styles.iconCircle}>
+                <PulsingEmoji char={step.emoji} animate={animate && i === stepIndex} />
+              </View>
+              <Text style={[styles.title, { color: colors.text.primary }]}>
+                {t(step.titleKey)}
+              </Text>
+              <Text style={[styles.desc, { color: colors.text.secondary }]}>
+                {t(step.descKey)}
+              </Text>
+            </View>
+          ))}
+        </ScrollView>
+
+        <View style={styles.dotsRow} testID="onboarding-dots">
+          {STEPS.map((_, i) => (
+            <View
+              key={i}
+              style={[
+                styles.dot,
+                i === stepIndex && styles.dotActive,
+              ]}
+            />
+          ))}
+        </View>
+
+        <Pressable
+          onPress={handleNext}
+          style={styles.nextButton}
+          accessibilityRole="button"
+          testID="onboarding-next"
+        >
+          <Text style={styles.nextButtonText}>
+            {stepIndex < STEPS.length - 1 ? t('onboarding.next') : t('onboarding.start')}
+          </Text>
+        </Pressable>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: Spacing.xxl,
+    paddingBottom: Spacing.lg,
+  },
+  topBar: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    paddingHorizontal: Spacing.lg,
+  },
+  skipButton: {
+    padding: Spacing.sm,
+  },
+  skipText: {
+    fontSize: FontSize.md,
+    fontWeight: FontWeight.semibold,
+  },
+  pager: {
+    flexGrow: 0,
+  },
+  page: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: Spacing.xl,
+    paddingVertical: Spacing.xxl,
+  },
+  iconCircle: {
+    width: 160,
+    height: 160,
+    borderRadius: 80,
+    backgroundColor: Colors.primary + '15',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: Spacing.xl,
+  },
+  emoji: {
+    fontSize: 96,
+  },
+  title: {
+    fontSize: FontSize.xl,
+    fontWeight: FontWeight.bold,
+    textAlign: 'center',
+    marginBottom: Spacing.md,
+  },
+  desc: {
+    fontSize: FontSize.md,
+    textAlign: 'center',
+    lineHeight: FontSize.md * 1.4,
+    maxWidth: 320,
+  },
+  dotsRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: Spacing.sm,
+    marginVertical: Spacing.lg,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: Colors.text.light,
+    opacity: 0.4,
+  },
+  dotActive: {
+    backgroundColor: Colors.primary,
+    opacity: 1,
+    width: 24,
+  },
+  nextButton: {
+    marginHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
+    borderRadius: BorderRadius.lg,
+    backgroundColor: Colors.primary,
+    alignItems: 'center',
+  },
+  nextButtonText: {
+    color: '#fff',
+    fontSize: FontSize.md,
+    fontWeight: FontWeight.bold,
+  },
+});

--- a/components/ParentDashboard.tsx
+++ b/components/ParentDashboard.tsx
@@ -1,0 +1,262 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from '@services/i18n';
+import { useTheme } from '@services/ThemeContext';
+import { getSessionStats, type SessionStats } from '@services/SessionTracker';
+import { getStreakData, type StreakData } from '@services/StreakManager';
+import Colors from '../constants/Colors';
+import { BorderRadius, FontSize, FontWeight, Spacing } from '../constants/Layout';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+}
+
+function formatDuration(ms: number): string {
+  const totalMin = Math.round(ms / 60000);
+  if (totalMin < 60) return `${totalMin} min`;
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  return m === 0 ? `${h} h` : `${h} h ${m} min`;
+}
+
+export default function ParentDashboard({ visible, onClose }: Props) {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const [stats, setStats] = useState<SessionStats | null>(null);
+  const [streak, setStreak] = useState<StreakData | null>(null);
+
+  useEffect(() => {
+    if (!visible) return;
+    let cancelled = false;
+    // Reset to loading state when re-opening
+    setStats(null);
+    setStreak(null);
+    Promise.all([getSessionStats(), getStreakData()])
+      .then(([s, st]) => {
+        if (cancelled) return;
+        setStats(s);
+        setStreak(st);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        // On error, surface an empty stats object so the UI exits "loading" state
+        setStats({
+          totalSessions: 0,
+          totalDurationMs: 0,
+          averageStars: 0,
+          favoriteLevels: [],
+          dailyBreakdown: [],
+        });
+        setStreak({ currentStreak: 0, longestStreak: 0, lastPlayedDate: null });
+      });
+    return () => { cancelled = true; };
+  }, [visible]);
+
+  const cardBg = colors.surface ?? Colors.surface;
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+      <View style={styles.backdrop}>
+        <View style={[styles.sheet, { backgroundColor: colors.background }]}>
+          <View style={styles.header}>
+            <Text style={[styles.title, { color: colors.text.primary }]}>
+              {t('parentDashboard.title')}
+            </Text>
+            <Text style={[styles.subtitle, { color: colors.text.secondary }]}>
+              {t('parentDashboard.subtitle')}
+            </Text>
+            <Text style={[styles.privacyHint, { color: colors.text.light }]}>
+              {t('parentDashboard.privacyHint')}
+            </Text>
+          </View>
+
+          <ScrollView contentContainerStyle={styles.body}>
+            {stats === null ? (
+              <Text style={[styles.empty, { color: colors.text.secondary }]}>
+                {t('parentDashboard.loading')}
+              </Text>
+            ) : stats.totalSessions === 0 ? (
+              <Text style={[styles.empty, { color: colors.text.secondary }]}>
+                {t('parentDashboard.empty')}
+              </Text>
+            ) : (
+              <>
+                <View style={styles.cardRow}>
+                  <View style={[styles.statCard, { backgroundColor: cardBg }]}>
+                    <Text style={[styles.statLabel, { color: colors.text.light }]}>
+                      {t('parentDashboard.totalSessions')}
+                    </Text>
+                    <Text style={[styles.statValue, { color: colors.text.primary }]}>
+                      {stats.totalSessions}
+                    </Text>
+                  </View>
+                  <View style={[styles.statCard, { backgroundColor: cardBg }]}>
+                    <Text style={[styles.statLabel, { color: colors.text.light }]}>
+                      {t('parentDashboard.totalTime')}
+                    </Text>
+                    <Text style={[styles.statValue, { color: colors.text.primary }]}>
+                      {formatDuration(stats.totalDurationMs)}
+                    </Text>
+                  </View>
+                </View>
+
+                <View style={styles.cardRow}>
+                  <View style={[styles.statCard, { backgroundColor: cardBg }]}>
+                    <Text style={[styles.statLabel, { color: colors.text.light }]}>
+                      {t('parentDashboard.avgStars')}
+                    </Text>
+                    <Text style={[styles.statValue, { color: colors.text.primary }]}>
+                      {stats.averageStars.toFixed(1)} ★
+                    </Text>
+                  </View>
+                  <View style={[styles.statCard, { backgroundColor: cardBg }]}>
+                    <Text style={[styles.statLabel, { color: colors.text.light }]}>
+                      {t('parentDashboard.streak')}
+                    </Text>
+                    <Text style={[styles.statValue, { color: colors.text.primary }]}>
+                      {streak?.currentStreak ?? 0} / {streak?.longestStreak ?? 0}
+                    </Text>
+                  </View>
+                </View>
+
+                {stats.favoriteLevels.length > 0 && (
+                  <View style={[styles.section, { backgroundColor: cardBg }]}>
+                    <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>
+                      {t('parentDashboard.favoriteLevels')}
+                    </Text>
+                    {stats.favoriteLevels.map((f) => (
+                      <View key={f.levelId} style={styles.listRow}>
+                        <Text style={[styles.listText, { color: colors.text.primary }]}>
+                          {t('parentDashboard.levelLine', { level: String(f.levelId), count: String(f.count) })}
+                        </Text>
+                      </View>
+                    ))}
+                  </View>
+                )}
+
+                {stats.dailyBreakdown.length > 0 && (
+                  <View style={[styles.section, { backgroundColor: cardBg }]}>
+                    <Text style={[styles.sectionTitle, { color: colors.text.primary }]}>
+                      {t('parentDashboard.dailyBreakdown')}
+                    </Text>
+                    {stats.dailyBreakdown.slice(-14).reverse().map((d) => (
+                      <View key={d.date} style={styles.listRow}>
+                        <Text style={[styles.listText, { color: colors.text.primary }]}>
+                          {d.date}
+                        </Text>
+                        <Text style={[styles.listSub, { color: colors.text.secondary }]}>
+                          {d.sessions}× · {formatDuration(d.totalDurationMs)} · {d.avgStars.toFixed(1)}★
+                        </Text>
+                      </View>
+                    ))}
+                  </View>
+                )}
+              </>
+            )}
+          </ScrollView>
+
+          <Pressable onPress={onClose} style={styles.closeButton} testID="parent-dashboard-close">
+            <Text style={styles.closeButtonText}>{t('common.close')}</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    maxHeight: '90%',
+    borderTopLeftRadius: BorderRadius.xxl,
+    borderTopRightRadius: BorderRadius.xxl,
+    paddingTop: Spacing.lg,
+    paddingHorizontal: Spacing.md,
+    paddingBottom: Spacing.lg,
+  },
+  header: {
+    alignItems: 'center',
+    marginBottom: Spacing.md,
+  },
+  title: {
+    fontSize: FontSize.xl,
+    fontWeight: FontWeight.bold,
+  },
+  subtitle: {
+    fontSize: FontSize.sm,
+    marginTop: 4,
+  },
+  privacyHint: {
+    fontSize: FontSize.xs,
+    marginTop: Spacing.xs,
+    fontStyle: 'italic',
+  },
+  body: {
+    paddingBottom: Spacing.md,
+    gap: Spacing.sm,
+  },
+  empty: {
+    textAlign: 'center',
+    paddingVertical: Spacing.xl,
+    fontSize: FontSize.md,
+  },
+  cardRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+  },
+  statCard: {
+    flex: 1,
+    padding: Spacing.md,
+    borderRadius: BorderRadius.lg,
+    alignItems: 'flex-start',
+  },
+  statLabel: {
+    fontSize: FontSize.xs,
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+  },
+  statValue: {
+    fontSize: FontSize.xl,
+    fontWeight: FontWeight.bold,
+    marginTop: 4,
+  },
+  section: {
+    padding: Spacing.md,
+    borderRadius: BorderRadius.lg,
+    gap: Spacing.xs,
+  },
+  sectionTitle: {
+    fontSize: FontSize.md,
+    fontWeight: FontWeight.semibold,
+    marginBottom: Spacing.xs,
+  },
+  listRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 4,
+  },
+  listText: {
+    fontSize: FontSize.sm,
+  },
+  listSub: {
+    fontSize: FontSize.xs,
+  },
+  closeButton: {
+    marginTop: Spacing.md,
+    paddingVertical: Spacing.md,
+    borderRadius: BorderRadius.lg,
+    backgroundColor: Colors.primary,
+    alignItems: 'center',
+  },
+  closeButtonText: {
+    color: '#fff',
+    fontSize: FontSize.md,
+    fontWeight: FontWeight.semibold,
+  },
+});

--- a/components/QuickStatsCards.tsx
+++ b/components/QuickStatsCards.tsx
@@ -1,0 +1,162 @@
+import React, { useState, useCallback } from 'react';
+import { View, Text, StyleSheet, useWindowDimensions } from 'react-native';
+import { useRouter, useFocusEffect } from 'expo-router';
+import { GlassCard } from '@components/AnimatedPrimitives';
+import { useTheme } from '@services/ThemeContext';
+import { useTranslation } from '@services/i18n';
+import storageManager from '@services/StorageManager';
+import { getStreakData } from '@services/StreakManager';
+import { getTotalLevels } from '@services/LevelManager';
+import Colors from '../constants/Colors';
+import { Spacing, FontSize, FontWeight, FontFamily, BorderRadius } from '../constants/Layout';
+
+interface Stats {
+  totalStars: number;
+  currentStreak: number;
+  levelsCompleted: number;
+}
+
+export default function QuickStatsCards() {
+  const { t } = useTranslation();
+  const { theme, colors } = useTheme();
+  const router = useRouter();
+  const { width } = useWindowDimensions();
+  const [stats, setStats] = useState<Stats>({ totalStars: 0, currentStreak: 0, levelsCompleted: 0 });
+
+  const glassSurface = theme === 'dark' ? Colors.glass.darkSurface : Colors.glass.lightSurface;
+  const glassBorder  = theme === 'dark' ? Colors.glass.darkBorder  : Colors.glass.lightBorder;
+  const glassShadow  = theme === 'dark' ? Colors.glass.darkShadow  : Colors.glass.lightShadow;
+
+  useFocusEffect(
+    useCallback(() => {
+      let mounted = true;
+      const load = async () => {
+        const [progress, streakData] = await Promise.all([
+          storageManager.getProgress(),
+          getStreakData(),
+        ]);
+        if (!mounted) return;
+        const totalStars = Object.values(progress.levels).reduce(
+          (sum, l) => sum + l.bestRating,
+          0
+        );
+        setStats({
+          totalStars,
+          currentStreak: streakData.currentStreak,
+          levelsCompleted: progress.totalLevelsCompleted,
+        });
+      };
+      load();
+      return () => { mounted = false; };
+    }, [])
+  );
+
+  // Below 340px: wrap into 2 rows; otherwise all 3 in one row
+  const narrow = width < 340;
+  const totalLevels = getTotalLevels();
+
+  const cardStyle = [
+    styles.card,
+    { backgroundColor: glassSurface, borderColor: glassBorder, borderWidth: 1.5 },
+    glassShadow,
+    narrow ? styles.cardNarrow : styles.cardWide,
+  ];
+
+  const cards = [
+    {
+      emoji: '⭐',
+      label: t('home.stats.stars'),
+      value: String(stats.totalStars),
+      sub: null,
+      onPress: () => router.push('/gallery'),
+      index: 0,
+    },
+    {
+      emoji: '🔥',
+      label: t('home.stats.streak'),
+      value: String(stats.currentStreak),
+      sub: stats.currentStreak > 0
+        ? t(stats.currentStreak === 1 ? 'home.stats.streakDay' : 'home.stats.streakDays')
+        : null,
+      onPress: () => router.push('/levels'),
+      index: 1,
+    },
+    {
+      emoji: '🏆',
+      label: t('home.stats.levels'),
+      value: String(stats.levelsCompleted),
+      sub: t('home.stats.levelOf', { total: String(totalLevels) }),
+      onPress: () => router.push('/levels'),
+      index: 2,
+    },
+  ];
+
+  return (
+    <View style={[styles.row, narrow && styles.rowWrap]}>
+      {cards.map((card) => (
+        <GlassCard
+          key={card.label}
+          index={card.index}
+          onPress={card.onPress}
+          style={cardStyle}
+          accessibilityLabel={`${card.label}: ${card.value}${card.sub ? ' ' + card.sub : ''}`}
+        >
+          <Text style={styles.emoji}>{card.emoji}</Text>
+          <Text style={[styles.value, { color: colors.text.primary }]}>{card.value}</Text>
+          <Text style={[styles.label, { color: colors.text.secondary }]}>{card.label}</Text>
+          {card.sub !== null && (
+            <Text style={[styles.sub, { color: colors.text.secondary }]}>{card.sub}</Text>
+          )}
+        </GlassCard>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    justifyContent: 'space-between',
+  },
+  rowWrap: {
+    flexWrap: 'wrap',
+  },
+  card: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.xs,
+    borderRadius: BorderRadius.xl,
+    minWidth: 80,
+    gap: 2,
+  },
+  cardWide: {
+    minWidth: 0,
+  },
+  cardNarrow: {
+    minWidth: '45%',
+    flexGrow: 1,
+  },
+  emoji: {
+    fontSize: 22,
+  },
+  value: {
+    fontSize: FontSize.lg,
+    fontWeight: FontWeight.bold,
+    fontFamily: FontFamily.bold,
+    lineHeight: 26,
+  },
+  label: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.semibold,
+    fontFamily: FontFamily.semibold,
+    textAlign: 'center',
+  },
+  sub: {
+    fontSize: 10,
+    textAlign: 'center',
+    marginTop: 1,
+  },
+});

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -8,6 +8,7 @@ import SoundManager from '@services/SoundManager';
 import Colors from '../constants/Colors';
 import { Spacing, FontSize, FontWeight, BorderRadius } from '../constants/Layout';
 import ParentalGate from './ParentalGate';
+import BadgesModal from './BadgesModal';
 
 interface SettingsModalProps {
   visible: boolean;
@@ -25,6 +26,7 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
   const [currentLang, setCurrentLang] = useState(getLanguage());
   const [currentTheme, setCurrentTheme] = useState<'light' | 'dark' | 'system'>(themeSetting);
   const [showAboutModal, setShowAboutModal] = useState(false);
+  const [showBadgesModal, setShowBadgesModal] = useState(false);
   const [soundEnabled, setSoundEnabled] = useState(true);
   const [parentalGateVisible, setParentalGateVisible] = useState(false);
   const [pendingUrl, setPendingUrl] = useState<string | null>(null);
@@ -301,6 +303,7 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
       <View style={[styles.card, { backgroundColor: colors.surface }]}>
         <View style={styles.actionGrid}>
           {([
+            { id: 'trophies', label: t('achievements.menuLabel'), icon: '🏆', onPress: () => setShowBadgesModal(true) },
             { id: 'feedback', label: t('settings.feedback'), icon: '✉️', onPress: handleSendFeedback },
             { id: 'support',  label: t('settings.support'),  icon: '☕',  onPress: handleSupport },
             { id: 'share',    label: t('settings.share'),    icon: '↗',   onPress: handleShareApp },
@@ -330,6 +333,7 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
       </View>
 
       {renderAboutModal()}
+      <BadgesModal visible={showBadgesModal} onClose={() => setShowBadgesModal(false)} />
     </View>
   );
 

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -8,6 +8,7 @@ import SoundManager from '@services/SoundManager';
 import Colors from '../constants/Colors';
 import { Spacing, FontSize, FontWeight, BorderRadius } from '../constants/Layout';
 import ParentalGate from './ParentalGate';
+import ParentDashboard from './ParentDashboard';
 import BadgesModal from './BadgesModal';
 
 interface SettingsModalProps {
@@ -30,6 +31,8 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
   const [soundEnabled, setSoundEnabled] = useState(true);
   const [parentalGateVisible, setParentalGateVisible] = useState(false);
   const [pendingUrl, setPendingUrl] = useState<string | null>(null);
+  const [showParentDashboard, setShowParentDashboard] = useState(false);
+  const [pendingAction, setPendingAction] = useState<null | (() => void)>(null);
 
   useEffect(() => {
     setCurrentLang(getLanguage());
@@ -79,6 +82,12 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
 
   const handleParentalGateSuccess = async () => {
     setParentalGateVisible(false);
+    if (pendingAction) {
+      const action = pendingAction;
+      setPendingAction(null);
+      action();
+      return;
+    }
     if (!pendingUrl) return;
     const url = pendingUrl;
     setPendingUrl(null);
@@ -100,6 +109,12 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
   const handleParentalGateCancel = () => {
     setParentalGateVisible(false);
     setPendingUrl(null);
+    setPendingAction(null);
+  };
+
+  const openParentDashboard = () => {
+    setPendingAction(() => () => setShowParentDashboard(true));
+    setParentalGateVisible(true);
   };
 
   const handleSendFeedback = async () => {
@@ -304,6 +319,7 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
         <View style={styles.actionGrid}>
           {([
             { id: 'trophies', label: t('achievements.menuLabel'), icon: '🏆', onPress: () => setShowBadgesModal(true) },
+            { id: 'parents',  label: t('parentDashboard.menuLabel'), icon: '👨‍👩‍👧', onPress: openParentDashboard },
             { id: 'feedback', label: t('settings.feedback'), icon: '✉️', onPress: handleSendFeedback },
             { id: 'support',  label: t('settings.support'),  icon: '☕',  onPress: handleSupport },
             { id: 'share',    label: t('settings.share'),    icon: '↗',   onPress: handleShareApp },
@@ -333,6 +349,7 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
       </View>
 
       {renderAboutModal()}
+      <ParentDashboard visible={showParentDashboard} onClose={() => setShowParentDashboard(false)} />
       <BadgesModal visible={showBadgesModal} onClose={() => setShowBadgesModal(false)} />
     </View>
   );

--- a/components/__tests__/AnimatedHero.test.tsx
+++ b/components/__tests__/AnimatedHero.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+
+jest.mock('react-native-reanimated', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: {
+      View,
+      createAnimatedComponent: (c: any) => c,
+    },
+    useSharedValue: (v: any) => ({ value: v }),
+    useAnimatedStyle: (_fn: any) => ({}),
+    withTiming: (v: any) => v,
+    withRepeat: jest.fn((v: any) => v),
+    withSequence: (...args: any[]) => args[args.length - 1],
+    Easing: {
+      ease: (t: number) => t,
+      inOut: (fn: any) => fn,
+      out: (fn: any) => fn,
+    },
+  };
+});
+
+const Reanimated = require('react-native-reanimated');
+const withRepeatMock = Reanimated.withRepeat as jest.Mock;
+
+import { AnimatedHero } from '../AnimatedHero';
+import { Text } from 'react-native';
+
+const getAllTexts = (getAllByType: (t: any) => any[]) =>
+  getAllByType(Text).map((n: any) => n.props.children).flat().map(String);
+
+describe('AnimatedHero', () => {
+  beforeEach(() => {
+    withRepeatMock.mockClear();
+  });
+
+  it('renders without crashing', async () => {
+    expect(() => render(<AnimatedHero />)).not.toThrow();
+    await act(async () => {});
+  });
+
+  it('renders brain and pencil emojis', async () => {
+    const { UNSAFE_getAllByType } = render(<AnimatedHero />);
+    await act(async () => {});
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain('🧠');
+    expect(texts).toContain('✏️');
+  });
+
+  it('starts repeating animations when reduced motion is off', async () => {
+    const { AccessibilityInfo } = require('react-native');
+    jest.spyOn(AccessibilityInfo, 'isReduceMotionEnabled').mockResolvedValueOnce(false);
+
+    render(<AnimatedHero />);
+    await act(async () => {});
+
+    expect(withRepeatMock).toHaveBeenCalled();
+  });
+
+  it('does not start animations when prefers-reduced-motion is enabled', async () => {
+    const { AccessibilityInfo } = require('react-native');
+    jest.spyOn(AccessibilityInfo, 'isReduceMotionEnabled').mockResolvedValueOnce(true);
+
+    render(<AnimatedHero />);
+    await act(async () => {});
+
+    expect(withRepeatMock).not.toHaveBeenCalled();
+  });
+});

--- a/components/__tests__/ConfettiBurst.test.tsx
+++ b/components/__tests__/ConfettiBurst.test.tsx
@@ -1,0 +1,31 @@
+import { buildParticles, CONFETTI_COUNT } from '../ConfettiBurst.shared';
+
+describe('ConfettiBurst.shared', () => {
+  it('builds the expected number of particles', () => {
+    const particles = buildParticles(300, 600, 42);
+    expect(particles).toHaveLength(CONFETTI_COUNT);
+  });
+
+  it('keeps particles roughly inside the canvas X range', () => {
+    const particles = buildParticles(400, 800, 7);
+    particles.forEach((p) => {
+      expect(p.x).toBeGreaterThanOrEqual(0);
+      expect(p.x).toBeLessThanOrEqual(400);
+    });
+  });
+
+  it('is deterministic given the same seed', () => {
+    const a = buildParticles(300, 600, 99);
+    const b = buildParticles(300, 600, 99);
+    expect(a[0]).toEqual(b[0]);
+    expect(a[CONFETTI_COUNT - 1]).toEqual(b[CONFETTI_COUNT - 1]);
+  });
+
+  it('produces particles that fall from above into the canvas', () => {
+    const particles = buildParticles(300, 600, 5);
+    particles.forEach((p) => {
+      expect(p.startY).toBeLessThan(0);
+      expect(p.endY).toBeGreaterThan(600);
+    });
+  });
+});

--- a/components/__tests__/FloatingStars.test.tsx
+++ b/components/__tests__/FloatingStars.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+
+jest.mock('react-native-reanimated', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: {
+      View,
+      createAnimatedComponent: (c: any) => c,
+    },
+    useSharedValue: (v: any) => ({ value: v }),
+    useAnimatedStyle: (_fn: any) => ({}),
+    withTiming: (v: any) => v,
+    withDelay: (_d: any, v: any) => v,
+    withRepeat: jest.fn((v: any) => v),
+    withSequence: (...args: any[]) => args[args.length - 1],
+    Easing: {
+      ease: (t: number) => t,
+      inOut: (fn: any) => fn,
+      out: (fn: any) => fn,
+    },
+  };
+});
+
+const Reanimated = require('react-native-reanimated');
+const withRepeatMock = Reanimated.withRepeat as jest.Mock;
+
+import { FloatingStars } from '../FloatingStars';
+import { Text } from 'react-native';
+
+describe('FloatingStars', () => {
+  beforeEach(() => {
+    withRepeatMock.mockClear();
+  });
+
+  it('renders without crashing', async () => {
+    expect(() => render(<FloatingStars />)).not.toThrow();
+    await act(async () => {});
+  });
+
+  it('renders all 8 decor glyphs', async () => {
+    const { UNSAFE_getAllByType } = render(<FloatingStars />);
+    await act(async () => {});
+    const texts = UNSAFE_getAllByType(Text);
+    expect(texts.length).toBe(8);
+  });
+
+  it('starts repeating animations on mount when reduced motion is off', async () => {
+    const { AccessibilityInfo } = require('react-native');
+    jest.spyOn(AccessibilityInfo, 'isReduceMotionEnabled').mockResolvedValueOnce(false);
+
+    render(<FloatingStars />);
+    await act(async () => {});
+
+    expect(withRepeatMock).toHaveBeenCalled();
+  });
+
+  it('does not start animations when prefers-reduced-motion is enabled', async () => {
+    const { AccessibilityInfo } = require('react-native');
+    jest.spyOn(AccessibilityInfo, 'isReduceMotionEnabled').mockResolvedValueOnce(true);
+
+    render(<FloatingStars />);
+    await act(async () => {});
+
+    expect(withRepeatMock).not.toHaveBeenCalled();
+  });
+
+  it('renders glyphs as non-accessible', async () => {
+    const { UNSAFE_getAllByType } = render(<FloatingStars />);
+    await act(async () => {});
+    const texts = UNSAFE_getAllByType(Text);
+    texts.forEach((t: any) => {
+      expect(t.props.accessible).toBe(false);
+    });
+  });
+});

--- a/components/__tests__/GameScreen.test.tsx
+++ b/components/__tests__/GameScreen.test.tsx
@@ -99,6 +99,33 @@ jest.mock('../../services/SoundManager', () => ({
   default: { init: jest.fn(), playPhaseTransition: jest.fn() },
 }));
 
+jest.mock('../../components/ConfettiBurst', () => {
+  const { View } = require('react-native');
+  return { __esModule: true, default: () => <View testID="confetti-burst" /> };
+});
+
+jest.mock('../../components/BadgeUnlockToast', () => {
+  const { View } = require('react-native');
+  return { __esModule: true, default: () => <View testID="badge-unlock-toast" /> };
+});
+
+jest.mock('../../services/AchievementManager', () => ({
+  checkAndUnlock: jest.fn(async () => []),
+  ACHIEVEMENTS: [],
+}));
+
+jest.mock('../../services/StreakManager', () => ({
+  getStreakData: jest.fn(async () => ({ currentStreak: 0, longestStreak: 0, lastPlayedDate: null })),
+}));
+
+jest.mock('../../services/StorageManager', () => ({
+  __esModule: true,
+  default: {
+    getGallery: jest.fn(async () => []),
+    getProgress: jest.fn(async () => ({ levels: {}, totalLevelsCompleted: 0, averageRating: 0 })),
+  },
+}));
+
 jest.mock('../../services/useGamePhase', () => ({
   useGamePhase: () => ({
     phase: 'memorize',

--- a/components/__tests__/HomeScreen.test.tsx
+++ b/components/__tests__/HomeScreen.test.tsx
@@ -34,6 +34,16 @@ jest.mock('../../components/SettingsModal', () => {
   return function SettingsModal() { return <View />; };
 });
 
+jest.mock('../../components/FloatingStars', () => {
+  const { View } = require('react-native');
+  return { FloatingStars: () => <View testID="floating-stars" /> };
+});
+
+jest.mock('../../components/AnimatedHero', () => {
+  const { View } = require('react-native');
+  return { AnimatedHero: () => <View testID="animated-hero" /> };
+});
+
 jest.mock('../../services/ThemeContext', () => ({
   useTheme: () => ({
     colors: {

--- a/components/__tests__/HomeScreen.test.tsx
+++ b/components/__tests__/HomeScreen.test.tsx
@@ -18,6 +18,15 @@ jest.mock('../../services/DailyChallengeManager', () => ({
   isTodayCompleted: () => Promise.resolve(false),
 }));
 
+jest.mock('../../services/StreakManager', () => ({
+  getStreakData: () => Promise.resolve({ currentStreak: 0, longestStreak: 0, lastPlayedDate: null }),
+}));
+
+jest.mock('../../components/QuickStatsCards', () => {
+  const { View } = require('react-native');
+  return function QuickStatsCards() { return <View />; };
+});
+
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));

--- a/components/__tests__/HomeScreen.test.tsx
+++ b/components/__tests__/HomeScreen.test.tsx
@@ -53,6 +53,16 @@ jest.mock('../../components/AnimatedHero', () => {
   return { AnimatedHero: () => <View testID="animated-hero" /> };
 });
 
+jest.mock('../../components/OnboardingModal', () => {
+  const { View } = require('react-native');
+  return { __esModule: true, default: () => <View testID="onboarding-modal" /> };
+});
+
+jest.mock('../../services/OnboardingManager', () => ({
+  isOnboardingDone: jest.fn(async () => true),
+  markOnboardingDone: jest.fn(async () => {}),
+}));
+
 jest.mock('../../services/ThemeContext', () => ({
   useTheme: () => ({
     colors: {

--- a/components/__tests__/LevelsScreen.test.tsx
+++ b/components/__tests__/LevelsScreen.test.tsx
@@ -52,6 +52,11 @@ jest.mock('../../components/Badge', () => {
   return { Badge: () => <View /> };
 });
 
+jest.mock('../../components/FloatingStars', () => {
+  const { View } = require('react-native');
+  return { FloatingStars: () => <View testID="floating-stars" /> };
+});
+
 import LevelsScreen from '../../app/levels';
 
 const getStarNodes = (UNSAFE_getAllByProps: (props: any) => any[], testID: string) => {

--- a/components/__tests__/QuickStatsCards.test.tsx
+++ b/components/__tests__/QuickStatsCards.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+import { Text } from 'react-native';
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  useFocusEffect: (cb: () => (() => void) | void) => {
+    const { useEffect } = require('react');
+    useEffect(() => {
+      const cleanup = cb();
+      return typeof cleanup === 'function' ? cleanup : undefined;
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  },
+}));
+
+jest.mock('../../services/StorageManager', () => ({
+  __esModule: true,
+  default: {
+    getProgress: () =>
+      Promise.resolve({
+        levels: {
+          1: { levelNumber: 1, rating: 4, completedAt: '', bestRating: 4 },
+          2: { levelNumber: 2, rating: 3, completedAt: '', bestRating: 3 },
+        },
+        lastPlayedLevel: 2,
+        totalLevelsCompleted: 2,
+        averageRating: 3.5,
+      }),
+  },
+}));
+
+jest.mock('../../services/StreakManager', () => ({
+  getStreakData: () =>
+    Promise.resolve({ currentStreak: 5, longestStreak: 7, lastPlayedDate: '2026-05-23' }),
+}));
+
+jest.mock('../../services/LevelManager', () => ({
+  getTotalLevels: () => 10,
+}));
+
+jest.mock('../../services/ThemeContext', () => ({
+  useTheme: () => ({
+    theme: 'light',
+    colors: {
+      text: { primary: '#000', secondary: '#666' },
+    },
+  }),
+}));
+
+jest.mock('../../services/i18n', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      if (params) {
+        return Object.entries(params).reduce(
+          (s, [k, v]) => s.replace(`{{${k}}}`, v),
+          key
+        );
+      }
+      return key;
+    },
+  }),
+}));
+
+jest.mock('react-native-reanimated', () => {
+  const { View, Text: RNText } = require('react-native');
+  return {
+    __esModule: true,
+    default: {
+      View,
+      Text: RNText,
+      createAnimatedComponent: (c: any) => c,
+      call: () => {},
+    },
+    useSharedValue: (v: any) => ({ value: v }),
+    useAnimatedStyle: (_fn: any) => ({}),
+    withSpring: (v: any) => v,
+    withTiming: (v: any) => v,
+    withDelay: (_d: any, v: any) => v,
+    withSequence: (...args: any[]) => args[args.length - 1],
+    Easing: { out: () => () => {}, ease: {} },
+    runOnJS: (fn: any) => fn,
+  };
+});
+
+const getAllTexts = (getAllByType: (type: any) => any[]) =>
+  getAllByType(Text).map((n: any) => n.props.children).flat();
+
+import QuickStatsCards from '../QuickStatsCards';
+
+describe('QuickStatsCards', () => {
+  it('renders stat labels for stars, streak, and levels', async () => {
+    const { UNSAFE_getAllByType } = render(<QuickStatsCards />);
+    await act(async () => {});
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain('home.stats.stars');
+    expect(texts).toContain('home.stats.streak');
+    expect(texts).toContain('home.stats.levels');
+  });
+
+  it('displays correct values after data load', async () => {
+    const { UNSAFE_getAllByType } = render(<QuickStatsCards />);
+    await act(async () => {});
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    // Total stars: 4 + 3 = 7
+    expect(texts).toContain('7');
+    // Current streak = 5
+    expect(texts).toContain('5');
+    // Levels completed = 2
+    expect(texts).toContain('2');
+  });
+
+  it('shows streak days label when streak > 0', async () => {
+    const { UNSAFE_getAllByType } = render(<QuickStatsCards />);
+    await act(async () => {});
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain('home.stats.streakDays');
+  });
+
+  it('shows level-of sub label for the levels card', async () => {
+    const { UNSAFE_getAllByType } = render(<QuickStatsCards />);
+    await act(async () => {});
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    // t('home.stats.levelOf', { total: '10' }) → key unchanged since key has no {{total}} placeholder
+    expect(texts).toContain('home.stats.levelOf');
+  });
+});

--- a/constants/featureFlags.ts
+++ b/constants/featureFlags.ts
@@ -1,0 +1,12 @@
+/**
+ * Feature-Flags — interner Kill-Switch für einzelne Features.
+ * Nicht für Endnutzer sichtbar; Änderung erfordert App-Rebuild.
+ *
+ * Konvention: ENABLE_* defaultet auf `true`. Auf `false` setzen, um
+ * das Feature ohne Code-Removal kurzfristig zu deaktivieren.
+ */
+
+export const FeatureFlags = {
+  /** Konfetti bei 5-Sterne-Ergebnis (Issue #186). */
+  ENABLE_CONFETTI: true,
+} as const;

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -40,8 +40,10 @@ Die folgenden Daten werden **ausschließlich lokal** auf Ihrem Gerät gespeicher
 |----------|-------|-------------|
 | Spielfortschritt | Speichern von freigeschalteten Leveln | Gerätespeicher |
 | Einstellungen | Sprache, Theme, Pinselgröße | Gerätespeicher |
+| Spielsessions | Datum, Dauer, Sterne, Level — für Eltern-Dashboard. Automatische Löschung nach 28 Tagen. | Gerätespeicher |
+| Onboarding-Flag | Merken, ob die Erst-Start-Tour abgeschlossen wurde | Gerätespeicher |
 
-**Wichtig:** Diese Daten verlassen niemals Ihr Gerät und werden nur zur Funktion der App verwendet.
+**Wichtig:** Diese Daten verlassen niemals Ihr Gerät und werden nur zur Funktion der App verwendet. Das Eltern-Dashboard (hinter Eltern-Sperre erreichbar) zeigt diese lokal gespeicherten Statistiken — es findet keine Übertragung statt.
 
 ### 2.2 Keine Berechtigungen erforderlich
 

--- a/docs/PRIVACY_POLICY_EN.md
+++ b/docs/PRIVACY_POLICY_EN.md
@@ -40,8 +40,10 @@ The following data is stored **exclusively locally** on your device:
 |-----------|---------|------------------|
 | Game Progress | Saving unlocked levels | Device storage |
 | Settings | Language, theme, brush size | Device storage |
+| Game Sessions | Date, duration, stars, level — for the Parent Dashboard. Auto-deleted after 28 days. | Device storage |
+| Onboarding flag | Remember whether the first-launch tour was completed | Device storage |
 
-**Important:** This data never leaves your device and is only used for app functionality.
+**Important:** This data never leaves your device and is only used for app functionality. The Parent Dashboard (reachable behind the Parental Gate) shows these locally-stored statistics — no transmission takes place.
 
 ### 2.2 No Permissions Required
 

--- a/eas.json
+++ b/eas.json
@@ -18,7 +18,7 @@
       }
     },
     "production": {
-      "autoIncrement": true,
+      "autoIncrement": false,
       "android": {
         "buildType": "app-bundle"
       }

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -9,7 +9,16 @@
     "continueButton": "Weiterspielen",
     "levelsButton": "Level auswählen",
     "galleryButton": "Meine Galerie",
-    "settingsButton": "Einstellungen"
+    "settingsButton": "Einstellungen",
+    "streakBadge": "🔥 {{count}}",
+    "stats": {
+      "stars": "Sterne",
+      "streak": "Streak",
+      "levels": "Level",
+      "streakDay": "Tag",
+      "streakDays": "Tage",
+      "levelOf": "von {{total}}"
+    }
   },
   "levels": {
     "title": "Level auswählen",

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -167,5 +167,17 @@
     "placeholder": "Antwort eingeben",
     "confirm": "Öffnen",
     "wrongAnswer": "Falsche Antwort. Bitte versuche es erneut."
+  },
+  "achievements": {
+    "title": "Trophäen",
+    "menuLabel": "Trophäen anzeigen",
+    "unlocked": "Neue Trophäe!",
+    "progress": "{{unlocked}} von {{total}} freigeschaltet",
+    "first_5_stars":    { "title": "Erste 5 Sterne",     "desc": "Erreiche zum ersten Mal 5 Sterne in einem Level." },
+    "gallery_10":       { "title": "Galerie-Künstler",   "desc": "Speichere 10 Zeichnungen in deiner Galerie." },
+    "streak_7":         { "title": "7-Tage-Streak",      "desc": "Spiele 7 Tage hintereinander." },
+    "all_levels_done":  { "title": "Alle Level",         "desc": "Schließe alle 10 Basis-Level ab." },
+    "daily_5":          { "title": "Daily-Champion",     "desc": "Bestehe 5× die tägliche Herausforderung." },
+    "all_difficulties": { "title": "Allrounder",         "desc": "Spiele jede Schwierigkeitsstufe mindestens einmal." }
   }
 }

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -168,6 +168,29 @@
     "confirm": "Öffnen",
     "wrongAnswer": "Falsche Antwort. Bitte versuche es erneut."
   },
+  "onboarding": {
+    "skip": "Überspringen",
+    "next": "Weiter",
+    "start": "Los geht's!",
+    "step1": { "title": "Merken",   "desc": "Schau dir das Bild ein paar Sekunden gut an." },
+    "step2": { "title": "Zeichnen", "desc": "Versuche, es aus dem Gedächtnis nachzumalen." },
+    "step3": { "title": "Sterne",   "desc": "Vergleiche dein Werk und bekomme Sterne." }
+  },
+  "parentDashboard": {
+    "menuLabel": "Eltern-Bereich",
+    "title": "Eltern-Dashboard",
+    "subtitle": "Spielnutzung der letzten 4 Wochen",
+    "privacyHint": "Alle Daten bleiben lokal auf diesem Gerät.",
+    "loading": "Lade Statistiken…",
+    "empty": "Noch keine Spielsessions aufgezeichnet.",
+    "totalSessions": "Sessions",
+    "totalTime": "Gesamtzeit",
+    "avgStars": "Ø Sterne",
+    "streak": "Streak (akt./best.)",
+    "favoriteLevels": "Lieblings-Level",
+    "dailyBreakdown": "Pro Tag (letzte 14)",
+    "levelLine": "Level {{level}} · {{count}}× gespielt"
+  },
   "achievements": {
     "title": "Trophäen",
     "menuLabel": "Trophäen anzeigen",

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -167,5 +167,17 @@
     "placeholder": "Enter answer",
     "confirm": "Open",
     "wrongAnswer": "Wrong answer. Please try again."
+  },
+  "achievements": {
+    "title": "Trophies",
+    "menuLabel": "Show trophies",
+    "unlocked": "New trophy!",
+    "progress": "{{unlocked}} of {{total}} unlocked",
+    "first_5_stars":    { "title": "First 5 Stars",     "desc": "Reach 5 stars in a level for the first time." },
+    "gallery_10":       { "title": "Gallery Artist",    "desc": "Save 10 drawings to your gallery." },
+    "streak_7":         { "title": "7-Day Streak",      "desc": "Play 7 days in a row." },
+    "all_levels_done":  { "title": "All Levels",        "desc": "Complete all 10 base levels." },
+    "daily_5":          { "title": "Daily Champion",    "desc": "Beat the daily challenge 5 times." },
+    "all_difficulties": { "title": "All-Rounder",       "desc": "Play every difficulty level at least once." }
   }
 }

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -9,7 +9,16 @@
     "continueButton": "Continue",
     "levelsButton": "Select Level",
     "galleryButton": "My Gallery",
-    "settingsButton": "Settings"
+    "settingsButton": "Settings",
+    "streakBadge": "🔥 {{count}}",
+    "stats": {
+      "stars": "Stars",
+      "streak": "Streak",
+      "levels": "Levels",
+      "streakDay": "day",
+      "streakDays": "days",
+      "levelOf": "of {{total}}"
+    }
   },
   "levels": {
     "title": "Select Level",

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -168,6 +168,29 @@
     "confirm": "Open",
     "wrongAnswer": "Wrong answer. Please try again."
   },
+  "onboarding": {
+    "skip": "Skip",
+    "next": "Next",
+    "start": "Let's go!",
+    "step1": { "title": "Remember", "desc": "Look at the picture carefully for a few seconds." },
+    "step2": { "title": "Draw",     "desc": "Try to draw it from memory." },
+    "step3": { "title": "Stars",    "desc": "Compare your drawing and earn stars." }
+  },
+  "parentDashboard": {
+    "menuLabel": "Parent Area",
+    "title": "Parent Dashboard",
+    "subtitle": "Game usage over the last 4 weeks",
+    "privacyHint": "All data stays local on this device.",
+    "loading": "Loading stats…",
+    "empty": "No game sessions recorded yet.",
+    "totalSessions": "Sessions",
+    "totalTime": "Total time",
+    "avgStars": "Avg. stars",
+    "streak": "Streak (curr./best)",
+    "favoriteLevels": "Favorite levels",
+    "dailyBreakdown": "Per day (last 14)",
+    "levelLine": "Level {{level}} · played {{count}}×"
+  },
   "achievements": {
     "title": "Trophies",
     "menuLabel": "Show trophies",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "expo-localization": "~55.0.8",
         "expo-router": "~55.0.5",
         "expo-status-bar": "~55.0.4",
+        "lottie-react-native": "~7.3.4",
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "react-native": "0.83.2",
@@ -9983,6 +9984,26 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lottie-react-native": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/lottie-react-native/-/lottie-react-native-7.3.8.tgz",
+      "integrity": "sha512-GAOl99TKi0c6xCcB1AJ+o70mgOPIAI/7K2G+Gs+o4po/qBhgvWijPNCKH8h6yNmlwFTg+RN3DmzRvHNFGxZMKQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@lottiefiles/dotlottie-react": "^0.13.5",
+        "react": "*",
+        "react-native": ">=0.46",
+        "react-native-windows": ">=0.63.x"
+      },
+      "peerDependenciesMeta": {
+        "@lottiefiles/dotlottie-react": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/lru-cache": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "merke-und-male",
-  "version": "1.4.2",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "merke-und-male",
-      "version": "1.4.2",
+      "version": "1.6.0",
       "dependencies": {
         "@expo-google-fonts/nunito": "^0.4.2",
         "@expo/metro-runtime": "~55.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merke-und-male",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "main": "expo-router/entry",
   "homepage": "https://s540d.github.io/DrawFromMemory/",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merke-und-male",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "expo-router/entry",
   "homepage": "https://s540d.github.io/DrawFromMemory/",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "expo-localization": "~55.0.8",
     "expo-router": "~55.0.5",
     "expo-status-bar": "~55.0.4",
+    "lottie-react-native": "~7.3.4",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merke-und-male",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "main": "expo-router/entry",
   "homepage": "https://s540d.github.io/DrawFromMemory/",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merke-und-male",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "main": "expo-router/entry",
   "homepage": "https://s540d.github.io/DrawFromMemory/",
   "repository": {

--- a/public/privacy-policy-en.html
+++ b/public/privacy-policy-en.html
@@ -162,8 +162,18 @@
                 <td>Language, theme, brush size</td>
                 <td>Device storage</td>
             </tr>
+            <tr>
+                <td>Game Sessions</td>
+                <td>Date, duration, stars, level — for the Parent Dashboard. Auto-deleted after 28 days.</td>
+                <td>Device storage</td>
+            </tr>
+            <tr>
+                <td>Onboarding flag</td>
+                <td>Remember whether the first-launch tour was completed</td>
+                <td>Device storage</td>
+            </tr>
         </table>
-        <p><strong>Important:</strong> This data never leaves your device and is only used for app functionality.</p>
+        <p><strong>Important:</strong> This data never leaves your device and is only used for app functionality. The Parent Dashboard (reachable behind the Parental Gate) shows these locally-stored statistics — no transmission takes place.</p>
 
         <h3>2.2 No Permissions Required</h3>
         <p>The app requires <strong>none</strong> of the following permissions:</p>

--- a/public/privacy-policy.html
+++ b/public/privacy-policy.html
@@ -162,8 +162,18 @@
                 <td>Sprache, Theme, Pinselgröße</td>
                 <td>Gerätespeicher</td>
             </tr>
+            <tr>
+                <td>Spielsessions</td>
+                <td>Datum, Dauer, Sterne, Level — für Eltern-Dashboard. Automatische Löschung nach 28 Tagen.</td>
+                <td>Gerätespeicher</td>
+            </tr>
+            <tr>
+                <td>Onboarding-Flag</td>
+                <td>Merken, ob die Erst-Start-Tour abgeschlossen wurde</td>
+                <td>Gerätespeicher</td>
+            </tr>
         </table>
-        <p><strong>Wichtig:</strong> Diese Daten verlassen niemals Ihr Gerät und werden nur zur Funktion der App verwendet.</p>
+        <p><strong>Wichtig:</strong> Diese Daten verlassen niemals Ihr Gerät und werden nur zur Funktion der App verwendet. Das Eltern-Dashboard (hinter Eltern-Sperre erreichbar) zeigt diese lokal gespeicherten Statistiken — es findet keine Übertragung statt.</p>
 
         <h3>2.2 Keine Berechtigungen erforderlich</h3>
         <p>Die App benötigt <strong>keine</strong> der folgenden Berechtigungen:</p>

--- a/services/AchievementManager.ts
+++ b/services/AchievementManager.ts
@@ -1,0 +1,153 @@
+/**
+ * AchievementManager — Badge-System
+ * Speichert freigeschaltete Badges via AsyncStorage.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = '@merke_male:achievements';
+
+export type AchievementId =
+  | 'first_5_stars'
+  | 'gallery_10'
+  | 'streak_7'
+  | 'all_levels_done'
+  | 'daily_5'
+  | 'all_difficulties';
+
+export interface AchievementDef {
+  id: AchievementId;
+  emoji: string;
+  titleKey: string;
+  descKey: string;
+}
+
+export const ACHIEVEMENTS: AchievementDef[] = [
+  { id: 'first_5_stars',    emoji: '🌟', titleKey: 'achievements.first_5_stars.title',    descKey: 'achievements.first_5_stars.desc' },
+  { id: 'gallery_10',       emoji: '🎨', titleKey: 'achievements.gallery_10.title',       descKey: 'achievements.gallery_10.desc' },
+  { id: 'streak_7',         emoji: '🔥', titleKey: 'achievements.streak_7.title',         descKey: 'achievements.streak_7.desc' },
+  { id: 'all_levels_done',  emoji: '🏆', titleKey: 'achievements.all_levels_done.title',  descKey: 'achievements.all_levels_done.desc' },
+  { id: 'daily_5',          emoji: '🎯', titleKey: 'achievements.daily_5.title',          descKey: 'achievements.daily_5.desc' },
+  { id: 'all_difficulties', emoji: '🌈', titleKey: 'achievements.all_difficulties.title', descKey: 'achievements.all_difficulties.desc' },
+];
+
+export interface UnlockedAchievement {
+  id: AchievementId;
+  unlockedAt: string; // ISO date
+}
+
+export interface AchievementEvent {
+  stars?: number;
+  galleryCount?: number;
+  currentStreak?: number;
+  levelsCompleted?: number;
+  dailyChallengesCompleted?: number;
+  difficultiesPlayed?: number[]; // distinct difficulties played at least once
+}
+
+const MEMORY: Record<string, string> = {};
+
+function safeParse(raw: string | null | undefined): UnlockedAchievement[] | null {
+  if (!raw) return null;
+  try {
+    const v = JSON.parse(raw);
+    return Array.isArray(v) ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+async function loadUnlocked(): Promise<UnlockedAchievement[]> {
+  let raw: string | null = null;
+  try {
+    raw = await AsyncStorage.getItem(STORAGE_KEY);
+  } catch {
+    // fall through
+  }
+  const fromRaw = safeParse(raw);
+  if (fromRaw) {
+    MEMORY[STORAGE_KEY] = raw as string;
+    return fromRaw;
+  }
+  // raw is missing or corrupt — try MEMORY cache
+  const fromMemory = safeParse(MEMORY[STORAGE_KEY]);
+  if (fromMemory) {
+    if (raw !== null && raw !== undefined) {
+      // storage was corrupt; clear it but keep valid in-memory cache
+      try { await AsyncStorage.removeItem(STORAGE_KEY); } catch { /* best-effort */ }
+    }
+    return fromMemory;
+  }
+  // nothing valid anywhere
+  if (raw !== null && raw !== undefined) {
+    delete MEMORY[STORAGE_KEY];
+    try { await AsyncStorage.removeItem(STORAGE_KEY); } catch { /* best-effort */ }
+  }
+  return [];
+}
+
+async function saveUnlocked(list: UnlockedAchievement[]): Promise<void> {
+  const raw = JSON.stringify(list);
+  MEMORY[STORAGE_KEY] = raw;
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, raw);
+  } catch {
+    // in-memory fallback
+  }
+}
+
+export async function getUnlockedAchievements(): Promise<UnlockedAchievement[]> {
+  try {
+    return await loadUnlocked();
+  } catch {
+    return [];
+  }
+}
+
+export async function isUnlocked(id: AchievementId): Promise<boolean> {
+  const list = await getUnlockedAchievements();
+  return list.some((u) => u.id === id);
+}
+
+/**
+ * Prüft Event gegen Achievement-Regeln und gibt neu freigeschaltete Badges zurück.
+ */
+export async function checkAndUnlock(event: AchievementEvent): Promise<AchievementDef[]> {
+  const list = await loadUnlocked();
+  const has = (id: AchievementId) => list.some((u) => u.id === id);
+  const newly: AchievementDef[] = [];
+
+  const tryUnlock = (id: AchievementId, condition: boolean) => {
+    if (condition && !has(id)) {
+      const def = ACHIEVEMENTS.find((a) => a.id === id);
+      if (def) newly.push(def);
+    }
+  };
+
+  tryUnlock('first_5_stars',    (event.stars ?? 0) >= 5);
+  tryUnlock('gallery_10',       (event.galleryCount ?? 0) >= 10);
+  tryUnlock('streak_7',         (event.currentStreak ?? 0) >= 7);
+  tryUnlock('all_levels_done',  (event.levelsCompleted ?? 0) >= 10);
+  tryUnlock('daily_5',          (event.dailyChallengesCompleted ?? 0) >= 5);
+  tryUnlock(
+    'all_difficulties',
+    Array.isArray(event.difficultiesPlayed) &&
+      [1, 2, 3, 4, 5].every((d) => event.difficultiesPlayed!.includes(d)),
+  );
+
+  if (newly.length > 0) {
+    const now = new Date().toISOString();
+    const updated = [...list, ...newly.map((d) => ({ id: d.id, unlockedAt: now }))];
+    await saveUnlocked(updated);
+  }
+  return newly;
+}
+
+export async function resetAchievements(): Promise<void> {
+  delete MEMORY[STORAGE_KEY];
+  try {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // best-effort
+  }
+}

--- a/services/OnboardingManager.ts
+++ b/services/OnboardingManager.ts
@@ -1,0 +1,38 @@
+/**
+ * OnboardingManager — Erst-Start-Tour-Flag
+ * Eigener AsyncStorage-Key, damit das typisierte AppSettings-Schema
+ * nicht aufgebohrt werden muss.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = '@merke_male:onboarding_done';
+const MEMORY: Record<string, string> = {};
+
+export async function isOnboardingDone(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (raw === '1') return true;
+    return MEMORY[STORAGE_KEY] === '1';
+  } catch {
+    return MEMORY[STORAGE_KEY] === '1';
+  }
+}
+
+export async function markOnboardingDone(): Promise<void> {
+  MEMORY[STORAGE_KEY] = '1';
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, '1');
+  } catch {
+    // in-memory fallback for web sessions
+  }
+}
+
+export async function resetOnboarding(): Promise<void> {
+  delete MEMORY[STORAGE_KEY];
+  try {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // best-effort
+  }
+}

--- a/services/SessionTracker.ts
+++ b/services/SessionTracker.ts
@@ -1,0 +1,181 @@
+/**
+ * SessionTracker — Lokale Spielsessions für Eltern-Dashboard (Issue #188)
+ *
+ * Speichert pro abgeschlossener Runde:
+ *   { date, durationMs, stars, levelId }
+ *
+ * Auto-Cleanup: Einträge älter als FOUR_WEEKS_MS (28 Tage) werden beim
+ * nächsten Zugriff entfernt. Daten verlassen das Gerät nicht.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = '@merke_male:sessions';
+export const FOUR_WEEKS_MS = 28 * 24 * 60 * 60 * 1000;
+const MAX_ENTRIES = 1000; // hard cap, defensiv
+
+export interface SessionRecord {
+  date: string;       // ISO timestamp
+  durationMs: number;
+  stars: number;      // 0..5
+  levelId: number;
+}
+
+export interface SessionStats {
+  totalSessions: number;
+  totalDurationMs: number;
+  averageStars: number;
+  favoriteLevels: { levelId: number; count: number }[]; // top 3
+  dailyBreakdown: { date: string; sessions: number; totalDurationMs: number; avgStars: number }[];
+}
+
+const MEMORY: Record<string, string> = {};
+
+function safeParse(raw: string | null | undefined): SessionRecord[] | null {
+  if (!raw) return null;
+  try {
+    const v = JSON.parse(raw);
+    return Array.isArray(v) ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+async function loadRaw(): Promise<SessionRecord[]> {
+  let raw: string | null = null;
+  try {
+    raw = await AsyncStorage.getItem(STORAGE_KEY);
+  } catch {
+    // fall through to in-memory
+  }
+  const fromRaw = safeParse(raw);
+  if (fromRaw) {
+    MEMORY[STORAGE_KEY] = raw as string;
+    return fromRaw;
+  }
+  // raw is missing or corrupt
+  const fromMemory = safeParse(MEMORY[STORAGE_KEY]);
+  if (raw !== null && raw !== undefined) {
+    // Self-heal: corrupt storage value — drop it so we stop reading garbage
+    try { await AsyncStorage.removeItem(STORAGE_KEY); } catch { /* best-effort */ }
+    if (!fromMemory) delete MEMORY[STORAGE_KEY];
+  }
+  return fromMemory ?? [];
+}
+
+async function saveRaw(records: SessionRecord[]): Promise<void> {
+  const raw = JSON.stringify(records);
+  MEMORY[STORAGE_KEY] = raw;
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, raw);
+  } catch {
+    // in-memory fallback
+  }
+}
+
+function pruneOld(records: SessionRecord[], now: number = Date.now()): SessionRecord[] {
+  const cutoff = now - FOUR_WEEKS_MS;
+  const fresh = records.filter((r) => {
+    const t = Date.parse(r.date);
+    return Number.isFinite(t) && t >= cutoff;
+  });
+  // Hard-cap (defensiv falls jemand sehr viel spielt)
+  return fresh.length > MAX_ENTRIES ? fresh.slice(-MAX_ENTRIES) : fresh;
+}
+
+export async function recordSession(record: Omit<SessionRecord, 'date'> & { date?: string }): Promise<void> {
+  try {
+    const records = await loadRaw();
+    const next: SessionRecord = {
+      date: record.date ?? new Date().toISOString(),
+      durationMs: Math.max(0, Math.floor(record.durationMs)),
+      stars: Math.max(0, Math.min(5, Math.floor(record.stars))),
+      levelId: Math.max(0, Math.floor(record.levelId)),
+    };
+    const pruned = pruneOld([...records, next]);
+    await saveRaw(pruned);
+  } catch {
+    // best-effort
+  }
+}
+
+export async function getSessions(now: number = Date.now()): Promise<SessionRecord[]> {
+  try {
+    const records = await loadRaw();
+    const pruned = pruneOld(records, now);
+    if (pruned.length !== records.length) {
+      // persistiere Cleanup
+      await saveRaw(pruned);
+    }
+    return pruned;
+  } catch {
+    return [];
+  }
+}
+
+export async function clearSessions(): Promise<void> {
+  delete MEMORY[STORAGE_KEY];
+  try {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // best-effort
+  }
+}
+
+function localDateKey(iso: string): string {
+  const d = new Date(iso);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export function computeStats(records: SessionRecord[]): SessionStats {
+  if (records.length === 0) {
+    return {
+      totalSessions: 0,
+      totalDurationMs: 0,
+      averageStars: 0,
+      favoriteLevels: [],
+      dailyBreakdown: [],
+    };
+  }
+  const totalSessions = records.length;
+  const totalDurationMs = records.reduce((sum, r) => sum + r.durationMs, 0);
+  const totalStars = records.reduce((sum, r) => sum + r.stars, 0);
+  const averageStars = totalStars / totalSessions;
+
+  // Favorite levels (top 3 by play count)
+  const levelCounts = new Map<number, number>();
+  records.forEach((r) => levelCounts.set(r.levelId, (levelCounts.get(r.levelId) ?? 0) + 1));
+  const favoriteLevels = Array.from(levelCounts.entries())
+    .map(([levelId, count]) => ({ levelId, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 3);
+
+  // Daily breakdown (chronological)
+  const dailyMap = new Map<string, { sessions: number; totalDurationMs: number; starsSum: number }>();
+  records.forEach((r) => {
+    const key = localDateKey(r.date);
+    const entry = dailyMap.get(key) ?? { sessions: 0, totalDurationMs: 0, starsSum: 0 };
+    entry.sessions += 1;
+    entry.totalDurationMs += r.durationMs;
+    entry.starsSum += r.stars;
+    dailyMap.set(key, entry);
+  });
+  const dailyBreakdown = Array.from(dailyMap.entries())
+    .map(([date, v]) => ({
+      date,
+      sessions: v.sessions,
+      totalDurationMs: v.totalDurationMs,
+      avgStars: v.starsSum / v.sessions,
+    }))
+    .sort((a, b) => (a.date < b.date ? -1 : 1));
+
+  return { totalSessions, totalDurationMs, averageStars, favoriteLevels, dailyBreakdown };
+}
+
+export async function getSessionStats(): Promise<SessionStats> {
+  const records = await getSessions();
+  return computeStats(records);
+}

--- a/services/StreakManager.ts
+++ b/services/StreakManager.ts
@@ -1,0 +1,133 @@
+/**
+ * StreakManager - Täglicher Streak-Tracker
+ * Zählt aufeinanderfolgende Tage mit ≥1 Spielrunde.
+ * DST-sicher via lokale YYYY-MM-DD-Strings (kein UTC).
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = '@merke_male:streak';
+
+export interface StreakData {
+  currentStreak: number;
+  longestStreak: number;
+  lastPlayedDate: string | null; // YYYY-MM-DD (local)
+}
+
+const MEMORY: Record<string, string> = {};
+
+const DEFAULT_STATE: StreakData = { currentStreak: 0, longestStreak: 0, lastPlayedDate: null };
+
+function safeParse(raw: string | undefined | null): StreakData | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as StreakData;
+  } catch {
+    return null;
+  }
+}
+
+async function loadState(): Promise<StreakData> {
+  let raw: string | null = null;
+  try {
+    raw = await AsyncStorage.getItem(STORAGE_KEY);
+  } catch {
+    // AsyncStorage unavailable — fall through to in-memory
+  }
+
+  const parsed = safeParse(raw) ?? safeParse(MEMORY[STORAGE_KEY]);
+  if (parsed) {
+    if (raw) MEMORY[STORAGE_KEY] = raw;
+    return parsed;
+  }
+
+  if (raw) {
+    // corrupt value stored — drop it so it can't keep crashing future loads
+    delete MEMORY[STORAGE_KEY];
+    try { await AsyncStorage.removeItem(STORAGE_KEY); } catch { /* best-effort */ }
+  }
+  return { ...DEFAULT_STATE };
+}
+
+async function saveState(state: StreakData): Promise<void> {
+  const raw = JSON.stringify(state);
+  MEMORY[STORAGE_KEY] = raw;
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, raw);
+  } catch {
+    // in-memory fallback is sufficient for web sessions
+  }
+}
+
+/**
+ * Gibt das Datum als lokalen YYYY-MM-DD-String zurück (DST-sicher).
+ */
+export function getLocalDateKey(date: Date = new Date()): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * Lädt die aktuellen Streak-Daten.
+ */
+export async function getStreakData(): Promise<StreakData> {
+  try {
+    return await loadState();
+  } catch {
+    return { ...DEFAULT_STATE };
+  }
+}
+
+/**
+ * Wird nach jeder abgeschlossenen Spielrunde aufgerufen.
+ * Aktualisiert currentStreak, longestStreak und lastPlayedDate.
+ */
+export async function updateStreakAfterGame(date: Date = new Date()): Promise<void> {
+  try {
+    const state = await loadState();
+    const today = getLocalDateKey(date);
+
+    if (state.lastPlayedDate === today) {
+      // Bereits heute gespielt — kein Update nötig
+      return;
+    }
+
+    let newStreak: number;
+
+    if (state.lastPlayedDate !== null) {
+      const yesterday = getLocalDateKey(new Date(date.getFullYear(), date.getMonth(), date.getDate() - 1));
+      if (state.lastPlayedDate === yesterday) {
+        // Gestern gespielt → Streak verlängern
+        newStreak = state.currentStreak + 1;
+      } else {
+        // Mehr als 1 Tag Pause → Streak zurücksetzen
+        newStreak = 1;
+      }
+    } else {
+      // Erster Spieltag überhaupt
+      newStreak = 1;
+    }
+
+    await saveState({
+      currentStreak: newStreak,
+      longestStreak: Math.max(state.longestStreak, newStreak),
+      lastPlayedDate: today,
+    });
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Setzt alle Streak-Daten zurück (nur für Tests / Reset-Funktion).
+ */
+export async function resetStreakData(): Promise<void> {
+  delete MEMORY[STORAGE_KEY];
+  try {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // best-effort
+  }
+}

--- a/services/__tests__/AchievementManager.test.ts
+++ b/services/__tests__/AchievementManager.test.ts
@@ -1,0 +1,77 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  checkAndUnlock,
+  getUnlockedAchievements,
+  isUnlocked,
+  resetAchievements,
+} from '../AchievementManager';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+const mockStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+describe('AchievementManager', () => {
+  beforeEach(async () => {
+    mockStorage.getItem.mockReset();
+    mockStorage.setItem.mockReset();
+    mockStorage.removeItem.mockReset();
+    mockStorage.getItem.mockResolvedValue(null);
+    await resetAchievements();
+  });
+
+  it('returns empty list when nothing unlocked yet', async () => {
+    expect(await getUnlockedAchievements()).toEqual([]);
+  });
+
+  it('unlocks first_5_stars on rating === 5', async () => {
+    const newly = await checkAndUnlock({ stars: 5 });
+    expect(newly.map((a) => a.id)).toContain('first_5_stars');
+    expect(await isUnlocked('first_5_stars')).toBe(true);
+  });
+
+  it('does not unlock same badge twice', async () => {
+    await checkAndUnlock({ stars: 5 });
+    mockStorage.getItem.mockResolvedValue(
+      JSON.stringify([{ id: 'first_5_stars', unlockedAt: '2026-01-01' }]),
+    );
+    const newly = await checkAndUnlock({ stars: 5 });
+    expect(newly).toEqual([]);
+  });
+
+  it('unlocks gallery_10 only at >= 10 entries', async () => {
+    expect((await checkAndUnlock({ galleryCount: 9 })).map((a) => a.id)).not.toContain('gallery_10');
+    mockStorage.getItem.mockResolvedValue(null);
+    expect((await checkAndUnlock({ galleryCount: 10 })).map((a) => a.id)).toContain('gallery_10');
+  });
+
+  it('unlocks streak_7 at >= 7 days', async () => {
+    expect((await checkAndUnlock({ currentStreak: 6 })).map((a) => a.id)).not.toContain('streak_7');
+    mockStorage.getItem.mockResolvedValue(null);
+    expect((await checkAndUnlock({ currentStreak: 7 })).map((a) => a.id)).toContain('streak_7');
+  });
+
+  it('unlocks all_levels_done at 10 levels', async () => {
+    expect((await checkAndUnlock({ levelsCompleted: 10 })).map((a) => a.id)).toContain('all_levels_done');
+  });
+
+  it('unlocks all_difficulties only when 1..5 all played', async () => {
+    expect((await checkAndUnlock({ difficultiesPlayed: [1, 2, 3, 4] })).map((a) => a.id))
+      .not.toContain('all_difficulties');
+    mockStorage.getItem.mockResolvedValue(null);
+    expect((await checkAndUnlock({ difficultiesPlayed: [1, 2, 3, 4, 5] })).map((a) => a.id))
+      .toContain('all_difficulties');
+  });
+
+  it('recovers from corrupt JSON in storage', async () => {
+    mockStorage.getItem.mockResolvedValue('{not-json');
+    expect(await getUnlockedAchievements()).toEqual([]);
+    expect(mockStorage.removeItem).toHaveBeenCalled();
+  });
+});

--- a/services/__tests__/OnboardingManager.test.ts
+++ b/services/__tests__/OnboardingManager.test.ts
@@ -1,0 +1,46 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { isOnboardingDone, markOnboardingDone, resetOnboarding } from '../OnboardingManager';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+const mockStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+describe('OnboardingManager', () => {
+  beforeEach(async () => {
+    mockStorage.getItem.mockReset();
+    mockStorage.setItem.mockReset();
+    mockStorage.removeItem.mockReset();
+    mockStorage.getItem.mockResolvedValue(null);
+    await resetOnboarding();
+  });
+
+  it('returns false when nothing is stored', async () => {
+    expect(await isOnboardingDone()).toBe(false);
+  });
+
+  it('returns true after markOnboardingDone', async () => {
+    await markOnboardingDone();
+    mockStorage.getItem.mockResolvedValue('1');
+    expect(await isOnboardingDone()).toBe(true);
+  });
+
+  it('persists the flag to AsyncStorage', async () => {
+    await markOnboardingDone();
+    expect(mockStorage.setItem).toHaveBeenCalledWith('@merke_male:onboarding_done', '1');
+  });
+
+  it('falls back to in-memory when AsyncStorage throws', async () => {
+    mockStorage.setItem.mockRejectedValueOnce(new Error('storage offline'));
+    await markOnboardingDone();
+    // getItem will return null but in-memory cache should still report done
+    mockStorage.getItem.mockResolvedValue(null);
+    expect(await isOnboardingDone()).toBe(true);
+  });
+});

--- a/services/__tests__/SessionTracker.test.ts
+++ b/services/__tests__/SessionTracker.test.ts
@@ -1,0 +1,115 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  recordSession,
+  getSessions,
+  clearSessions,
+  computeStats,
+  getSessionStats,
+  FOUR_WEEKS_MS,
+} from '../SessionTracker';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+const mockStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+describe('SessionTracker', () => {
+  beforeEach(async () => {
+    mockStorage.getItem.mockReset();
+    mockStorage.setItem.mockReset();
+    mockStorage.removeItem.mockReset();
+    mockStorage.getItem.mockResolvedValue(null);
+    await clearSessions();
+  });
+
+  it('records a session and reads it back', async () => {
+    await recordSession({ durationMs: 30_000, stars: 4, levelId: 3 });
+    // simulate storage returning the just-saved value
+    const saved = mockStorage.setItem.mock.calls[0][1];
+    mockStorage.getItem.mockResolvedValue(saved);
+    const sessions = await getSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({ durationMs: 30_000, stars: 4, levelId: 3 });
+  });
+
+  it('prunes entries older than 4 weeks on read', async () => {
+    const now = Date.now();
+    const old = new Date(now - FOUR_WEEKS_MS - 60_000).toISOString();
+    const fresh = new Date(now - 5_000).toISOString();
+    mockStorage.getItem.mockResolvedValue(JSON.stringify([
+      { date: old,   durationMs: 10_000, stars: 3, levelId: 1 },
+      { date: fresh, durationMs: 20_000, stars: 5, levelId: 2 },
+    ]));
+    const sessions = await getSessions(now);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].levelId).toBe(2);
+  });
+
+  it('clamps stars to 0..5 and durationMs to >= 0', async () => {
+    await recordSession({ durationMs: -10, stars: 99, levelId: 1 });
+    const saved = JSON.parse(mockStorage.setItem.mock.calls[0][1]);
+    expect(saved[0].durationMs).toBe(0);
+    expect(saved[0].stars).toBe(5);
+  });
+
+  it('recovers from corrupt JSON gracefully', async () => {
+    mockStorage.getItem.mockResolvedValue('{not-valid-json');
+    const sessions = await getSessions();
+    expect(sessions).toEqual([]);
+  });
+
+  describe('computeStats', () => {
+    it('returns empty stats for no records', () => {
+      const s = computeStats([]);
+      expect(s.totalSessions).toBe(0);
+      expect(s.favoriteLevels).toEqual([]);
+      expect(s.dailyBreakdown).toEqual([]);
+    });
+
+    it('computes totals and averages', () => {
+      const s = computeStats([
+        { date: '2026-05-01T10:00:00.000Z', durationMs: 60_000, stars: 5, levelId: 1 },
+        { date: '2026-05-01T11:00:00.000Z', durationMs: 30_000, stars: 3, levelId: 1 },
+        { date: '2026-05-02T12:00:00.000Z', durationMs: 90_000, stars: 4, levelId: 2 },
+      ]);
+      expect(s.totalSessions).toBe(3);
+      expect(s.totalDurationMs).toBe(180_000);
+      expect(s.averageStars).toBeCloseTo((5 + 3 + 4) / 3, 5);
+    });
+
+    it('returns top 3 favorite levels by play count', () => {
+      const records = [
+        ...Array(5).fill({ date: '2026-05-01T10:00:00.000Z', durationMs: 0, stars: 0, levelId: 1 }),
+        ...Array(3).fill({ date: '2026-05-01T10:00:00.000Z', durationMs: 0, stars: 0, levelId: 2 }),
+        ...Array(2).fill({ date: '2026-05-01T10:00:00.000Z', durationMs: 0, stars: 0, levelId: 3 }),
+        ...Array(1).fill({ date: '2026-05-01T10:00:00.000Z', durationMs: 0, stars: 0, levelId: 4 }),
+      ];
+      const s = computeStats(records);
+      expect(s.favoriteLevels.map((f) => f.levelId)).toEqual([1, 2, 3]);
+      expect(s.favoriteLevels[0].count).toBe(5);
+    });
+
+    it('produces chronological daily breakdown', () => {
+      const s = computeStats([
+        { date: '2026-05-02T10:00:00.000Z', durationMs: 60_000, stars: 5, levelId: 1 },
+        { date: '2026-05-01T10:00:00.000Z', durationMs: 30_000, stars: 3, levelId: 1 },
+      ]);
+      expect(s.dailyBreakdown.map((d) => d.date)).toEqual(['2026-05-01', '2026-05-02']);
+    });
+  });
+
+  it('getSessionStats integrates loading + computing', async () => {
+    mockStorage.getItem.mockResolvedValue(JSON.stringify([
+      { date: new Date().toISOString(), durationMs: 60_000, stars: 5, levelId: 1 },
+    ]));
+    const s = await getSessionStats();
+    expect(s.totalSessions).toBe(1);
+    expect(s.averageStars).toBe(5);
+  });
+});

--- a/services/__tests__/StreakManager.test.ts
+++ b/services/__tests__/StreakManager.test.ts
@@ -1,0 +1,132 @@
+/**
+ * StreakManager Tests
+ * Prüft Streak-Logik: Tag-Übergang, DST-Wechsel, Streak-Bruch nach Pause
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  getLocalDateKey,
+  getStreakData,
+  updateStreakAfterGame,
+  resetStreakData,
+} from '../StreakManager';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+describe('StreakManager', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    await resetStreakData();
+  });
+
+  describe('getLocalDateKey', () => {
+    it('formats date as YYYY-MM-DD in local time', () => {
+      const date = new Date(2026, 4, 23); // May 23, 2026
+      expect(getLocalDateKey(date)).toBe('2026-05-23');
+    });
+
+    it('pads month and day with leading zeros', () => {
+      const date = new Date(2026, 0, 5); // January 5, 2026
+      expect(getLocalDateKey(date)).toBe('2026-01-05');
+    });
+  });
+
+  describe('initial state', () => {
+    it('starts with zero streak and no lastPlayedDate', async () => {
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(0);
+      expect(data.longestStreak).toBe(0);
+      expect(data.lastPlayedDate).toBeNull();
+    });
+  });
+
+  describe('updateStreakAfterGame', () => {
+    it('sets streak to 1 on first game', async () => {
+      await updateStreakAfterGame(new Date(2026, 4, 1));
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(1);
+      expect(data.longestStreak).toBe(1);
+      expect(data.lastPlayedDate).toBe('2026-05-01');
+    });
+
+    it('does not increment streak when playing twice the same day', async () => {
+      await updateStreakAfterGame(new Date(2026, 4, 1));
+      await updateStreakAfterGame(new Date(2026, 4, 1));
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(1);
+    });
+
+    it('increments streak on consecutive day', async () => {
+      await updateStreakAfterGame(new Date(2026, 4, 1));
+      await updateStreakAfterGame(new Date(2026, 4, 2));
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(2);
+      expect(data.longestStreak).toBe(2);
+    });
+
+    it('builds streak across multiple consecutive days', async () => {
+      for (let day = 10; day <= 14; day++) {
+        await updateStreakAfterGame(new Date(2026, 4, day));
+      }
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(5);
+      expect(data.longestStreak).toBe(5);
+    });
+
+    it('resets streak to 1 after a 1-day gap', async () => {
+      await updateStreakAfterGame(new Date(2026, 4, 1));
+      await updateStreakAfterGame(new Date(2026, 4, 3)); // skip day 2
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(1);
+    });
+
+    it('resets streak to 1 after 2 days pause', async () => {
+      await updateStreakAfterGame(new Date(2026, 4, 1));
+      await updateStreakAfterGame(new Date(2026, 4, 2));
+      await updateStreakAfterGame(new Date(2026, 4, 3));
+      // 2-day pause
+      await updateStreakAfterGame(new Date(2026, 4, 6));
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(1);
+    });
+
+    it('preserves longestStreak after reset', async () => {
+      // Build streak of 3
+      await updateStreakAfterGame(new Date(2026, 4, 1));
+      await updateStreakAfterGame(new Date(2026, 4, 2));
+      await updateStreakAfterGame(new Date(2026, 4, 3));
+      // Break streak
+      await updateStreakAfterGame(new Date(2026, 4, 5));
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(1);
+      expect(data.longestStreak).toBe(3);
+    });
+
+    it('handles month boundary correctly', async () => {
+      await updateStreakAfterGame(new Date(2026, 3, 30)); // Apr 30
+      await updateStreakAfterGame(new Date(2026, 4, 1));  // May 1
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(2);
+    });
+
+    it('handles year boundary correctly', async () => {
+      await updateStreakAfterGame(new Date(2025, 11, 31)); // Dec 31
+      await updateStreakAfterGame(new Date(2026, 0, 1));   // Jan 1
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(2);
+    });
+
+    it('DST spring-forward: treats local days correctly (Apr 1 → Apr 2)', async () => {
+      // Simulate playing on consecutive local days near DST change
+      // Local date strings are used, so DST does not affect the result
+      const day1 = new Date(2026, 2, 29); // March 29 (near DST in Europe)
+      const day2 = new Date(2026, 2, 30); // March 30
+      await updateStreakAfterGame(day1);
+      await updateStreakAfterGame(day2);
+      const data = await getStreakData();
+      expect(data.currentStreak).toBe(2);
+    });
+  });
+});

--- a/services/useGamePhase.ts
+++ b/services/useGamePhase.ts
@@ -6,6 +6,7 @@ import { getImageElementCount } from '@components/LevelImageDisplay';
 import storageManager from '@services/StorageManager';
 import { markTodayCompleted } from '@services/DailyChallengeManager';
 import { updateStreakAfterGame } from '@services/StreakManager';
+import { recordSession } from '@services/SessionTracker';
 import SoundManager from '@services/SoundManager';
 import { useTimer } from '@services/useTimer';
 import type { DrawingPath } from '@components/DrawingCanvas';
@@ -39,6 +40,7 @@ export function useGamePhase({
   const timerExpireTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const replayCompleteTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const currentImageRef = useRef<LevelImage | null>(null);
+  const levelStartedAtRef = useRef<number>(Date.now());
 
   const [extraTimeMode, setExtraTimeMode] = useState(false);
 
@@ -73,6 +75,7 @@ export function useGamePhase({
       const image = getRandomImageForLevel(levelNumber);
       currentImageRef.current = image;
       setCurrentImage(image);
+      levelStartedAtRef.current = Date.now();
     } catch (error) {
       console.error('Error initializing level:', error);
       router.back();
@@ -171,6 +174,11 @@ export function useGamePhase({
       setUserRating(rating);
       await storageManager.saveLevelProgress(levelNumber, rating);
       await updateStreakAfterGame();
+      await recordSession({
+        durationMs: Date.now() - levelStartedAtRef.current,
+        stars: rating,
+        levelId: levelNumber,
+      });
       if (dailyChallengeLevel !== null && levelNumber === dailyChallengeLevel) {
         await markTodayCompleted();
       }
@@ -214,6 +222,7 @@ export function useGamePhase({
       currentImageRef.current = image;
       setCurrentImage(image);
       setTimeRemaining(getDisplayDuration(levelNumber, extraTimeMode));
+      levelStartedAtRef.current = Date.now();
       setPhase('memorize');
     } catch (error) {
       console.error('Error restarting level:', error);

--- a/services/useGamePhase.ts
+++ b/services/useGamePhase.ts
@@ -5,6 +5,7 @@ import { getDisplayDuration, getTotalLevels } from '@services/LevelManager';
 import { getImageElementCount } from '@components/LevelImageDisplay';
 import storageManager from '@services/StorageManager';
 import { markTodayCompleted } from '@services/DailyChallengeManager';
+import { updateStreakAfterGame } from '@services/StreakManager';
 import SoundManager from '@services/SoundManager';
 import { useTimer } from '@services/useTimer';
 import type { DrawingPath } from '@components/DrawingCanvas';
@@ -169,6 +170,7 @@ export function useGamePhase({
       SoundManager.playStarTap(rating);
       setUserRating(rating);
       await storageManager.saveLevelProgress(levelNumber, rating);
+      await updateStreakAfterGame();
       if (dailyChallengeLevel !== null && levelNumber === dailyChallengeLevel) {
         await markTodayCompleted();
       }


### PR DESCRIPTION
## Summary

Promotes accumulated `testing` work into `staging` for pre-production validation.

### Enthaltene Änderungen
- **Sprint A** (#191): FloatingStars + AnimatedHero (v1.5.1)
- **Version bumps**: 1.4.2 → 1.5.0, versionCode-Cleanup → 60
- **Sprint B** (#192): Streak-Tracker & Quick-Stats-Cards (#183, #185)
- **Sprint C** (#193): Konfetti + Achievement-System (v1.6.1) — inkl. Copilot-Review-Fixes (Recovery-Logik, Achievement-Reachability, stable Toast-Callback)
- **CI** (a82ef89): Pipeline läuft jetzt auch auf `testing`-Branch + testing-PRs
- **Sprint D** (#195): Onboarding (3-Step-Tour) + Eltern-Dashboard mit SessionTracker — inkl. Copilot-Review-Fixes (Session-Dauer-Reset, Dashboard-Cleanup, Animation-Cancel, SessionTracker self-heal)

### Status
- 323 Tests grün auf `testing`
- Alle 7 CI-Jobs zuletzt auf `testing` pass (Code Quality, Tests, Build Web, Platform, Security Audit, Privacy Docs, Keystore Scan)
- Privacy-Policy in allen 5 Files synchron (Sprint D)

## Test plan
- [ ] CI auf staging grün
- [ ] Web-Demo manuell: Onboarding (Erst-Start), Konfetti bei 5★, Badges-Modal, Eltern-Dashboard hinter ParentalGate
- [ ] Native (optional): Skia-Konfetti läuft, Pulse-Animation respektiert reduced-motion
- [ ] Privacy-Policy-Links prüfen (DE + EN)

> ⚠️ Merge nach `main` nur nach expliziter Freigabe durch den Nutzer (CLAUDE.md-Regel).