### PR TITLE
fix(ts): TypeScript-Fehler in Button, FloatingStars, Chip beheben (#194)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -74,7 +74,7 @@ jobs:
         run: npm run validate:svg-counts
 
       - name: TypeScript Type Check
-        run: npx tsc --noEmit || true
+        run: npx tsc --noEmit
 
   # ============================================================================
   # JOB 2: Unit Tests & Coverage

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -152,7 +152,7 @@ export function Button({
       >
         {variant === 'primary' && (
           <LinearGradient
-            colors={Colors.gradient.cta as [string, ...string[]]}
+            colors={Colors.gradient.cta}
             start={{ x: 0, y: 0 }}
             end={{ x: 1, y: 0 }}
             style={StyleSheet.absoluteFillObject}

--- a/components/Chip.tsx
+++ b/components/Chip.tsx
@@ -42,12 +42,12 @@ export function Chip({
   }));
 
   const handlePressIn = () => {
-    if (reduceMotion.current) return;
+    if (reduceMotion) return;
     scale.value = withSpring(0.94, { damping: 15, stiffness: 300 });
   };
 
   const handlePressOut = () => {
-    if (reduceMotion.current) return;
+    if (reduceMotion) return;
     scale.value = withSpring(1, { damping: 15, stiffness: 300 });
   };
 

--- a/components/FloatingStars.tsx
+++ b/components/FloatingStars.tsx
@@ -66,7 +66,8 @@ function DecorElement({ item, animate }: { item: DecorItem; animate: boolean }) 
     <Animated.View
       style={[
         styles.item,
-        { top: item.top, left: item.left, opacity: item.opacity },
+        // reanimated style typing rejects '%' strings — runtime supports them
+        { top: item.top as unknown as number, left: item.left as unknown as number, opacity: item.opacity },
         animStyle,
       ]}
       pointerEvents="none"

--- a/components/FloatingStars.tsx
+++ b/components/FloatingStars.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View, type ViewStyle } from 'react-native';
 import { useReduceMotion } from '../utils/useReduceMotion';
 import Animated, {
   cancelAnimation,
@@ -66,8 +66,8 @@ function DecorElement({ item, animate }: { item: DecorItem; animate: boolean }) 
     <Animated.View
       style={[
         styles.item,
-        // reanimated style typing rejects '%' strings — runtime supports them
-        { top: item.top as unknown as number, left: item.left as unknown as number, opacity: item.opacity },
+        // reanimated style typing rejects '%' strings — cast to ViewStyle['top'] (DimensionValue) preserves semantic intent
+        { top: item.top as ViewStyle['top'], left: item.left as ViewStyle['left'], opacity: item.opacity },
         animStyle,
       ]}
       pointerEvents="none"

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -15,11 +15,11 @@ export const Colors = {
 
   // Gradient-Kombinationen (für LinearGradient)
   gradient: {
-    primary: ['#7C5CFF', '#F093FB'],     // Primary Gradient (Vivid Purple → Rosa)
-    secondary: ['#F093FB', '#f5576c'],   // Rosa-Gradient
-    warm: ['#FFB547', '#FF6B6B'],        // Apricot-Gradient
-    cta: ['#7C5CFF', '#F093FB'],         // CTA-Gradient mit neuem Primary
-    teal: ['#4ECDC4', '#44CF6C'],        // Teal-Gradient
+    primary:   ['#7C5CFF', '#F093FB'] as const,
+    secondary: ['#F093FB', '#f5576c'] as const,
+    warm:      ['#FFB547', '#FF6B6B'] as const,
+    cta:       ['#7C5CFF', '#F093FB'] as const,
+    teal:      ['#4ECDC4', '#44CF6C'] as const,
   },
 
   // UI Farben - "Warm Paper"

--- a/utils/__tests__/useReduceMotion.test.tsx
+++ b/utils/__tests__/useReduceMotion.test.tsx
@@ -35,7 +35,7 @@ describe('useReduceMotion', () => {
     jest.spyOn(AccessibilityInfo, 'isReduceMotionEnabled').mockResolvedValue(false);
     let capturedHandler: ((rm: boolean) => void) | undefined;
     jest.spyOn(AccessibilityInfo, 'addEventListener').mockImplementation((_event, handler) => {
-      capturedHandler = handler as (rm: boolean) => void;
+      capturedHandler = handler as unknown as (rm: boolean) => void;
       return { remove: jest.fn() } as any;
     });
 


### PR DESCRIPTION
## Problem

`npx tsc --noEmit` meldete **4 TypeScript-Fehler** auf `testing`. CI fing sie nicht ab, weil der TypeScript-Check mit `|| true` als non-blocking lief.

## Änderungen

### `constants/Colors.ts`
`Colors.gradient.*` als `as const`-Tupel typisiert — alle Gradient-Arrays haben jetzt den Typ `readonly [string, string]`, was `expo-linear-gradient`s `readonly [ColorValue, ColorValue, ...ColorValue[]]` direkt erfüllt. Kein Cast mehr nötig.

### `components/Button.tsx`
`as [string, ...string[]]`-Cast entfernt — durch die `as const`-Typisierung in Colors.ts überflüssig.

### `components/FloatingStars.tsx`
`top`/`left` per `as unknown as number` gecastet mit erklärendem Kommentar: Reanimateds Style-Typing lehnt `%`-Strings ab, obwohl die Runtime sie unterstützt.

### `components/Chip.tsx`
`reduceMotion.current` → `reduceMotion` — `useReduceMotion()` gibt `boolean` zurück (kein Ref), `.current` war ein Überbleibsel einer alten Implementierung.

### `utils/__tests__/useReduceMotion.test.tsx`
`as unknown as (rm: boolean) => void` statt direktem Cast — löst Typ-Inkompatiblität zwischen Reacts `AccessibilityAnnouncementFinishedEventHandler` und dem Test-Handler auf.

### `.github/workflows/ci-cd.yml`
TypeScript-Check von `npx tsc --noEmit || true` (non-blocking) auf `npx tsc --noEmit` (blocking) umgestellt.

## Test

- `npx tsc --noEmit` → **sauber, keine Fehler**
- `npm run lint` → grün
- `npm run test:ci` → **342 Tests bestanden**

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)