### PR TITLE
fix: flachere Aktions-Buttons + Eimer-Icon-Clipping (#180)

### DIFF
--- a/app/game.tsx
+++ b/app/game.tsx
@@ -339,7 +339,12 @@ export default function GameScreen() {
           accessibilityLabel={t('game.draw.undo')}
           accessibilityRole="button"
         >
-          <Text style={[styles.secondaryButtonText, isSmall && styles.buttonTextSmall]}>{t('game.draw.undo')}</Text>
+          <Text
+            style={[styles.secondaryButtonText, isSmall && styles.buttonTextSmall]}
+            numberOfLines={1}
+            adjustsFontSizeToFit
+            minimumFontScale={0.7}
+          >{t('game.draw.undo')}</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={[styles.secondaryButton, dynButton, drawing.paths.length === 0 && styles.buttonDisabled]}
@@ -368,7 +373,12 @@ export default function GameScreen() {
           }}
           disabled={drawing.paths.length === 0}
         >
-          <Text style={[styles.secondaryButtonText, isSmall && styles.buttonTextSmall]}>{t('game.draw.clear')}</Text>
+          <Text
+            style={[styles.secondaryButtonText, isSmall && styles.buttonTextSmall]}
+            numberOfLines={1}
+            adjustsFontSizeToFit
+            minimumFontScale={0.7}
+          >{t('game.draw.clear')}</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={[styles.primaryButton, dynButton]}
@@ -377,7 +387,12 @@ export default function GameScreen() {
             setPhase('result');
           }}
         >
-          <Text style={[styles.primaryButtonText, isSmall && styles.buttonTextSmall]}>{t('game.draw.done')}</Text>
+          <Text
+            style={[styles.primaryButtonText, isSmall && styles.buttonTextSmall]}
+            numberOfLines={1}
+            adjustsFontSizeToFit
+            minimumFontScale={0.7}
+          >{t('game.draw.done')}</Text>
         </TouchableOpacity>
       </View>
     </View>
@@ -826,7 +841,11 @@ const styles = StyleSheet.create({
     borderColor: Colors.primary,
   },
   toolToggleIcon: {
-    fontSize: 18,
+    fontSize: 20,
+    lineHeight: 24,
+    textAlign: 'center',
+    textAlignVertical: 'center',
+    includeFontPadding: false,
   },
   toolRowSeparator: {
     width: 1,

--- a/utils/useScreenLayout.ts
+++ b/utils/useScreenLayout.ts
@@ -110,8 +110,8 @@ export function useScreenLayout(): ScreenLayout {
   const toolbarMarginVertical        = isXSmall ? 2  : isSmall ? 4  : 8;
 
   // ── Aktions-Buttons ─────────────────────────────────────────────────
-  const buttonMinHeight      = isXSmall ? 34 : isSmall ? 38 : 48;
-  const buttonPaddingVertical = isXSmall ? 4  : isSmall ? 6  : 16;
+  const buttonMinHeight      = isXSmall ? 34 : isSmall ? 38 : 44;
+  const buttonPaddingVertical = isXSmall ? 4  : isSmall ? 6  : isMedium ? 8 : 10;
 
   // ── Canvas ───────────────────────────────────────────────────────────
   // Schätzung des Platzes, der von festen Elementen verbraucht wird:


### PR DESCRIPTION
Closes #180

## Problem

Auf Geräten mit größerem Bildschirm (insb. Nexus-6-Klasse / `md` Layout-Klasse) war das Draw-Phase-Layout suboptimal:

1. **Aktions-Buttons zu hoch** — "Rückgängig", "Alles löschen", "Fertig" hatten ~80 px Höhe, weil "Rückgängig" auf zwei Zeilen umbrach und `paddingVertical: 16` zusätzlich aufschlug.
2. **"Vorlage anzeigen"-Balken verschwunden** — Folge von (1), weil die Buttons den Platz nach unten wegfraßen.
3. **Eimer-Emoji halb abgeschnitten** — `toolToggleIcon` hatte `fontSize: 18` ohne explizite `lineHeight`, sodass das Bucket-Emoji auf Android visuell oberhalb der Button-Bounds saß.

## Änderungen

- [utils/useScreenLayout.ts](utils/useScreenLayout.ts#L113-L114): `buttonMinHeight` auf md/lg von 48 → 44, `buttonPaddingVertical` von 16 → 8 (md) / 10 (lg). Spart ~20 px Höhe pro Button-Reihe → Vorlage-Balken bleibt sichtbar.
- [app/game.tsx](app/game.tsx#L342-L386): Button-Texte mit `numberOfLines={1}` + `adjustsFontSizeToFit` + `minimumFontScale={0.7}`, damit "Rückgängig" einzeilig bleibt und bei extrem schmalen Buttons proportional skaliert statt umzubrechen.
- [app/game.tsx](app/game.tsx#L828-L834): `toolToggleIcon` mit `lineHeight: 24`, `textAlignVertical: 'center'`, `includeFontPadding: false` und `fontSize: 20` — Eimer/Pinsel werden vertikal mittig im 40×40 Button gerendert.

## Test plan

- [ ] `npm test` — alle Tests grün (geprüft: useScreenLayout + GameScreen passen)
- [ ] `npm run lint` — clean (geprüft)
- [ ] Auf Nexus 6 (oder vergleichbarem Android API 26 Gerät): Draw-Phase prüfen, dass Buttons einzeilig + flach sind und "Vorlage anzeigen" sichtbar bleibt
- [ ] Eimer-Icon ist vollständig sichtbar innerhalb des Tool-Toggle-Buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)