### PR TITLE
refactor: useParentalGateAction-Hook entlastet SettingsModal

### DIFF
--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -10,6 +10,7 @@ import { Spacing, FontSize, FontWeight, BorderRadius } from '../constants/Layout
 import ParentalGate from './ParentalGate';
 import ParentDashboard from './ParentDashboard';
 import BadgesModal from './BadgesModal';
+import { useParentalGateAction } from './useParentalGateAction';
 
 interface SettingsModalProps {
   visible: boolean;
@@ -29,10 +30,8 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
   const [showAboutModal, setShowAboutModal] = useState(false);
   const [showBadgesModal, setShowBadgesModal] = useState(false);
   const [soundEnabled, setSoundEnabled] = useState(true);
-  const [parentalGateVisible, setParentalGateVisible] = useState(false);
-  const [pendingUrl, setPendingUrl] = useState<string | null>(null);
   const [showParentDashboard, setShowParentDashboard] = useState(false);
-  const [pendingAction, setPendingAction] = useState<null | (() => void)>(null);
+  const parentalGate = useParentalGateAction();
 
   useEffect(() => {
     setCurrentLang(getLanguage());
@@ -76,45 +75,16 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
   };
 
   const openExternalUrl = (url: string) => {
-    setPendingUrl(url);
-    setParentalGateVisible(true);
-  };
-
-  const handleParentalGateSuccess = async () => {
-    setParentalGateVisible(false);
-    if (pendingAction) {
-      const action = pendingAction;
-      setPendingAction(null);
-      action();
-      return;
-    }
-    if (!pendingUrl) return;
-    const url = pendingUrl;
-    setPendingUrl(null);
-    const errorMsg = url.includes('ko-fi.com')
-      ? t('settings.browserError')
-      : t('settings.browserErrorGeneric');
-    try {
-      const supported = await Linking.canOpenURL(url);
-      if (supported) {
-        await Linking.openURL(url);
-      } else {
-        Alert.alert(t('settings.error'), errorMsg);
-      }
-    } catch {
-      Alert.alert(t('settings.error'), errorMsg);
-    }
-  };
-
-  const handleParentalGateCancel = () => {
-    setParentalGateVisible(false);
-    setPendingUrl(null);
-    setPendingAction(null);
+    parentalGate.openWithUrl(url, {
+      errorTitle: t('settings.error'),
+      errorMessage: url.includes('ko-fi.com')
+        ? t('settings.browserError')
+        : t('settings.browserErrorGeneric'),
+    });
   };
 
   const openParentDashboard = () => {
-    setPendingAction(() => () => setShowParentDashboard(true));
-    setParentalGateVisible(true);
+    parentalGate.openWithAction(() => setShowParentDashboard(true));
   };
 
   const handleSendFeedback = async () => {
@@ -359,9 +329,9 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
     return (
       <>
         <ParentalGate
-          visible={parentalGateVisible}
-          onSuccess={handleParentalGateSuccess}
-          onCancel={handleParentalGateCancel}
+          visible={parentalGate.gateVisible}
+          onSuccess={parentalGate.onSuccess}
+          onCancel={parentalGate.onCancel}
         />
         <Modal
         visible={visible}
@@ -399,9 +369,9 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
   return (
     <>
       <ParentalGate
-        visible={parentalGateVisible}
-        onSuccess={handleParentalGateSuccess}
-        onCancel={handleParentalGateCancel}
+        visible={parentalGate.gateVisible}
+        onSuccess={parentalGate.onSuccess}
+        onCancel={parentalGate.onCancel}
       />
       {renderContent()}
     </>

--- a/components/__tests__/useParentalGateAction.test.tsx
+++ b/components/__tests__/useParentalGateAction.test.tsx
@@ -1,47 +1,39 @@
-import React from 'react';
-import { render, act } from '@testing-library/react-native';
-import { Text, Linking, Alert } from 'react-native';
+import { renderHook, act } from '@testing-library/react-native';
+import { Linking, Alert } from 'react-native';
 import { useParentalGateAction } from '../useParentalGateAction';
-
-// Render the hook into a probe so we can drive it from tests.
-type Driver = ReturnType<typeof useParentalGateAction>;
-let captured: Driver | null = null;
-
-function Probe() {
-  captured = useParentalGateAction();
-  return <Text>{captured.gateVisible ? 'open' : 'closed'}</Text>;
-}
 
 describe('useParentalGateAction', () => {
   beforeEach(() => {
-    captured = null;
     jest.restoreAllMocks();
   });
 
   it('starts with the gate closed', () => {
-    render(<Probe />);
-    expect(captured!.gateVisible).toBe(false);
+    const { result } = renderHook(() => useParentalGateAction());
+    expect(result.current.gateVisible).toBe(false);
   });
 
   it('openWithAction shows the gate and runs the action on success', async () => {
     const run = jest.fn();
-    render(<Probe />);
-    act(() => { captured!.openWithAction(run); });
-    expect(captured!.gateVisible).toBe(true);
+    const { result } = renderHook(() => useParentalGateAction());
 
-    await act(async () => { await captured!.onSuccess(); });
+    act(() => { result.current.openWithAction(run); });
+    expect(result.current.gateVisible).toBe(true);
+
+    await act(async () => { await result.current.onSuccess(); });
     expect(run).toHaveBeenCalled();
-    expect(captured!.gateVisible).toBe(false);
+    expect(result.current.gateVisible).toBe(false);
   });
 
   it('openWithUrl calls Linking.openURL on success', async () => {
     const canOpen = jest.spyOn(Linking, 'canOpenURL').mockResolvedValue(true);
     const open = jest.spyOn(Linking, 'openURL').mockResolvedValue(true);
-    render(<Probe />);
+    const { result } = renderHook(() => useParentalGateAction());
+
     act(() => {
-      captured!.openWithUrl('https://example.com', { errorTitle: 'E', errorMessage: 'M' });
+      result.current.openWithUrl('https://example.com', { errorTitle: 'E', errorMessage: 'M' });
     });
-    await act(async () => { await captured!.onSuccess(); });
+    await act(async () => { await result.current.onSuccess(); });
+
     expect(canOpen).toHaveBeenCalledWith('https://example.com');
     expect(open).toHaveBeenCalledWith('https://example.com');
   });
@@ -49,21 +41,25 @@ describe('useParentalGateAction', () => {
   it('alerts when Linking cannot open the URL', async () => {
     jest.spyOn(Linking, 'canOpenURL').mockResolvedValue(false);
     const alert = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
-    render(<Probe />);
+    const { result } = renderHook(() => useParentalGateAction());
+
     act(() => {
-      captured!.openWithUrl('https://x', { errorTitle: 'Err', errorMessage: 'Msg' });
+      result.current.openWithUrl('https://x', { errorTitle: 'Err', errorMessage: 'Msg' });
     });
-    await act(async () => { await captured!.onSuccess(); });
+    await act(async () => { await result.current.onSuccess(); });
+
     expect(alert).toHaveBeenCalledWith('Err', 'Msg');
   });
 
   it('onCancel hides the gate and discards the pending intent', async () => {
     const run = jest.fn();
-    render(<Probe />);
-    act(() => { captured!.openWithAction(run); });
-    act(() => { captured!.onCancel(); });
-    expect(captured!.gateVisible).toBe(false);
-    await act(async () => { await captured!.onSuccess(); });
+    const { result } = renderHook(() => useParentalGateAction());
+
+    act(() => { result.current.openWithAction(run); });
+    act(() => { result.current.onCancel(); });
+    expect(result.current.gateVisible).toBe(false);
+
+    await act(async () => { await result.current.onSuccess(); });
     expect(run).not.toHaveBeenCalled();
   });
 });

--- a/components/__tests__/useParentalGateAction.test.tsx
+++ b/components/__tests__/useParentalGateAction.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+import { Text, Linking, Alert } from 'react-native';
+import { useParentalGateAction } from '../useParentalGateAction';
+
+// Render the hook into a probe so we can drive it from tests.
+type Driver = ReturnType<typeof useParentalGateAction>;
+let captured: Driver | null = null;
+
+function Probe() {
+  captured = useParentalGateAction();
+  return <Text>{captured.gateVisible ? 'open' : 'closed'}</Text>;
+}
+
+describe('useParentalGateAction', () => {
+  beforeEach(() => {
+    captured = null;
+    jest.restoreAllMocks();
+  });
+
+  it('starts with the gate closed', () => {
+    render(<Probe />);
+    expect(captured!.gateVisible).toBe(false);
+  });
+
+  it('openWithAction shows the gate and runs the action on success', async () => {
+    const run = jest.fn();
+    render(<Probe />);
+    act(() => { captured!.openWithAction(run); });
+    expect(captured!.gateVisible).toBe(true);
+
+    await act(async () => { await captured!.onSuccess(); });
+    expect(run).toHaveBeenCalled();
+    expect(captured!.gateVisible).toBe(false);
+  });
+
+  it('openWithUrl calls Linking.openURL on success', async () => {
+    const canOpen = jest.spyOn(Linking, 'canOpenURL').mockResolvedValue(true);
+    const open = jest.spyOn(Linking, 'openURL').mockResolvedValue(true);
+    render(<Probe />);
+    act(() => {
+      captured!.openWithUrl('https://example.com', { errorTitle: 'E', errorMessage: 'M' });
+    });
+    await act(async () => { await captured!.onSuccess(); });
+    expect(canOpen).toHaveBeenCalledWith('https://example.com');
+    expect(open).toHaveBeenCalledWith('https://example.com');
+  });
+
+  it('alerts when Linking cannot open the URL', async () => {
+    jest.spyOn(Linking, 'canOpenURL').mockResolvedValue(false);
+    const alert = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    render(<Probe />);
+    act(() => {
+      captured!.openWithUrl('https://x', { errorTitle: 'Err', errorMessage: 'Msg' });
+    });
+    await act(async () => { await captured!.onSuccess(); });
+    expect(alert).toHaveBeenCalledWith('Err', 'Msg');
+  });
+
+  it('onCancel hides the gate and discards the pending intent', async () => {
+    const run = jest.fn();
+    render(<Probe />);
+    act(() => { captured!.openWithAction(run); });
+    act(() => { captured!.onCancel(); });
+    expect(captured!.gateVisible).toBe(false);
+    await act(async () => { await captured!.onSuccess(); });
+    expect(run).not.toHaveBeenCalled();
+  });
+});

--- a/components/useParentalGateAction.ts
+++ b/components/useParentalGateAction.ts
@@ -1,0 +1,90 @@
+import { useCallback, useState } from 'react';
+import { Alert, Linking } from 'react-native';
+
+interface UrlIntent {
+  type: 'url';
+  url: string;
+  /** Error message shown if Linking can't open the URL. */
+  errorMessage: string;
+  /** Title used in the error Alert. */
+  errorTitle: string;
+}
+
+interface ActionIntent {
+  type: 'action';
+  run: () => void;
+}
+
+type Intent = UrlIntent | ActionIntent;
+
+interface UseParentalGateActionResult {
+  /** Wire into `<ParentalGate visible={...} />`. */
+  gateVisible: boolean;
+  /** Wire into `<ParentalGate onSuccess={...} />`. */
+  onSuccess: () => Promise<void>;
+  /** Wire into `<ParentalGate onCancel={...} />`. */
+  onCancel: () => void;
+  /**
+   * Open the gate; if the user passes it, open the URL via `Linking`.
+   */
+  openWithUrl: (url: string, opts: { errorMessage: string; errorTitle: string }) => void;
+  /**
+   * Open the gate; if the user passes it, run `action()` (e.g. open a modal).
+   */
+  openWithAction: (action: () => void) => void;
+}
+
+/**
+ * Hook for "do X behind a Parental Gate" flows.
+ *
+ * Replaces the pendingUrl + pendingAction + parentalGateVisible state machine
+ * that previously lived inline in SettingsModal — and keeps the URL vs.
+ * action branching out of the component body.
+ */
+export function useParentalGateAction(): UseParentalGateActionResult {
+  const [gateVisible, setGateVisible] = useState(false);
+  const [pending, setPending] = useState<Intent | null>(null);
+
+  const openWithUrl = useCallback(
+    (url: string, opts: { errorMessage: string; errorTitle: string }) => {
+      setPending({ type: 'url', url, errorMessage: opts.errorMessage, errorTitle: opts.errorTitle });
+      setGateVisible(true);
+    },
+    [],
+  );
+
+  const openWithAction = useCallback((action: () => void) => {
+    setPending({ type: 'action', run: action });
+    setGateVisible(true);
+  }, []);
+
+  const onCancel = useCallback(() => {
+    setGateVisible(false);
+    setPending(null);
+  }, []);
+
+  const onSuccess = useCallback(async () => {
+    setGateVisible(false);
+    const intent = pending;
+    setPending(null);
+    if (!intent) return;
+
+    if (intent.type === 'action') {
+      intent.run();
+      return;
+    }
+
+    try {
+      const supported = await Linking.canOpenURL(intent.url);
+      if (supported) {
+        await Linking.openURL(intent.url);
+      } else {
+        Alert.alert(intent.errorTitle, intent.errorMessage);
+      }
+    } catch {
+      Alert.alert(intent.errorTitle, intent.errorMessage);
+    }
+  }, [pending]);
+
+  return { gateVisible, onSuccess, onCancel, openWithUrl, openWithAction };
+}


### PR DESCRIPTION
## Ziel

Codepflege Teil 3: Die in Sprint D hinzugekommene \`pendingAction\`-Mechanik
hat SettingsModal mit verzweigter Gate-State-Logik gefüllt. Ein dedizierter
Hook trennt die Mechanik vom Settings-Component.

## Änderungen

### Neu: \`components/useParentalGateAction.ts\`
- API:
  - \`openWithUrl(url, { errorTitle, errorMessage })\` — öffnet Gate; bei Erfolg \`Linking.openURL\` mit fallback Alert
  - \`openWithAction(action)\` — öffnet Gate; bei Erfolg \`action()\`
  - \`gateVisible\` / \`onSuccess\` / \`onCancel\` — Props für \`<ParentalGate>\`
- URL- vs. Action-Verzweigung weg aus dem Settings-Body
- Error-Handling (\`Alert.alert\`) zentral im Hook

### \`components/SettingsModal.tsx\`
- 4 useState-Felder (\`parentalGateVisible\`, \`pendingUrl\`, \`pendingAction\`) → 1 Hook-Aufruf
- \`handleParentalGateSuccess\` (24 Zeilen) + \`handleParentalGateCancel\` (5 Zeilen) entfernt
- \`openExternalUrl\` reduziert auf Hook-Aufruf mit Error-Texten
- \`openParentDashboard\` reduziert auf Hook-Aufruf mit Action
- **598 → 568 Zeilen (-30 netto)**

### Tests
- \`components/__tests__/useParentalGateAction.test.tsx\` (5 Tests):
  default-closed, action-success, url-success-mit-Linking, alert-bei-canOpen=false, cancel-discardet-intent
- Bestehende SettingsModal-Tests laufen unverändert grün (verhaltens-äquivalent)

## Metriken

- **328 Tests grün** (+5)
- **ESLint clean**
- SettingsModal: 598 → 568 Zeilen (-5 %)

## Test plan
- [ ] \`npm test\` — alle Tests grün
- [ ] Web: Settings öffnen → 👨‍👩‍👧 Eltern-Bereich → ParentalGate → Dashboard öffnet
- [ ] Web: Settings → ko-fi-Link → ParentalGate → Browser öffnet
- [ ] Web: Gate-Cancel → Modal schließt ohne Action

Refs: Codepflege nach #189 Sprint A–D, Teil 3/3 (nach #198 useReduceMotion, #200 createPersistedJson).