### PR TITLE
testing → staging: game.tsx Refactoring + Issue #199 Fix (#206 + #207)

### DIFF
--- a/app/game.tsx
+++ b/app/game.tsx
@@ -1,12 +1,11 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Alert, Modal, Platform, ScrollView, FlatList } from 'react-native';
+import React, { useState, useEffect, useCallback } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Modal, Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useScreenLayout } from '@utils/useScreenLayout';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { getTotalLevels, getDifficultyForLevel } from '@services/LevelManager';
 import { useTranslation, getLanguage } from '@services/i18n';
 import { useTheme } from '@services/ThemeContext';
-import { DrawingColors } from '../constants/Colors';
 import Colors from '../constants/Colors';
 import { Spacing, FontSize, FontWeight, BorderRadius } from '../constants/Layout';
 import { FeatureFlags } from '../constants/featureFlags';
@@ -14,7 +13,6 @@ import LevelImageDisplay from '@components/LevelImageDisplay';
 import DrawingCanvas, { useDrawingCanvas } from '@components/DrawingCanvas';
 import SettingsModal from '@components/SettingsModal';
 import { ErrorBoundary } from '@components/ErrorBoundary';
-import { AnimatedFeedback, AnimatedStar } from '@components/AnimatedPrimitives';
 import ConfettiBurst from '@components/ConfettiBurst';
 import BadgeUnlockToast from '@components/BadgeUnlockToast';
 import SoundManager from '@services/SoundManager';
@@ -25,14 +23,10 @@ import {
 } from '@services/AchievementManager';
 import { getStreakData } from '@services/StreakManager';
 import storageManager from '@services/StorageManager';
-import type { DrawingPath } from '@components/DrawingCanvas';
+import MemorizePhase from '@components/game/MemorizePhase';
+import DrawPhase from '@components/game/DrawPhase';
+import ResultPhase from '@components/game/ResultPhase';
 
-/**
- * Game Screen - Hauptspiel mit 3 Phasen
- * Phase 1: Memorize (Bild anzeigen mit Timer)
- * Phase 2: Draw (Zeichnen - noch nicht implementiert)
- * Phase 3: Result (Bewertung - noch nicht implementiert)
- */
 export default function GameScreen() {
   const { t } = useTranslation();
   const router = useRouter();
@@ -49,13 +43,9 @@ export default function GameScreen() {
   const lastCheckedRatingRef = React.useRef<number>(0);
   const handleBadgeToastHide = useCallback(() => setUnlockedBadge(null), []);
 
-  // Drawing Canvas Hook
   const drawing = useDrawingCanvas();
-
-  // Get current language for accessibility
   const currentLang = getLanguage();
 
-  // Level aus URL-Parameter auslesen, falls vorhanden, und validieren
   const parsedLevel = params.level ? parseInt(params.level as string, 10) : 1;
   const totalLevels = getTotalLevels();
   const initialLevel =
@@ -90,7 +80,6 @@ export default function GameScreen() {
     isDailyChallenge,
   });
 
-  // Reset hint joker when level changes
   const handleRestartCurrentLevel = () => {
     setHasUsedHint(false);
     restartCurrentLevel();
@@ -106,22 +95,19 @@ export default function GameScreen() {
     restartFromLevel1();
   };
 
-  // Initialize sound manager
   useEffect(() => {
     SoundManager.init();
   }, []);
 
-  // Trigger confetti + achievement check on each new rating (run once per rating value)
   useEffect(() => {
     if (userRating === 0 || userRating === lastCheckedRatingRef.current) return;
     lastCheckedRatingRef.current = userRating;
 
     if (userRating === 5 && FeatureFlags.ENABLE_CONFETTI) {
       setShowConfetti(true);
-      const t = setTimeout(() => setShowConfetti(false), 2700);
-      // not awaited — best-effort
+      const timer = setTimeout(() => setShowConfetti(false), 2700);
       checkAchievements(userRating);
-      return () => clearTimeout(t);
+      return () => clearTimeout(timer);
     }
     checkAchievements(userRating);
   }, [userRating]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -133,9 +119,7 @@ export default function GameScreen() {
         storageManager.getProgress(),
         getStreakData(),
       ]);
-      // Derive daily-challenge count from gallery (saved daily entries are flagged)
       const dailyChallengesCompleted = gallery.filter((g) => g.isDailyChallenge).length;
-      // Derive distinct difficulties played from completed levels
       const difficultiesPlayed = Array.from(
         new Set(
           Object.keys(progress.levels ?? {})
@@ -158,378 +142,11 @@ export default function GameScreen() {
     }
   };
 
-  // Memoized dynamic styles – stable across re-renders unless layout changes
-  const dynCanvasContainer = useMemo(() => ({
-    maxHeight: layout.canvasMaxHeight,
-    minHeight: layout.canvasMinHeight,
-    marginVertical: layout.canvasMarginVertical,
-  }), [layout.canvasMaxHeight, layout.canvasMinHeight, layout.canvasMarginVertical]);
-
-  const dynToolbar = useMemo(() => ({
-    marginVertical: layout.toolbarMarginVertical,
-  }), [layout.toolbarMarginVertical]);
-
-  const dynToolbarButton = useMemo(() => ({
-    minHeight: layout.toolbarButtonMinHeight,
-    paddingVertical: layout.toolbarButtonPaddingVertical,
-  }), [layout.toolbarButtonMinHeight, layout.toolbarButtonPaddingVertical]);
-
-  const dynButton = useMemo(() => ({
-    minHeight: layout.buttonMinHeight,
-    paddingVertical: layout.buttonPaddingVertical,
-  }), [layout.buttonMinHeight, layout.buttonPaddingVertical]);
-
-  // Render Memorize Phase
-  const renderMemorizePhase = () => (
-    <View style={styles.phaseContainer}>
-      <Text style={styles.phaseTitle}>{t('game.memorize.title')}</Text>
-
-      {/* Timer */}
-      <View style={styles.timerContainer}>
-        <Text style={styles.timerText}>{timeRemaining}s</Text>
-      </View>
-
-      {/* Bild-Container */}
-      <View style={styles.imageContainer}>
-        {currentImage && (
-          <View style={[styles.imagePlaceholder, { minWidth: layout.imagePlaceholderMinSize, minHeight: layout.imagePlaceholderMinSize }]}>
-            <ErrorBoundary>
-              <LevelImageDisplay image={currentImage} size={layout.memorizeImageSize} revealStep={revealStep} />
-            </ErrorBoundary>
-            <Text style={styles.imageName}>{currentLang === 'en' ? currentImage.displayNameEn : currentImage.displayName}</Text>
-            <Text style={styles.imageInfo}>
-              Level {levelNumber} • {currentImage.strokeCount} Striche
-            </Text>
-          </View>
-        )}
-      </View>
-    </View>
-  );
-
-  // Render Draw Phase
-  const renderDrawPhase = () => {
-    const levelName = currentLang === 'en' ? currentImage?.displayNameEn : currentImage?.displayName;
-    return (
-    <View style={styles.phaseContainer}>
-      {/* Info-Streifen: Aufgabe + Hint-Joker */}
-      <View style={styles.infoStrip}>
-        <View style={styles.infoStripCenter}>
-          <Text style={styles.infoStripLabel}>{t('game.draw.referenceLabel')}</Text>
-          <Text style={styles.infoStripText} numberOfLines={2}>
-            {t('game.draw.drawFromMemory')}{levelName ? ` — ${levelName}` : ''}
-          </Text>
-        </View>
-        <TouchableOpacity
-          style={[styles.hintButton, hasUsedHint && styles.hintButtonUsed]}
-          onPress={() => {
-            if (!hasUsedHint) {
-              setHasUsedHint(true);
-              setShowHintModal(true);
-            }
-          }}
-          disabled={hasUsedHint}
-          accessibilityLabel={hasUsedHint ? t('game.draw.hintUsed') : t('game.draw.hintButton')}
-          accessibilityRole="button"
-        >
-          <Text style={styles.hintButtonIcon}>👁</Text>
-        </TouchableOpacity>
-      </View>
-
-      {/* Zeichenfläche mit react-native-skia */}
-      <View style={[styles.canvasContainer, dynCanvasContainer]}>
-        <ErrorBoundary>
-          <DrawingCanvas
-            strokeColor={drawing.color}
-            strokeWidth={drawing.strokeWidth}
-            tool={drawing.tool}
-            paths={drawing.paths}
-            onDrawingChange={drawing.setPaths}
-          />
-        </ErrorBoundary>
-      </View>
-
-      {/* Toolbar-Gruppe */}
-      <View style={[styles.toolbarGroup, dynToolbar]}>
-        {/* Reihe 1: Inline-Farbreihe */}
-        <FlatList
-          data={DrawingColors}
-          keyExtractor={(item) => item.hex}
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={styles.colorRowContent}
-          renderItem={({ item }) => (
-            <TouchableOpacity
-              style={[
-                styles.inlineColorSwatch,
-                item.border && { borderColor: item.border },
-                drawing.color === item.hex && styles.inlineColorSwatchActive,
-              ]}
-              onPress={() => drawing.setColor(item.hex)}
-              accessibilityLabel={currentLang === 'de' ? item.name : item.nameEn}
-              accessibilityRole="button"
-            >
-              <View style={[styles.inlineColorSwatchInner, { backgroundColor: item.hex }]} />
-              {drawing.color === item.hex && (
-                <Text style={styles.inlineColorCheckmark}>✓</Text>
-              )}
-            </TouchableOpacity>
-          )}
-        />
-
-        {/* Trennlinie */}
-        <View style={styles.toolbarDivider} />
-
-        {/* Reihe 2: Pen/Fill + Strichstärken in einer Zeile */}
-        <View style={styles.toolRow}>
-          {/* Pen/Fill Toggle */}
-          <TouchableOpacity
-            style={[styles.toolToggleButton, drawing.tool === 'brush' && styles.toolToggleButtonActive]}
-            onPress={() => drawing.setTool('brush')}
-            accessibilityLabel={t('game.draw.toolBrush')}
-            accessibilityRole="button"
-          >
-            <Text style={styles.toolToggleIcon}>✏️</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={[styles.toolToggleButton, drawing.tool === 'fill' && styles.toolToggleButtonActive]}
-            onPress={() => drawing.setTool('fill')}
-            accessibilityLabel={t('game.draw.toolFill')}
-            accessibilityRole="button"
-          >
-            <Text style={styles.toolToggleIcon}>🪣</Text>
-          </TouchableOpacity>
-
-          {/* Vertikaler Trenner */}
-          <View style={styles.toolRowSeparator} />
-
-          {/* Strichstärken-Circles */}
-          {([2, 3, 5] as const).map((size) => (
-            <TouchableOpacity
-              key={size}
-              style={[
-                styles.strokeCircleButton,
-                drawing.tool === 'fill' && styles.strokeCircleDisabled,
-              ]}
-              onPress={() => { if (drawing.tool !== 'fill') drawing.setStrokeWidth(size); }}
-              disabled={drawing.tool === 'fill'}
-              accessibilityLabel={`${t('game.draw.strokeWidth')} ${size}`}
-              accessibilityRole="button"
-            >
-              <View style={[
-                styles.strokeCircle,
-                {
-                  width: size === 2 ? 10 : size === 3 ? 16 : 22,
-                  height: size === 2 ? 10 : size === 3 ? 16 : 22,
-                  backgroundColor: drawing.strokeWidth === size && drawing.tool !== 'fill'
-                    ? drawing.color
-                    : Colors.text.secondary,
-                },
-              ]} />
-            </TouchableOpacity>
-          ))}
-        </View>
-      </View>
-
-      {/* Buttons */}
-      <View style={styles.buttonRow}>
-        <TouchableOpacity
-          style={[styles.secondaryButton, dynButton]}
-          onPress={drawing.undo}
-          disabled={drawing.paths.length === 0}
-          accessibilityLabel={t('game.draw.undo')}
-          accessibilityRole="button"
-        >
-          <Text
-            style={[styles.secondaryButtonText, isSmall && styles.buttonTextSmall]}
-            numberOfLines={1}
-            adjustsFontSizeToFit
-            minimumFontScale={0.7}
-          >{t('game.draw.undo')}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.secondaryButton, dynButton, drawing.paths.length === 0 && styles.buttonDisabled]}
-          accessibilityLabel={t('game.draw.clear')}
-          accessibilityRole="button"
-          onPress={() => {
-            if (Platform.OS === 'web') {
-              if (drawing.paths.length > 0 && window.confirm(t('game.draw.clearConfirm'))) { // platform-safe
-                drawing.setPaths([]);
-              }
-            } else {
-              if (drawing.paths.length === 0) return;
-              Alert.alert(
-                t('game.draw.clear'),
-                t('game.draw.clearConfirm'),
-                [
-                  { text: t('common.cancel'), style: 'cancel' },
-                  {
-                    text: t('common.yes'),
-                    style: 'destructive',
-                    onPress: () => { drawing.setPaths([]); },
-                  },
-                ]
-              );
-            }
-          }}
-          disabled={drawing.paths.length === 0}
-        >
-          <Text
-            style={[styles.secondaryButtonText, isSmall && styles.buttonTextSmall]}
-            numberOfLines={1}
-            adjustsFontSizeToFit
-            minimumFontScale={0.7}
-          >{t('game.draw.clear')}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.primaryButton, dynButton]}
-          onPress={() => {
-            SoundManager.playPhaseTransition();
-            setPhase('result');
-          }}
-        >
-          <Text
-            style={[styles.primaryButtonText, isSmall && styles.buttonTextSmall]}
-            numberOfLines={1}
-            adjustsFontSizeToFit
-            minimumFontScale={0.7}
-          >{t('game.draw.done')}</Text>
-        </TouchableOpacity>
-      </View>
-    </View>
-    );
-  };
-
-  // Render Result Phase
-  const renderResultPhase = () => {
-    const getFeedbackText = (rating: number) => {
-      if (rating === 5) return t('game.result.feedback5');
-      if (rating === 4) return t('game.result.feedback4');
-      if (rating === 3) return t('game.result.feedback3');
-      if (rating >= 1) return t('game.result.feedback1');
-      return t('game.result.tapStars');
-    };
-
-    // Bildgröße: 44% der Bildschirmbreite, min 140px, max 220px
-    const imageSize = Math.min(Math.max(screenWidth * 0.44, 140), 220);
-
-    return (
-      <ScrollView
-        style={styles.resultScrollView}
-        contentContainerStyle={styles.resultContent}
-        showsVerticalScrollIndicator={false}
-      >
-        {/* 1. Side-by-side Vergleich */}
-        <View style={styles.comparisonContainer}>
-          {/* Vorlage */}
-          <View style={[styles.comparisonCard, { width: imageSize }]}>
-            <View style={[styles.comparisonCardHeader, styles.comparisonCardHeaderTemplate]}>
-              <Text style={[styles.comparisonCardLabel, { color: Colors.primary }]}>
-                {t('game.result.template').toUpperCase()}
-              </Text>
-            </View>
-            <View style={[styles.comparisonImage, { width: imageSize, height: imageSize }]}>
-              {currentImage && (
-                <LevelImageDisplay image={currentImage} size={imageSize} />
-              )}
-            </View>
-          </View>
-
-          {/* Deine Zeichnung */}
-          <View style={[styles.comparisonCard, { width: imageSize }]}>
-            <View style={[styles.comparisonCardHeader, styles.comparisonCardHeaderDrawing]}>
-              <Text style={[styles.comparisonCardLabel, { color: Colors.secondary }]}>
-                {t('game.result.yourDrawing').toUpperCase()}
-              </Text>
-            </View>
-            <View style={[styles.comparisonImage, { width: imageSize, height: imageSize }]}>
-              <DrawingCanvas
-                width={imageSize}
-                height={imageSize}
-                paths={isReplaying ? replayPaths : drawing.paths}
-                strokeColor={Colors.drawing.black}
-                strokeWidth={2}
-              />
-            </View>
-          </View>
-        </View>
-
-        {/* 2. Sterne-Bewertung */}
-        <View style={[styles.starsContainer, isSmall && styles.starsContainerSmall]}>
-          <Text style={styles.starsTitle}>{t('game.result.howWell')}</Text>
-          <View style={styles.starsRow}>
-            {[1, 2, 3, 4, 5].map((star) => (
-              <AnimatedStar
-                key={star}
-                filled={star <= userRating}
-                index={star - 1}
-                onPress={() => handleRatingSubmit(star)}
-                accessibilityLabel={`${star} Stern${star !== 1 ? 'e' : ''}`}
-              />
-            ))}
-          </View>
-          <AnimatedFeedback visible={userRating > 0}>
-            <Text style={styles.feedbackText}>{getFeedbackText(userRating)}</Text>
-          </AnimatedFeedback>
-        </View>
-
-        {/* Completion banner for Level 10 */}
-        {levelNumber >= getTotalLevels() && userRating > 0 && (
-          <View style={styles.completionBanner}>
-            <Text style={styles.completionTitle}>{t('game.result.allLevelsComplete')}</Text>
-            <Text style={styles.completionMessage}>{t('game.result.allLevelsCompleteMessage')}</Text>
-          </View>
-        )}
-
-        {/* 3. Aktions-Zeile: Zeitraffer | Galerie | Weiter */}
-        <View style={styles.actionRow}>
-          <TouchableOpacity
-            style={styles.actionButton}
-            onPress={isReplaying ? () => setIsReplaying(false) : startReplay}
-            accessibilityRole="button"
-          >
-            <Text style={styles.actionButtonText}>
-              {isReplaying ? '⏹' : '🎬'}
-            </Text>
-            <Text style={styles.actionButtonLabel}>
-              {isReplaying ? t('game.result.replayStop') : t('game.result.replay')}
-            </Text>
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            style={[styles.actionButton, savedToGallery && styles.actionButtonSaved]}
-            onPress={saveToGallery}
-            disabled={savedToGallery}
-            accessibilityRole="button"
-            accessibilityLabel={savedToGallery ? t('gallery.saved') : t('gallery.save')}
-            accessibilityState={{ disabled: savedToGallery }}
-          >
-            <Text style={styles.actionButtonText}>{savedToGallery ? '✓' : '🖼'}</Text>
-            <Text style={[styles.actionButtonLabel, savedToGallery && styles.actionButtonLabelSaved]}>
-              {savedToGallery ? t('gallery.saved') : t('gallery.save')}
-            </Text>
-          </TouchableOpacity>
-
-          {levelNumber < getTotalLevels() ? (
-            <TouchableOpacity style={[styles.actionButton, styles.actionButtonPrimary]} onPress={handleStartNextLevel}>
-              <Text style={[styles.actionButtonText, styles.actionButtonPrimaryText]}>→</Text>
-              <Text style={[styles.actionButtonLabel, styles.actionButtonPrimaryText]}>{t('game.result.nextLevel')}</Text>
-            </TouchableOpacity>
-          ) : (
-            <TouchableOpacity style={[styles.actionButton, styles.actionButtonPrimary]} onPress={handleRestartFromLevel1}>
-              <Text style={[styles.actionButtonText, styles.actionButtonPrimaryText]}>🔄</Text>
-              <Text style={[styles.actionButtonLabel, styles.actionButtonPrimaryText]}>{t('game.result.playAgain')}</Text>
-            </TouchableOpacity>
-          )}
-        </View>
-      </ScrollView>
-    );
-  };
-
   const levelName = currentLang === 'en' ? currentImage?.displayNameEn : currentImage?.displayName;
 
   return (
     <View style={[styles.container, { paddingBottom: insets.bottom }]}>
-      {/* Header — Referenz-Design: Titel + Level-Info links, Progress-Dots + Settings rechts */}
+      {/* Header */}
       <View style={[styles.header, { paddingTop: insets.top + 8, paddingHorizontal: layout.headerPaddingHorizontal, paddingBottom: Spacing.sm }]}>
         <TouchableOpacity
           style={styles.headerLeft}
@@ -564,7 +181,7 @@ export default function GameScreen() {
         </View>
       </View>
 
-      {/* Pill-Tabs: ✏️ Zeichnen / 🎨 Ergebnis */}
+      {/* Pill-Tabs: Zeichnen / Ergebnis */}
       {(phase === 'draw' || phase === 'result') && (
         <View style={styles.tabBar}>
           <TouchableOpacity
@@ -587,7 +204,7 @@ export default function GameScreen() {
       {/* Settings Modal */}
       <SettingsModal visible={showSettings} onClose={() => setShowSettings(false)} />
 
-      {/* Hint Modal — Vorlage einmal ansehen */}
+      {/* Hint Modal */}
       <Modal
         visible={showHintModal}
         transparent
@@ -618,11 +235,64 @@ export default function GameScreen() {
       </Modal>
 
       {/* Phase Content */}
-      {phase === 'memorize' && renderMemorizePhase()}
-      {phase === 'draw' && renderDrawPhase()}
-      {phase === 'result' && renderResultPhase()}
+      {phase === 'memorize' && (
+        <MemorizePhase
+          timeRemaining={timeRemaining}
+          currentImage={currentImage}
+          levelNumber={levelNumber}
+          currentLang={currentLang}
+          memorizeImageSize={layout.memorizeImageSize}
+          imagePlaceholderMinSize={layout.imagePlaceholderMinSize}
+          revealStep={revealStep}
+        />
+      )}
+      {phase === 'draw' && (
+        <DrawPhase
+          currentImage={currentImage}
+          currentLang={currentLang}
+          hasUsedHint={hasUsedHint}
+          onUseHint={() => setHasUsedHint(true)}
+          onShowHintModal={() => setShowHintModal(true)}
+          drawing={drawing}
+          layout={{
+            canvasMaxHeight: layout.canvasMaxHeight,
+            canvasMinHeight: layout.canvasMinHeight,
+            canvasMarginVertical: layout.canvasMarginVertical,
+            toolbarMarginVertical: layout.toolbarMarginVertical,
+            toolbarButtonMinHeight: layout.toolbarButtonMinHeight,
+            toolbarButtonPaddingVertical: layout.toolbarButtonPaddingVertical,
+            buttonMinHeight: layout.buttonMinHeight,
+            buttonPaddingVertical: layout.buttonPaddingVertical,
+            isSmall,
+          }}
+          onDone={() => {
+            SoundManager.playPhaseTransition();
+            setPhase('result');
+          }}
+        />
+      )}
+      {phase === 'result' && (
+        <ResultPhase
+          currentImage={currentImage}
+          currentLang={currentLang}
+          levelNumber={levelNumber}
+          userRating={userRating}
+          savedToGallery={savedToGallery}
+          isReplaying={isReplaying}
+          replayPaths={replayPaths}
+          drawingPaths={drawing.paths}
+          screenWidth={screenWidth}
+          isSmall={isSmall}
+          onRatingSubmit={handleRatingSubmit}
+          onSaveToGallery={saveToGallery}
+          onStartReplay={startReplay}
+          onStopReplay={() => setIsReplaying(false)}
+          onNextLevel={handleStartNextLevel}
+          onRestartFromLevel1={handleRestartFromLevel1}
+        />
+      )}
 
-      {/* Delight overlays (Sprint C) */}
+      {/* Delight overlays */}
       {phase === 'result' && (
         <View pointerEvents="none" style={StyleSheet.absoluteFill}>
           <ConfettiBurst width={screenWidth} height={layout.canvasMaxHeight + 200} active={showConfetti} />
@@ -717,322 +387,6 @@ const styles = StyleSheet.create({
     fontWeight: FontWeight.bold,
     color: Colors.text.primary,
   },
-  phaseContainer: {
-    flex: 1,
-    padding: Spacing.md, // Reduced from lg
-    justifyContent: 'space-between',
-  },
-  phaseTitle: {
-    fontSize: FontSize.lg,
-    fontWeight: FontWeight.bold,
-    color: Colors.text.primary,
-    marginTop: 0,
-    marginBottom: Spacing.xs,
-    textAlign: 'center',
-  },
-  timerContainer: {
-    alignSelf: 'center',
-    backgroundColor: Colors.primary,
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginBottom: Spacing.md,
-    ...Colors.shadow.large, // Soft & Modern: Timer mit prominentem Schatten
-  },
-  timerText: {
-    fontSize: FontSize.huge,
-    fontWeight: FontWeight.bold,
-    color: Colors.background,
-  },
-  imageContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  imagePlaceholder: {
-    backgroundColor: Colors.surface,
-    padding: Spacing.lg,
-    borderRadius: BorderRadius.xxl, // xl → xxl (20px → 24px für große Cards)
-    alignItems: 'center',
-    justifyContent: 'center',
-    ...Colors.shadow.large, // Soft & Modern: Cards mit prominentem Schatten
-  },
-  imageName: {
-    fontSize: FontSize.lg,
-    fontWeight: FontWeight.bold,
-    color: Colors.text.primary,
-    marginBottom: Spacing.sm,
-  },
-  imageInfo: {
-    fontSize: FontSize.sm,
-    color: Colors.text.secondary,
-  },
-  canvasContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  // Toolbar-Gruppe Styles
-  toolbarGroup: {
-    backgroundColor: Colors.surfaceAlt,
-    borderRadius: BorderRadius.xl,
-    padding: Spacing.sm,
-    marginVertical: Spacing.sm,
-    gap: Spacing.xs,
-  },
-  colorRowContent: {
-    gap: Spacing.xs,
-    paddingHorizontal: Spacing.xs,
-    paddingVertical: Spacing.xs,
-    alignItems: 'center',
-  },
-  inlineColorSwatch: {
-    width: 32,
-    height: 32,
-    borderRadius: BorderRadius.md,
-    borderWidth: 2,
-    borderColor: Colors.border,
-    justifyContent: 'center',
-    alignItems: 'center',
-    overflow: 'hidden',
-  },
-  inlineColorSwatchActive: {
-    borderColor: Colors.primary,
-    borderWidth: 3,
-    transform: [{ scale: 1.15 }],
-  },
-  inlineColorSwatchInner: {
-    ...StyleSheet.absoluteFillObject,
-  },
-  inlineColorCheckmark: {
-    fontSize: 16,
-    fontWeight: FontWeight.bold,
-    color: Colors.text.primary,
-    textShadowColor: Colors.background,
-    textShadowOffset: { width: 0, height: 0 },
-    textShadowRadius: 3,
-  },
-  toolbarDivider: {
-    height: 1,
-    backgroundColor: Colors.border,
-    marginHorizontal: Spacing.xs,
-  },
-  toolRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-    paddingVertical: Spacing.xs,
-    paddingHorizontal: Spacing.xs,
-  },
-  toolToggleButton: {
-    width: 40,
-    height: 40,
-    borderRadius: BorderRadius.md,
-    backgroundColor: Colors.surface,
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderWidth: 2,
-    borderColor: Colors.border,
-  },
-  toolToggleButtonActive: {
-    backgroundColor: Colors.primary,
-    borderColor: Colors.primary,
-  },
-  toolToggleIcon: {
-    fontSize: 20,
-    lineHeight: 24,
-    textAlign: 'center',
-    textAlignVertical: 'center',
-    includeFontPadding: false,
-  },
-  toolRowSeparator: {
-    width: 1,
-    height: 28,
-    backgroundColor: Colors.border,
-    marginHorizontal: Spacing.xs,
-  },
-  strokeCircleButton: {
-    width: 36,
-    height: 36,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  strokeCircle: {
-    borderRadius: 999,
-  },
-  strokeCircleDisabled: {
-    opacity: 0.35,
-  },
-  buttonRow: {
-    flexDirection: 'row',
-    gap: Spacing.sm,
-  },
-  actionRow: {
-    flexDirection: 'row',
-    gap: Spacing.sm,
-    marginTop: Spacing.sm,
-  },
-  actionButton: {
-    flex: 1,
-    backgroundColor: Colors.surface,
-    paddingVertical: Spacing.sm,
-    paddingHorizontal: Spacing.xs,
-    borderRadius: BorderRadius.lg,
-    alignItems: 'center',
-    borderWidth: 2,
-    borderColor: Colors.border,
-    minHeight: 60,
-    justifyContent: 'center',
-    gap: 2,
-    ...Colors.shadow.small,
-  },
-  actionButtonPrimary: {
-    backgroundColor: Colors.primary,
-    borderColor: Colors.primary,
-  },
-  actionButtonSaved: {
-    borderColor: Colors.success,
-    backgroundColor: Colors.success + '10',
-  },
-  actionButtonText: {
-    fontSize: 20,
-    textAlign: 'center',
-  },
-  actionButtonLabel: {
-    fontSize: FontSize.xs,
-    fontWeight: FontWeight.semibold,
-    color: Colors.text.secondary,
-    textAlign: 'center',
-  },
-  actionButtonLabelSaved: {
-    color: Colors.success,
-  },
-  actionButtonPrimaryText: {
-    color: Colors.background,
-  },
-  primaryButton: {
-    flex: 1,
-    backgroundColor: Colors.primary,
-    paddingVertical: Spacing.md,
-    paddingHorizontal: Spacing.lg,
-    borderRadius: BorderRadius.lg,
-    alignItems: 'center',
-    minHeight: 48,
-    justifyContent: 'center',
-    ...Colors.shadow.medium, // Soft & Modern: Weiche Schatten
-  },
-  primaryButtonText: {
-    fontSize: FontSize.md,
-    fontWeight: FontWeight.bold,
-    color: Colors.background,
-  },
-  secondaryButton: {
-    flex: 1,
-    backgroundColor: Colors.surface,
-    paddingVertical: Spacing.md,
-    paddingHorizontal: Spacing.lg,
-    borderRadius: BorderRadius.lg,
-    alignItems: 'center',
-    borderWidth: 2,
-    borderColor: Colors.primary,
-    minHeight: 48,
-    justifyContent: 'center',
-    ...Colors.shadow.small, // Soft & Modern: Subtile Schatten für sekundäre Buttons
-  },
-  buttonDisabled: {
-    opacity: 0.4,
-    borderColor: Colors.text.light,
-  },
-  secondaryButtonText: {
-    fontSize: FontSize.md,
-    fontWeight: FontWeight.semibold,
-    color: Colors.primary,
-  },
-  resultScrollView: {
-    flex: 1,
-  },
-  resultContent: {
-    padding: Spacing.md,
-    flexGrow: 1,
-  },
-  starsTitle: {
-    fontSize: FontSize.lg,
-    fontWeight: FontWeight.bold,
-    color: Colors.text.primary,
-    marginBottom: Spacing.md,
-    textAlign: 'center',
-  },
-  starsContainer: {
-    backgroundColor: Colors.surface,
-    borderRadius: BorderRadius.xxl,
-    padding: Spacing.lg,
-    alignItems: 'center',
-    marginBottom: Spacing.md,
-    ...Colors.shadow.medium,
-  },
-  starsContainerSmall: {
-    marginBottom: Spacing.sm,
-  },
-  starsRow: {
-    flexDirection: 'row',
-    gap: Spacing.sm,
-    marginBottom: Spacing.md,
-  },
-  ratingText: {
-    fontSize: FontSize.xl,
-    fontWeight: FontWeight.bold,
-    color: Colors.success,
-    marginBottom: Spacing.sm,
-  },
-  feedbackText: {
-    fontSize: FontSize.md,
-    color: Colors.text.secondary,
-    textAlign: 'center',
-    paddingHorizontal: Spacing.lg,
-  },
-  comparisonContainer: {
-    flexDirection: 'row',
-    gap: Spacing.sm,
-    marginBottom: Spacing.md,
-    justifyContent: 'center',
-  },
-  comparisonCard: {
-    backgroundColor: Colors.surface,
-    borderRadius: BorderRadius.xl,
-    overflow: 'hidden',
-    borderWidth: 1,
-    borderColor: Colors.border,
-    ...Colors.shadow.medium,
-  },
-  comparisonCardHeader: {
-    paddingVertical: Spacing.xs,
-    paddingHorizontal: Spacing.sm,
-  },
-  comparisonCardHeaderTemplate: {
-    backgroundColor: Colors.primary + '18',
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.primary + '22',
-  },
-  comparisonCardHeaderDrawing: {
-    backgroundColor: Colors.secondary + '18',
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.secondary + '22',
-  },
-  comparisonCardLabel: {
-    fontSize: FontSize.xs,
-    fontWeight: FontWeight.bold,
-    letterSpacing: 0.6,
-  },
-  comparisonImage: {
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  placeholderText: {
-    fontSize: FontSize.md,
-    color: Colors.text.secondary,
-  },
   settingsButton: {
     width: 44,
     height: 44,
@@ -1051,188 +405,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     padding: Spacing.lg,
   },
-  completionBanner: {
-    backgroundColor: Colors.success + '15',
-    borderWidth: 2,
-    borderColor: Colors.success,
-    borderRadius: BorderRadius.xl,
-    padding: Spacing.lg,
-    alignItems: 'center',
-    marginBottom: Spacing.lg,
-  },
-  completionTitle: {
-    fontSize: FontSize.xl,
-    fontWeight: FontWeight.bold,
-    color: Colors.success,
-    marginBottom: Spacing.sm,
-    textAlign: 'center',
-  },
-  completionMessage: {
-    fontSize: FontSize.md,
-    color: Colors.text.secondary,
-    textAlign: 'center',
-  },
-  canvasIconRow: {
-    position: 'absolute',
-    bottom: Spacing.xs,
-    right: Spacing.xs,
-    flexDirection: 'row',
-    gap: Spacing.xs,
-  },
-  canvasIconButton: {
-    width: 44,
-    height: 44,
-    borderRadius: BorderRadius.sm,
-    backgroundColor: Colors.surface,
-    borderWidth: 1,
-    borderColor: Colors.primary,
-    justifyContent: 'center',
-    alignItems: 'center',
-    ...Colors.shadow.small,
-  },
-  canvasIconButtonActive: {
-    backgroundColor: Colors.primary,
-    borderColor: Colors.primary,
-  },
-  canvasIconButtonSaved: {
-    backgroundColor: Colors.success + '20',
-    borderColor: Colors.success,
-  },
-  canvasIconText: {
-    fontSize: FontSize.xs,
-    color: Colors.primary,
-  },
-  canvasIconTextActive: {
-    color: Colors.background,
-  },
-  canvasIconTextSaved: {
-    color: Colors.success,
-  },
-  toolContainer: {
-    marginBottom: Spacing.md,
-    alignItems: 'center',
-  },
-  toolLabel: {
-    fontSize: FontSize.sm,
-    fontWeight: FontWeight.semibold,
-    color: Colors.text.secondary,
-    marginBottom: Spacing.sm,
-  },
-  toolButtons: {
-    flexDirection: 'row',
-    gap: Spacing.sm,
-  },
-  toolButton: {
-    backgroundColor: Colors.surface,
-    paddingVertical: Spacing.sm,
-    paddingHorizontal: Spacing.lg,
-    borderRadius: BorderRadius.md,
-    alignItems: 'center',
-    borderWidth: 2,
-    borderColor: Colors.surface,
-    minWidth: 80,
-  },
-  toolButtonActive: {
-    backgroundColor: Colors.primary,
-    borderColor: Colors.primary,
-  },
-  toolButtonText: {
-    fontSize: FontSize.sm,
-    fontWeight: FontWeight.semibold,
-    color: Colors.text.primary,
-  },
-  toolButtonTextActive: {
-    color: Colors.background,
-  },
-  strokeWidthContainer: {
-    marginBottom: Spacing.lg,
-    alignItems: 'center',
-  },
-  strokeWidthLabel: {
-    fontSize: FontSize.sm,
-    fontWeight: FontWeight.semibold,
-    color: Colors.text.secondary,
-    marginBottom: Spacing.sm,
-  },
-  strokeWidthButtons: {
-    flexDirection: 'row',
-    gap: Spacing.sm,
-  },
-  strokeWidthButton: {
-    backgroundColor: Colors.surface,
-    paddingVertical: Spacing.sm,
-    paddingHorizontal: Spacing.md,
-    borderRadius: BorderRadius.md,
-    alignItems: 'center',
-    borderWidth: 2,
-    borderColor: Colors.surface,
-    minWidth: 70,
-  },
-  strokeWidthButtonActive: {
-    backgroundColor: Colors.primary,
-    borderColor: Colors.primary,
-  },
-  strokeWidthPreview: {
-    width: 40,
-    backgroundColor: Colors.text.primary,
-    borderRadius: 2,
-    marginBottom: Spacing.xs,
-  },
-  strokeWidthButtonText: {
-    fontSize: FontSize.xs,
-    fontWeight: FontWeight.medium,
-    color: Colors.text.primary,
-  },
-  strokeWidthButtonTextActive: {
-    color: Colors.background,
-  },
-  // Info-Streifen (Draw Phase)
-  infoStrip: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-    backgroundColor: Colors.surface,
-    borderRadius: BorderRadius.xl,
-    padding: Spacing.sm,
-    marginBottom: Spacing.xs,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    ...Colors.shadow.small,
-  },
-  infoStripCenter: {
-    flex: 1,
-  },
-  infoStripLabel: {
-    fontSize: FontSize.xs,
-    fontWeight: FontWeight.bold,
-    color: Colors.text.secondary,
-    textTransform: 'uppercase',
-    letterSpacing: 0.6,
-    marginBottom: 2,
-  },
-  infoStripText: {
-    fontSize: FontSize.sm,
-    fontWeight: FontWeight.bold,
-    color: Colors.text.primary,
-  },
-  hintButton: {
-    width: 40,
-    height: 40,
-    borderRadius: BorderRadius.md,
-    backgroundColor: Colors.primary,
-    flexShrink: 0,
-    alignItems: 'center',
-    justifyContent: 'center',
-    ...Colors.shadow.small,
-  },
-  hintButtonUsed: {
-    backgroundColor: Colors.border,
-    opacity: 0.5,
-  },
-  hintButtonIcon: {
-    fontSize: 20,
-  },
-  // Hint Modal
   hintModal: {
     backgroundColor: Colors.background,
     borderRadius: BorderRadius.xxl,
@@ -1263,8 +435,5 @@ const styles = StyleSheet.create({
   closeText: {
     fontSize: 24,
     color: Colors.text.secondary,
-  },
-  buttonTextSmall: {
-    fontSize: FontSize.md,
   },
 });

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -182,7 +182,7 @@ export default function GameScreen() {
       </View>
 
       {/* Pill-Tabs: Zeichnen / Ergebnis */}
-      {(phase === 'draw' || phase === 'result') && (
+      {FeatureFlags.ENABLE_GAME_PHASE_TABS && (phase === 'draw' || phase === 'result') && (
         <View style={styles.tabBar}>
           <TouchableOpacity
             style={[styles.tab, phase === 'draw' && styles.tabActive]}

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -259,8 +259,6 @@ export default function GameScreen() {
             canvasMinHeight: layout.canvasMinHeight,
             canvasMarginVertical: layout.canvasMarginVertical,
             toolbarMarginVertical: layout.toolbarMarginVertical,
-            toolbarButtonMinHeight: layout.toolbarButtonMinHeight,
-            toolbarButtonPaddingVertical: layout.toolbarButtonPaddingVertical,
             buttonMinHeight: layout.buttonMinHeight,
             buttonPaddingVertical: layout.buttonPaddingVertical,
             isSmall,
@@ -274,7 +272,6 @@ export default function GameScreen() {
       {phase === 'result' && (
         <ResultPhase
           currentImage={currentImage}
-          currentLang={currentLang}
           levelNumber={levelNumber}
           userRating={userRating}
           savedToGallery={savedToGallery}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -60,22 +60,6 @@ export default function HomeScreen() {
     }, [])
   );
 
-  // Fallback: update daily level on every render to ensure correct date
-  // This ensures the calendar always shows today's date, even if the user
-  // hasn't navigated away/back after midnight.
-  useEffect(() => {
-    const today = new Date();
-    const nextMidnight = new Date(today);
-    nextMidnight.setHours(24, 0, 0, 0);
-    const msUntilMidnight = nextMidnight.getTime() - today.getTime();
-
-    if (msUntilMidnight > 0) {
-      const timer = setTimeout(() => {
-        setDailyLevel(getDailyChallengeLevel());
-      }, msUntilMidnight);
-      return () => clearTimeout(timer);
-    }
-  }, []);
 
   const countdownHours = Math.floor(secondsLeft / 3600);
   const countdownMinutes = Math.floor((secondsLeft % 3600) / 60);

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -60,6 +60,23 @@ export default function HomeScreen() {
     }, [])
   );
 
+  // Fallback: update daily level on every render to ensure correct date
+  // This ensures the calendar always shows today's date, even if the user
+  // hasn't navigated away/back after midnight.
+  useEffect(() => {
+    const today = new Date();
+    const nextMidnight = new Date(today);
+    nextMidnight.setHours(24, 0, 0, 0);
+    const msUntilMidnight = nextMidnight.getTime() - today.getTime();
+
+    if (msUntilMidnight > 0) {
+      const timer = setTimeout(() => {
+        setDailyLevel(getDailyChallengeLevel());
+      }, msUntilMidnight);
+      return () => clearTimeout(timer);
+    }
+  }, []);
+
   const countdownHours = Math.floor(secondsLeft / 3600);
   const countdownMinutes = Math.floor((secondsLeft % 3600) / 60);
 

--- a/components/__tests__/GamePhaseComponents.test.tsx
+++ b/components/__tests__/GamePhaseComponents.test.tsx
@@ -1,0 +1,251 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+// ─── Shared mocks ────────────────────────────────────────────────────────────
+
+jest.mock('../../services/i18n', () => ({
+  t: (key: string) => key,
+  getLanguage: () => 'en',
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../../services/LevelManager', () => ({
+  getTotalLevels: () => 10,
+}));
+
+jest.mock('../../components/LevelImageDisplay', () => {
+  const { View } = require('react-native');
+  return function LevelImageDisplay() { return <View testID="level-image-display" />; };
+});
+
+jest.mock('../../components/DrawingCanvas', () => {
+  const { View } = require('react-native');
+  const DrawingCanvas = (props: any) => <View testID="drawing-canvas" />;
+  return {
+    __esModule: true,
+    default: DrawingCanvas,
+    useDrawingCanvas: () => ({
+      color: '#000',
+      strokeWidth: 2,
+      tool: 'brush',
+      paths: [],
+      setPaths: jest.fn(),
+      clearCanvas: jest.fn(),
+      setColor: jest.fn(),
+      setTool: jest.fn(),
+      setStrokeWidth: jest.fn(),
+      undo: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('../../components/ErrorBoundary', () => ({
+  ErrorBoundary: ({ children }: any) => {
+    const { View } = require('react-native');
+    return <View>{children}</View>;
+  },
+}));
+
+jest.mock('../../components/AnimatedPrimitives', () => {
+  const { View } = require('react-native');
+  return {
+    AnimatedFeedback: ({ children, visible }: any) => visible ? <View>{children}</View> : null,
+    AnimatedStar: ({ onPress, accessibilityLabel }: any) => {
+      const { TouchableOpacity, Text } = require('react-native');
+      return (
+        <TouchableOpacity onPress={onPress} accessibilityLabel={accessibilityLabel}>
+          <Text>★</Text>
+        </TouchableOpacity>
+      );
+    },
+  };
+});
+
+// ─── MemorizePhase ────────────────────────────────────────────────────────────
+
+import MemorizePhase from '../../components/game/MemorizePhase';
+
+const mockImage = {
+  id: 'sun',
+  displayName: 'Sonne',
+  displayNameEn: 'Sun',
+  strokeCount: 5,
+  difficulty: 1,
+  component: null,
+  width: 200,
+  height: 200,
+} as any;
+
+const getAllTexts = (UNSAFE_getAllByType: any): any[] => {
+  const { Text } = require('react-native');
+  return UNSAFE_getAllByType(Text).map((n: any) => n.props.children).flat();
+};
+
+describe('MemorizePhase', () => {
+  const baseProps = {
+    timeRemaining: 5,
+    currentImage: null,
+    levelNumber: 1,
+    currentLang: 'en',
+    memorizeImageSize: 200,
+    imagePlaceholderMinSize: 160,
+    revealStep: 0,
+  };
+
+  it('renders timer countdown value as a number', () => {
+    const { UNSAFE_getAllByType } = render(<MemorizePhase {...baseProps} timeRemaining={3} />);
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain(3);
+  });
+
+  it('renders title translation key', () => {
+    const { UNSAFE_getAllByType } = render(<MemorizePhase {...baseProps} />);
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain('game.memorize.title');
+  });
+
+  it('renders image info when image is provided', () => {
+    const { UNSAFE_getAllByType } = render(<MemorizePhase {...baseProps} currentImage={mockImage} />);
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain('Sun');
+  });
+
+  it('shows displayName when lang is de', () => {
+    const { UNSAFE_getAllByType } = render(
+      <MemorizePhase {...baseProps} currentImage={mockImage} currentLang="de" />
+    );
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain('Sonne');
+  });
+});
+
+// ─── DrawPhase ───────────────────────────────────────────────────────────────
+
+import DrawPhase from '../../components/game/DrawPhase';
+
+const drawProps = {
+  currentImage: mockImage,
+  currentLang: 'en',
+  hasUsedHint: false,
+  onUseHint: jest.fn(),
+  onShowHintModal: jest.fn(),
+  drawing: {
+    color: '#000',
+    strokeWidth: 2,
+    tool: 'brush' as const,
+    paths: [],
+    setPaths: jest.fn(),
+    setColor: jest.fn(),
+    setTool: jest.fn(),
+    setStrokeWidth: jest.fn(),
+    undo: jest.fn(),
+  },
+  layout: {
+    canvasMaxHeight: 400,
+    canvasMinHeight: 200,
+    canvasMarginVertical: 8,
+    toolbarMarginVertical: 8,
+    toolbarButtonMinHeight: 44,
+    toolbarButtonPaddingVertical: 8,
+    buttonMinHeight: 44,
+    buttonPaddingVertical: 8,
+    isSmall: false,
+  },
+  onDone: jest.fn(),
+};
+
+describe('DrawPhase', () => {
+  it('renders done button with translation key', () => {
+    const { UNSAFE_getAllByType } = render(<DrawPhase {...drawProps} />);
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain('game.draw.done');
+  });
+
+  it('renders toolbar reference label', () => {
+    const { UNSAFE_getAllByType } = render(<DrawPhase {...drawProps} />);
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain('game.draw.referenceLabel');
+  });
+
+  it('renders hint button as disabled when hint used', () => {
+    const { UNSAFE_getAllByType } = render(<DrawPhase {...drawProps} hasUsedHint={true} />);
+    const { TouchableOpacity } = require('react-native');
+    const buttons = UNSAFE_getAllByType(TouchableOpacity);
+    const hintBtn = buttons.find((b: any) => b.props.accessibilityLabel === 'game.draw.hintUsed');
+    expect(hintBtn).toBeTruthy();
+    expect(hintBtn.props.disabled).toBe(true);
+  });
+
+  it('renders undo and clear buttons', () => {
+    const { UNSAFE_getAllByType } = render(<DrawPhase {...drawProps} />);
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain('game.draw.undo');
+    expect(texts).toContain('game.draw.clear');
+  });
+});
+
+// ─── ResultPhase ─────────────────────────────────────────────────────────────
+
+import ResultPhase from '../../components/game/ResultPhase';
+
+const resultProps = {
+  currentImage: mockImage,
+  currentLang: 'en',
+  levelNumber: 1,
+  userRating: 0,
+  savedToGallery: false,
+  isReplaying: false,
+  replayPaths: [],
+  drawingPaths: [],
+  screenWidth: 375,
+  isSmall: false,
+  onRatingSubmit: jest.fn(),
+  onSaveToGallery: jest.fn(),
+  onStartReplay: jest.fn(),
+  onStopReplay: jest.fn(),
+  onNextLevel: jest.fn(),
+  onRestartFromLevel1: jest.fn(),
+};
+
+describe('ResultPhase', () => {
+  it('renders comparison cards (template + drawing)', () => {
+    const { UNSAFE_getAllByType } = render(<ResultPhase {...resultProps} />);
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    // t() returns key as-is; .toUpperCase() is applied in JSX, so we match uppercased form
+    expect(texts.some((t: any) => typeof t === 'string' && t.includes('GAME.RESULT.TEMPLATE'))).toBeTruthy();
+    expect(texts.some((t: any) => typeof t === 'string' && t.includes('GAME.RESULT.YOURDRAWING'))).toBeTruthy();
+  });
+
+  it('renders 5 star buttons', () => {
+    const { UNSAFE_getAllByType } = render(<ResultPhase {...resultProps} />);
+    const { TouchableOpacity } = require('react-native');
+    const starButtons = UNSAFE_getAllByType(TouchableOpacity).filter(
+      (b: any) => b.props.accessibilityLabel && b.props.accessibilityLabel.includes('Stern')
+    );
+    expect(starButtons).toHaveLength(5);
+  });
+
+  it('shows next level button when not last level', () => {
+    const { UNSAFE_getAllByType } = render(<ResultPhase {...resultProps} levelNumber={1} />);
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain('game.result.nextLevel');
+  });
+
+  it('shows play again button on last level', () => {
+    const { UNSAFE_getAllByType } = render(<ResultPhase {...resultProps} levelNumber={10} />);
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain('game.result.playAgain');
+  });
+
+  it('shows feedback text when rating > 0', () => {
+    const { UNSAFE_getAllByType } = render(<ResultPhase {...resultProps} userRating={5} />);
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain('game.result.feedback5');
+  });
+
+  it('shows saved label when savedToGallery is true', () => {
+    const { UNSAFE_getAllByType } = render(<ResultPhase {...resultProps} savedToGallery={true} />);
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain('gallery.saved');
+  });
+});

--- a/components/__tests__/GamePhaseComponents.test.tsx
+++ b/components/__tests__/GamePhaseComponents.test.tsx
@@ -50,10 +50,10 @@ jest.mock('../../components/AnimatedPrimitives', () => {
   const { View } = require('react-native');
   return {
     AnimatedFeedback: ({ children, visible }: any) => visible ? <View>{children}</View> : null,
-    AnimatedStar: ({ onPress, accessibilityLabel }: any) => {
+    AnimatedStar: ({ onPress, accessibilityLabel, index }: any) => {
       const { TouchableOpacity, Text } = require('react-native');
       return (
-        <TouchableOpacity onPress={onPress} accessibilityLabel={accessibilityLabel}>
+        <TouchableOpacity onPress={onPress} accessibilityLabel={accessibilityLabel} index={index}>
           <Text>★</Text>
         </TouchableOpacity>
       );
@@ -92,10 +92,10 @@ describe('MemorizePhase', () => {
     revealStep: 0,
   };
 
-  it('renders timer countdown value as a number', () => {
+  it('renders timer with i18n translation key', () => {
     const { UNSAFE_getAllByType } = render(<MemorizePhase {...baseProps} timeRemaining={3} />);
     const texts = getAllTexts(UNSAFE_getAllByType);
-    expect(texts).toContain(3);
+    expect(texts).toContain('game.memorize.timeLeft');
   });
 
   it('renders title translation key', () => {
@@ -220,7 +220,7 @@ describe('ResultPhase', () => {
     const { UNSAFE_getAllByType } = render(<ResultPhase {...resultProps} />);
     const { TouchableOpacity } = require('react-native');
     const starButtons = UNSAFE_getAllByType(TouchableOpacity).filter(
-      (b: any) => b.props.accessibilityLabel && b.props.accessibilityLabel.includes('Stern')
+      (b: any) => b.props.index !== undefined
     );
     expect(starButtons).toHaveLength(5);
   });

--- a/components/game/DrawPhase.tsx
+++ b/components/game/DrawPhase.tsx
@@ -32,11 +32,6 @@ export default function DrawPhase({
     marginVertical: layout.toolbarMarginVertical,
   }), [layout.toolbarMarginVertical]);
 
-  const dynButton = useMemo(() => ({
-    minHeight: layout.buttonMinHeight,
-    paddingVertical: layout.buttonPaddingVertical,
-  }), [layout.buttonMinHeight, layout.buttonPaddingVertical]);
-
   return (
     <View style={styles.phaseContainer}>
       {/* Info-Streifen: Aufgabe + Hint-Joker */}
@@ -157,7 +152,7 @@ export default function DrawPhase({
       {/* Buttons */}
       <View style={styles.buttonRow}>
         <TouchableOpacity
-          style={[styles.secondaryButton, dynButton]}
+          style={styles.secondaryButton}
           onPress={drawing.undo}
           disabled={drawing.paths.length === 0}
           accessibilityLabel={t('game.draw.undo')}
@@ -171,7 +166,7 @@ export default function DrawPhase({
           >{t('game.draw.undo')}</Text>
         </TouchableOpacity>
         <TouchableOpacity
-          style={[styles.secondaryButton, dynButton, drawing.paths.length === 0 && styles.buttonDisabled]}
+          style={[styles.secondaryButton, drawing.paths.length === 0 && styles.buttonDisabled]}
           accessibilityLabel={t('game.draw.clear')}
           accessibilityRole="button"
           onPress={() => {
@@ -201,7 +196,7 @@ export default function DrawPhase({
           >{t('game.draw.clear')}</Text>
         </TouchableOpacity>
         <TouchableOpacity
-          style={[styles.primaryButton, dynButton]}
+          style={styles.primaryButton}
           onPress={onDone}
         >
           <Text

--- a/components/game/DrawPhase.tsx
+++ b/components/game/DrawPhase.tsx
@@ -1,0 +1,410 @@
+import React, { useMemo } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Alert, Platform, FlatList } from 'react-native';
+import DrawingCanvas from '@components/DrawingCanvas';
+import { ErrorBoundary } from '@components/ErrorBoundary';
+import { DrawingColors } from '../../constants/Colors';
+import Colors from '../../constants/Colors';
+import { Spacing, FontSize, FontWeight, BorderRadius } from '../../constants/Layout';
+import type { DrawPhaseProps } from './game.shared';
+import { useTranslation } from '@services/i18n';
+
+export default function DrawPhase({
+  currentImage,
+  currentLang,
+  hasUsedHint,
+  onUseHint,
+  onShowHintModal,
+  drawing,
+  layout,
+  onDone,
+}: DrawPhaseProps) {
+  const { t } = useTranslation();
+
+  const levelName = currentLang === 'en' ? currentImage?.displayNameEn : currentImage?.displayName;
+
+  const dynCanvasContainer = useMemo(() => ({
+    maxHeight: layout.canvasMaxHeight,
+    minHeight: layout.canvasMinHeight,
+    marginVertical: layout.canvasMarginVertical,
+  }), [layout.canvasMaxHeight, layout.canvasMinHeight, layout.canvasMarginVertical]);
+
+  const dynToolbar = useMemo(() => ({
+    marginVertical: layout.toolbarMarginVertical,
+  }), [layout.toolbarMarginVertical]);
+
+  const dynButton = useMemo(() => ({
+    minHeight: layout.buttonMinHeight,
+    paddingVertical: layout.buttonPaddingVertical,
+  }), [layout.buttonMinHeight, layout.buttonPaddingVertical]);
+
+  return (
+    <View style={styles.phaseContainer}>
+      {/* Info-Streifen: Aufgabe + Hint-Joker */}
+      <View style={styles.infoStrip}>
+        <View style={styles.infoStripCenter}>
+          <Text style={styles.infoStripLabel}>{t('game.draw.referenceLabel')}</Text>
+          <Text style={styles.infoStripText} numberOfLines={2}>
+            {t('game.draw.drawFromMemory')}{levelName ? ` — ${levelName}` : ''}
+          </Text>
+        </View>
+        <TouchableOpacity
+          style={[styles.hintButton, hasUsedHint && styles.hintButtonUsed]}
+          onPress={() => {
+            if (!hasUsedHint) {
+              onUseHint();
+              onShowHintModal();
+            }
+          }}
+          disabled={hasUsedHint}
+          accessibilityLabel={hasUsedHint ? t('game.draw.hintUsed') : t('game.draw.hintButton')}
+          accessibilityRole="button"
+        >
+          <Text style={styles.hintButtonIcon}>👁</Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* Zeichenfläche */}
+      <View style={[styles.canvasContainer, dynCanvasContainer]}>
+        <ErrorBoundary>
+          <DrawingCanvas
+            strokeColor={drawing.color}
+            strokeWidth={drawing.strokeWidth}
+            tool={drawing.tool}
+            paths={drawing.paths}
+            onDrawingChange={drawing.setPaths}
+          />
+        </ErrorBoundary>
+      </View>
+
+      {/* Toolbar-Gruppe */}
+      <View style={[styles.toolbarGroup, dynToolbar]}>
+        {/* Reihe 1: Inline-Farbreihe */}
+        <FlatList
+          data={DrawingColors}
+          keyExtractor={(item) => item.hex}
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.colorRowContent}
+          renderItem={({ item }) => (
+            <TouchableOpacity
+              style={[
+                styles.inlineColorSwatch,
+                item.border && { borderColor: item.border },
+                drawing.color === item.hex && styles.inlineColorSwatchActive,
+              ]}
+              onPress={() => drawing.setColor(item.hex)}
+              accessibilityLabel={currentLang === 'de' ? item.name : item.nameEn}
+              accessibilityRole="button"
+            >
+              <View style={[styles.inlineColorSwatchInner, { backgroundColor: item.hex }]} />
+              {drawing.color === item.hex && (
+                <Text style={styles.inlineColorCheckmark}>✓</Text>
+              )}
+            </TouchableOpacity>
+          )}
+        />
+
+        <View style={styles.toolbarDivider} />
+
+        {/* Reihe 2: Pen/Fill + Strichstärken */}
+        <View style={styles.toolRow}>
+          <TouchableOpacity
+            style={[styles.toolToggleButton, drawing.tool === 'brush' && styles.toolToggleButtonActive]}
+            onPress={() => drawing.setTool('brush')}
+            accessibilityLabel={t('game.draw.toolBrush')}
+            accessibilityRole="button"
+          >
+            <Text style={styles.toolToggleIcon}>✏️</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.toolToggleButton, drawing.tool === 'fill' && styles.toolToggleButtonActive]}
+            onPress={() => drawing.setTool('fill')}
+            accessibilityLabel={t('game.draw.toolFill')}
+            accessibilityRole="button"
+          >
+            <Text style={styles.toolToggleIcon}>🪣</Text>
+          </TouchableOpacity>
+
+          <View style={styles.toolRowSeparator} />
+
+          {([2, 3, 5] as const).map((size) => (
+            <TouchableOpacity
+              key={size}
+              style={[
+                styles.strokeCircleButton,
+                drawing.tool === 'fill' && styles.strokeCircleDisabled,
+              ]}
+              onPress={() => { if (drawing.tool !== 'fill') drawing.setStrokeWidth(size); }}
+              disabled={drawing.tool === 'fill'}
+              accessibilityLabel={`${t('game.draw.strokeWidth')} ${size}`}
+              accessibilityRole="button"
+            >
+              <View style={[
+                styles.strokeCircle,
+                {
+                  width: size === 2 ? 10 : size === 3 ? 16 : 22,
+                  height: size === 2 ? 10 : size === 3 ? 16 : 22,
+                  backgroundColor: drawing.strokeWidth === size && drawing.tool !== 'fill'
+                    ? drawing.color
+                    : Colors.text.secondary,
+                },
+              ]} />
+            </TouchableOpacity>
+          ))}
+        </View>
+      </View>
+
+      {/* Buttons */}
+      <View style={styles.buttonRow}>
+        <TouchableOpacity
+          style={[styles.secondaryButton, dynButton]}
+          onPress={drawing.undo}
+          disabled={drawing.paths.length === 0}
+          accessibilityLabel={t('game.draw.undo')}
+          accessibilityRole="button"
+        >
+          <Text
+            style={[styles.secondaryButtonText, layout.isSmall && styles.buttonTextSmall]}
+            numberOfLines={1}
+            adjustsFontSizeToFit
+            minimumFontScale={0.7}
+          >{t('game.draw.undo')}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.secondaryButton, dynButton, drawing.paths.length === 0 && styles.buttonDisabled]}
+          accessibilityLabel={t('game.draw.clear')}
+          accessibilityRole="button"
+          onPress={() => {
+            if (Platform.OS === 'web') {
+              if (drawing.paths.length > 0 && window.confirm(t('game.draw.clearConfirm'))) { // platform-safe
+                drawing.setPaths([]);
+              }
+            } else {
+              if (drawing.paths.length === 0) return;
+              Alert.alert(
+                t('game.draw.clear'),
+                t('game.draw.clearConfirm'),
+                [
+                  { text: t('common.cancel'), style: 'cancel' },
+                  { text: t('common.yes'), style: 'destructive', onPress: () => { drawing.setPaths([]); } },
+                ]
+              );
+            }
+          }}
+          disabled={drawing.paths.length === 0}
+        >
+          <Text
+            style={[styles.secondaryButtonText, layout.isSmall && styles.buttonTextSmall]}
+            numberOfLines={1}
+            adjustsFontSizeToFit
+            minimumFontScale={0.7}
+          >{t('game.draw.clear')}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.primaryButton, dynButton]}
+          onPress={onDone}
+        >
+          <Text
+            style={[styles.primaryButtonText, layout.isSmall && styles.buttonTextSmall]}
+            numberOfLines={1}
+            adjustsFontSizeToFit
+            minimumFontScale={0.7}
+          >{t('game.draw.done')}</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  phaseContainer: {
+    flex: 1,
+    padding: Spacing.md,
+    justifyContent: 'space-between',
+  },
+  infoStrip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    backgroundColor: Colors.surface,
+    borderRadius: BorderRadius.xl,
+    padding: Spacing.sm,
+    marginBottom: Spacing.xs,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    ...Colors.shadow.small,
+  },
+  infoStripCenter: {
+    flex: 1,
+  },
+  infoStripLabel: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.bold,
+    color: Colors.text.secondary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+    marginBottom: 2,
+  },
+  infoStripText: {
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.bold,
+    color: Colors.text.primary,
+  },
+  hintButton: {
+    width: 40,
+    height: 40,
+    borderRadius: BorderRadius.md,
+    backgroundColor: Colors.primary,
+    flexShrink: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...Colors.shadow.small,
+  },
+  hintButtonUsed: {
+    backgroundColor: Colors.border,
+    opacity: 0.5,
+  },
+  hintButtonIcon: {
+    fontSize: 20,
+  },
+  canvasContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  toolbarGroup: {
+    backgroundColor: Colors.surfaceAlt,
+    borderRadius: BorderRadius.xl,
+    padding: Spacing.sm,
+    marginVertical: Spacing.sm,
+    gap: Spacing.xs,
+  },
+  colorRowContent: {
+    gap: Spacing.xs,
+    paddingHorizontal: Spacing.xs,
+    paddingVertical: Spacing.xs,
+    alignItems: 'center',
+  },
+  inlineColorSwatch: {
+    width: 32,
+    height: 32,
+    borderRadius: BorderRadius.md,
+    borderWidth: 2,
+    borderColor: Colors.border,
+    justifyContent: 'center',
+    alignItems: 'center',
+    overflow: 'hidden',
+  },
+  inlineColorSwatchActive: {
+    borderColor: Colors.primary,
+    borderWidth: 3,
+    transform: [{ scale: 1.15 }],
+  },
+  inlineColorSwatchInner: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  inlineColorCheckmark: {
+    fontSize: 16,
+    fontWeight: FontWeight.bold,
+    color: Colors.text.primary,
+    textShadowColor: Colors.background,
+    textShadowOffset: { width: 0, height: 0 },
+    textShadowRadius: 3,
+  },
+  toolbarDivider: {
+    height: 1,
+    backgroundColor: Colors.border,
+    marginHorizontal: Spacing.xs,
+  },
+  toolRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    paddingVertical: Spacing.xs,
+    paddingHorizontal: Spacing.xs,
+  },
+  toolToggleButton: {
+    width: 40,
+    height: 40,
+    borderRadius: BorderRadius.md,
+    backgroundColor: Colors.surface,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 2,
+    borderColor: Colors.border,
+  },
+  toolToggleButtonActive: {
+    backgroundColor: Colors.primary,
+    borderColor: Colors.primary,
+  },
+  toolToggleIcon: {
+    fontSize: 20,
+    lineHeight: 24,
+    textAlign: 'center',
+    textAlignVertical: 'center',
+    includeFontPadding: false,
+  },
+  toolRowSeparator: {
+    width: 1,
+    height: 28,
+    backgroundColor: Colors.border,
+    marginHorizontal: Spacing.xs,
+  },
+  strokeCircleButton: {
+    width: 36,
+    height: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  strokeCircle: {
+    borderRadius: 999,
+  },
+  strokeCircleDisabled: {
+    opacity: 0.35,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+  },
+  primaryButton: {
+    flex: 1,
+    backgroundColor: Colors.primary,
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.lg,
+    borderRadius: BorderRadius.lg,
+    alignItems: 'center',
+    minHeight: 48,
+    justifyContent: 'center',
+    ...Colors.shadow.medium,
+  },
+  primaryButtonText: {
+    fontSize: FontSize.md,
+    fontWeight: FontWeight.bold,
+    color: Colors.background,
+  },
+  secondaryButton: {
+    flex: 1,
+    backgroundColor: Colors.surface,
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.lg,
+    borderRadius: BorderRadius.lg,
+    alignItems: 'center',
+    borderWidth: 2,
+    borderColor: Colors.primary,
+    minHeight: 48,
+    justifyContent: 'center',
+    ...Colors.shadow.small,
+  },
+  secondaryButtonText: {
+    fontSize: FontSize.md,
+    fontWeight: FontWeight.semibold,
+    color: Colors.primary,
+  },
+  buttonDisabled: {
+    opacity: 0.4,
+    borderColor: Colors.text.light,
+  },
+  buttonTextSmall: {
+    fontSize: FontSize.md,
+  },
+});

--- a/components/game/MemorizePhase.tsx
+++ b/components/game/MemorizePhase.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import LevelImageDisplay from '@components/LevelImageDisplay';
+import { ErrorBoundary } from '@components/ErrorBoundary';
+import Colors from '../../constants/Colors';
+import { Spacing, FontSize, FontWeight, BorderRadius } from '../../constants/Layout';
+import type { MemorizePhaseProps } from './game.shared';
+import { useTranslation } from '@services/i18n';
+
+export default function MemorizePhase({
+  timeRemaining,
+  currentImage,
+  levelNumber,
+  currentLang,
+  memorizeImageSize,
+  imagePlaceholderMinSize,
+  revealStep,
+}: MemorizePhaseProps) {
+  const { t } = useTranslation();
+
+  return (
+    <View style={styles.phaseContainer}>
+      <Text style={styles.phaseTitle}>{t('game.memorize.title')}</Text>
+
+      <View style={styles.timerContainer}>
+        <Text style={styles.timerText}>{timeRemaining}s</Text>
+      </View>
+
+      <View style={styles.imageContainer}>
+        {currentImage && (
+          <View style={[styles.imagePlaceholder, { minWidth: imagePlaceholderMinSize, minHeight: imagePlaceholderMinSize }]}>
+            <ErrorBoundary>
+              <LevelImageDisplay image={currentImage} size={memorizeImageSize} revealStep={revealStep} />
+            </ErrorBoundary>
+            <Text style={styles.imageName}>
+              {currentLang === 'en' ? currentImage.displayNameEn : currentImage.displayName}
+            </Text>
+            <Text style={styles.imageInfo}>
+              Level {levelNumber} • {currentImage.strokeCount} Striche
+            </Text>
+          </View>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  phaseContainer: {
+    flex: 1,
+    padding: Spacing.md,
+    justifyContent: 'space-between',
+  },
+  phaseTitle: {
+    fontSize: FontSize.lg,
+    fontWeight: FontWeight.bold,
+    color: Colors.text.primary,
+    marginTop: 0,
+    marginBottom: Spacing.xs,
+    textAlign: 'center',
+  },
+  timerContainer: {
+    alignSelf: 'center',
+    backgroundColor: Colors.primary,
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: Spacing.md,
+    ...Colors.shadow.large,
+  },
+  timerText: {
+    fontSize: FontSize.huge,
+    fontWeight: FontWeight.bold,
+    color: Colors.background,
+  },
+  imageContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  imagePlaceholder: {
+    backgroundColor: Colors.surface,
+    padding: Spacing.lg,
+    borderRadius: BorderRadius.xxl,
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...Colors.shadow.large,
+  },
+  imageName: {
+    fontSize: FontSize.lg,
+    fontWeight: FontWeight.bold,
+    color: Colors.text.primary,
+    marginBottom: Spacing.sm,
+  },
+  imageInfo: {
+    fontSize: FontSize.sm,
+    color: Colors.text.secondary,
+  },
+});

--- a/components/game/MemorizePhase.tsx
+++ b/components/game/MemorizePhase.tsx
@@ -23,7 +23,7 @@ export default function MemorizePhase({
       <Text style={styles.phaseTitle}>{t('game.memorize.title')}</Text>
 
       <View style={styles.timerContainer}>
-        <Text style={styles.timerText}>{timeRemaining}s</Text>
+        <Text style={styles.timerText}>{t('game.memorize.timeLeft', { seconds: timeRemaining })}</Text>
       </View>
 
       <View style={styles.imageContainer}>
@@ -36,7 +36,7 @@ export default function MemorizePhase({
               {currentLang === 'en' ? currentImage.displayNameEn : currentImage.displayName}
             </Text>
             <Text style={styles.imageInfo}>
-              Level {levelNumber} • {currentImage.strokeCount} Striche
+              {t('game.memorize.imageInfo', { level: levelNumber, strokeCount: currentImage.strokeCount })}
             </Text>
           </View>
         )}

--- a/components/game/ResultPhase.tsx
+++ b/components/game/ResultPhase.tsx
@@ -11,7 +11,6 @@ import { useTranslation } from '@services/i18n';
 
 export default function ResultPhase({
   currentImage,
-  currentLang,
   levelNumber,
   userRating,
   savedToGallery,
@@ -83,14 +82,14 @@ export default function ResultPhase({
       {/* 2. Sterne-Bewertung */}
       <View style={[styles.starsContainer, isSmall && styles.starsContainerSmall]}>
         <Text style={styles.starsTitle}>{t('game.result.howWell')}</Text>
-        <View style={styles.starsRow}>
+        <View style={styles.starsRow} testID="stars-container">
           {[1, 2, 3, 4, 5].map((star) => (
             <AnimatedStar
               key={star}
               filled={star <= userRating}
               index={star - 1}
               onPress={() => onRatingSubmit(star)}
-              accessibilityLabel={`${star} Stern${star !== 1 ? 'e' : ''}`}
+              accessibilityLabel={t('game.result.starAccessibilityLabel', { rating: star, plural: star !== 1 ? 's' : '' })}
             />
           ))}
         </View>

--- a/components/game/ResultPhase.tsx
+++ b/components/game/ResultPhase.tsx
@@ -1,0 +1,293 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
+import DrawingCanvas from '@components/DrawingCanvas';
+import LevelImageDisplay from '@components/LevelImageDisplay';
+import { AnimatedFeedback, AnimatedStar } from '@components/AnimatedPrimitives';
+import Colors from '../../constants/Colors';
+import { Spacing, FontSize, FontWeight, BorderRadius } from '../../constants/Layout';
+import { getTotalLevels } from '@services/LevelManager';
+import type { ResultPhaseProps } from './game.shared';
+import { useTranslation } from '@services/i18n';
+
+export default function ResultPhase({
+  currentImage,
+  currentLang,
+  levelNumber,
+  userRating,
+  savedToGallery,
+  isReplaying,
+  replayPaths,
+  drawingPaths,
+  screenWidth,
+  isSmall,
+  onRatingSubmit,
+  onSaveToGallery,
+  onStartReplay,
+  onStopReplay,
+  onNextLevel,
+  onRestartFromLevel1,
+}: ResultPhaseProps) {
+  const { t } = useTranslation();
+
+  const getFeedbackText = (rating: number) => {
+    if (rating === 5) return t('game.result.feedback5');
+    if (rating === 4) return t('game.result.feedback4');
+    if (rating === 3) return t('game.result.feedback3');
+    if (rating >= 1) return t('game.result.feedback1');
+    return t('game.result.tapStars');
+  };
+
+  const imageSize = Math.min(Math.max(screenWidth * 0.44, 140), 220);
+
+  return (
+    <ScrollView
+      style={styles.resultScrollView}
+      contentContainerStyle={styles.resultContent}
+      showsVerticalScrollIndicator={false}
+    >
+      {/* 1. Side-by-side Vergleich */}
+      <View style={styles.comparisonContainer}>
+        {/* Vorlage */}
+        <View style={[styles.comparisonCard, { width: imageSize }]}>
+          <View style={[styles.comparisonCardHeader, styles.comparisonCardHeaderTemplate]}>
+            <Text style={[styles.comparisonCardLabel, { color: Colors.primary }]}>
+              {t('game.result.template').toUpperCase()}
+            </Text>
+          </View>
+          <View style={[styles.comparisonImage, { width: imageSize, height: imageSize }]}>
+            {currentImage && (
+              <LevelImageDisplay image={currentImage} size={imageSize} />
+            )}
+          </View>
+        </View>
+
+        {/* Deine Zeichnung */}
+        <View style={[styles.comparisonCard, { width: imageSize }]}>
+          <View style={[styles.comparisonCardHeader, styles.comparisonCardHeaderDrawing]}>
+            <Text style={[styles.comparisonCardLabel, { color: Colors.secondary }]}>
+              {t('game.result.yourDrawing').toUpperCase()}
+            </Text>
+          </View>
+          <View style={[styles.comparisonImage, { width: imageSize, height: imageSize }]}>
+            <DrawingCanvas
+              width={imageSize}
+              height={imageSize}
+              paths={isReplaying ? replayPaths : drawingPaths}
+              strokeColor={Colors.drawing.black}
+              strokeWidth={2}
+            />
+          </View>
+        </View>
+      </View>
+
+      {/* 2. Sterne-Bewertung */}
+      <View style={[styles.starsContainer, isSmall && styles.starsContainerSmall]}>
+        <Text style={styles.starsTitle}>{t('game.result.howWell')}</Text>
+        <View style={styles.starsRow}>
+          {[1, 2, 3, 4, 5].map((star) => (
+            <AnimatedStar
+              key={star}
+              filled={star <= userRating}
+              index={star - 1}
+              onPress={() => onRatingSubmit(star)}
+              accessibilityLabel={`${star} Stern${star !== 1 ? 'e' : ''}`}
+            />
+          ))}
+        </View>
+        <AnimatedFeedback visible={userRating > 0}>
+          <Text style={styles.feedbackText}>{getFeedbackText(userRating)}</Text>
+        </AnimatedFeedback>
+      </View>
+
+      {/* Completion banner for Level 10 */}
+      {levelNumber >= getTotalLevels() && userRating > 0 && (
+        <View style={styles.completionBanner}>
+          <Text style={styles.completionTitle}>{t('game.result.allLevelsComplete')}</Text>
+          <Text style={styles.completionMessage}>{t('game.result.allLevelsCompleteMessage')}</Text>
+        </View>
+      )}
+
+      {/* 3. Aktions-Zeile: Zeitraffer | Galerie | Weiter */}
+      <View style={styles.actionRow}>
+        <TouchableOpacity
+          style={styles.actionButton}
+          onPress={isReplaying ? onStopReplay : onStartReplay}
+          accessibilityRole="button"
+        >
+          <Text style={styles.actionButtonText}>
+            {isReplaying ? '⏹' : '🎬'}
+          </Text>
+          <Text style={styles.actionButtonLabel}>
+            {isReplaying ? t('game.result.replayStop') : t('game.result.replay')}
+          </Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.actionButton, savedToGallery && styles.actionButtonSaved]}
+          onPress={onSaveToGallery}
+          disabled={savedToGallery}
+          accessibilityRole="button"
+          accessibilityLabel={savedToGallery ? t('gallery.saved') : t('gallery.save')}
+          accessibilityState={{ disabled: savedToGallery }}
+        >
+          <Text style={styles.actionButtonText}>{savedToGallery ? '✓' : '🖼'}</Text>
+          <Text style={[styles.actionButtonLabel, savedToGallery && styles.actionButtonLabelSaved]}>
+            {savedToGallery ? t('gallery.saved') : t('gallery.save')}
+          </Text>
+        </TouchableOpacity>
+
+        {levelNumber < getTotalLevels() ? (
+          <TouchableOpacity style={[styles.actionButton, styles.actionButtonPrimary]} onPress={onNextLevel}>
+            <Text style={[styles.actionButtonText, styles.actionButtonPrimaryText]}>→</Text>
+            <Text style={[styles.actionButtonLabel, styles.actionButtonPrimaryText]}>{t('game.result.nextLevel')}</Text>
+          </TouchableOpacity>
+        ) : (
+          <TouchableOpacity style={[styles.actionButton, styles.actionButtonPrimary]} onPress={onRestartFromLevel1}>
+            <Text style={[styles.actionButtonText, styles.actionButtonPrimaryText]}>🔄</Text>
+            <Text style={[styles.actionButtonLabel, styles.actionButtonPrimaryText]}>{t('game.result.playAgain')}</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  resultScrollView: {
+    flex: 1,
+  },
+  resultContent: {
+    padding: Spacing.md,
+    flexGrow: 1,
+  },
+  comparisonContainer: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    marginBottom: Spacing.md,
+    justifyContent: 'center',
+  },
+  comparisonCard: {
+    backgroundColor: Colors.surface,
+    borderRadius: BorderRadius.xl,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: Colors.border,
+    ...Colors.shadow.medium,
+  },
+  comparisonCardHeader: {
+    paddingVertical: Spacing.xs,
+    paddingHorizontal: Spacing.sm,
+  },
+  comparisonCardHeaderTemplate: {
+    backgroundColor: Colors.primary + '18',
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.primary + '22',
+  },
+  comparisonCardHeaderDrawing: {
+    backgroundColor: Colors.secondary + '18',
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.secondary + '22',
+  },
+  comparisonCardLabel: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.bold,
+    letterSpacing: 0.6,
+  },
+  comparisonImage: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  starsContainer: {
+    backgroundColor: Colors.surface,
+    borderRadius: BorderRadius.xxl,
+    padding: Spacing.lg,
+    alignItems: 'center',
+    marginBottom: Spacing.md,
+    ...Colors.shadow.medium,
+  },
+  starsContainerSmall: {
+    marginBottom: Spacing.sm,
+  },
+  starsTitle: {
+    fontSize: FontSize.lg,
+    fontWeight: FontWeight.bold,
+    color: Colors.text.primary,
+    marginBottom: Spacing.md,
+    textAlign: 'center',
+  },
+  starsRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    marginBottom: Spacing.md,
+  },
+  feedbackText: {
+    fontSize: FontSize.md,
+    color: Colors.text.secondary,
+    textAlign: 'center',
+    paddingHorizontal: Spacing.lg,
+  },
+  completionBanner: {
+    backgroundColor: Colors.success + '15',
+    borderWidth: 2,
+    borderColor: Colors.success,
+    borderRadius: BorderRadius.xl,
+    padding: Spacing.lg,
+    alignItems: 'center',
+    marginBottom: Spacing.lg,
+  },
+  completionTitle: {
+    fontSize: FontSize.xl,
+    fontWeight: FontWeight.bold,
+    color: Colors.success,
+    marginBottom: Spacing.sm,
+    textAlign: 'center',
+  },
+  completionMessage: {
+    fontSize: FontSize.md,
+    color: Colors.text.secondary,
+    textAlign: 'center',
+  },
+  actionRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    marginTop: Spacing.sm,
+  },
+  actionButton: {
+    flex: 1,
+    backgroundColor: Colors.surface,
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.xs,
+    borderRadius: BorderRadius.lg,
+    alignItems: 'center',
+    borderWidth: 2,
+    borderColor: Colors.border,
+    minHeight: 60,
+    justifyContent: 'center',
+    gap: 2,
+    ...Colors.shadow.small,
+  },
+  actionButtonPrimary: {
+    backgroundColor: Colors.primary,
+    borderColor: Colors.primary,
+  },
+  actionButtonSaved: {
+    borderColor: Colors.success,
+    backgroundColor: Colors.success + '10',
+  },
+  actionButtonText: {
+    fontSize: 20,
+    textAlign: 'center',
+  },
+  actionButtonLabel: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.semibold,
+    color: Colors.text.secondary,
+    textAlign: 'center',
+  },
+  actionButtonLabelSaved: {
+    color: Colors.success,
+  },
+  actionButtonPrimaryText: {
+    color: Colors.background,
+  },
+});

--- a/components/game/game.shared.ts
+++ b/components/game/game.shared.ts
@@ -33,8 +33,6 @@ export interface DrawPhaseProps {
     canvasMinHeight: number;
     canvasMarginVertical: number;
     toolbarMarginVertical: number;
-    toolbarButtonMinHeight: number;
-    toolbarButtonPaddingVertical: number;
     buttonMinHeight: number;
     buttonPaddingVertical: number;
     isSmall: boolean;
@@ -44,7 +42,6 @@ export interface DrawPhaseProps {
 
 export interface ResultPhaseProps {
   currentImage: LevelImage | null;
-  currentLang: string;
   levelNumber: number;
   userRating: number;
   savedToGallery: boolean;

--- a/components/game/game.shared.ts
+++ b/components/game/game.shared.ts
@@ -1,0 +1,62 @@
+import type { DrawingPath } from '@components/DrawingCanvas';
+import type { LevelImage } from '../../types';
+
+export interface MemorizePhaseProps {
+  timeRemaining: number;
+  currentImage: LevelImage | null;
+  levelNumber: number;
+  currentLang: string;
+  memorizeImageSize: number;
+  imagePlaceholderMinSize: number;
+  revealStep: number;
+}
+
+export interface DrawPhaseProps {
+  currentImage: LevelImage | null;
+  currentLang: string;
+  hasUsedHint: boolean;
+  onUseHint: () => void;
+  onShowHintModal: () => void;
+  drawing: {
+    color: string;
+    strokeWidth: number;
+    tool: 'brush' | 'fill';
+    paths: DrawingPath[];
+    setPaths: (paths: DrawingPath[]) => void;
+    setColor: (color: string) => void;
+    setTool: (tool: 'brush' | 'fill') => void;
+    setStrokeWidth: (width: number) => void;
+    undo: () => void;
+  };
+  layout: {
+    canvasMaxHeight: number;
+    canvasMinHeight: number;
+    canvasMarginVertical: number;
+    toolbarMarginVertical: number;
+    toolbarButtonMinHeight: number;
+    toolbarButtonPaddingVertical: number;
+    buttonMinHeight: number;
+    buttonPaddingVertical: number;
+    isSmall: boolean;
+  };
+  onDone: () => void;
+}
+
+export interface ResultPhaseProps {
+  currentImage: LevelImage | null;
+  currentLang: string;
+  levelNumber: number;
+  userRating: number;
+  savedToGallery: boolean;
+  isReplaying: boolean;
+  replayPaths: DrawingPath[];
+  drawingPaths: DrawingPath[];
+  screenWidth: number;
+  isSmall: boolean;
+  onRatingSubmit: (rating: number) => void;
+  onSaveToGallery: () => void;
+  onStartReplay: () => void;
+  onStopReplay: () => void;
+  onNextLevel: () => void;
+  onRestartFromLevel1: () => void;
+}

--- a/constants/featureFlags.ts
+++ b/constants/featureFlags.ts
@@ -4,6 +4,8 @@
  *
  * Konvention: ENABLE_* defaultet auf `true`. Auf `false` setzen, um
  * das Feature ohne Code-Removal kurzfristig zu deaktivieren.
+ * Ausnahme: Neue Features in Entwicklung können mit `false` starten
+ * und werden auf `true` gesetzt, sobald sie bereit sind.
  */
 
 export const FeatureFlags = {

--- a/constants/featureFlags.ts
+++ b/constants/featureFlags.ts
@@ -9,4 +9,6 @@
 export const FeatureFlags = {
   /** Konfetti bei 5-Sterne-Ergebnis (Issue #186). */
   ENABLE_CONFETTI: true,
+  /** Draw/Result Tab-Navigation im Game-Screen (Issue #199). */
+  ENABLE_GAME_PHASE_TABS: false,
 } as const;

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -32,7 +32,8 @@
   "game": {
     "memorize": {
       "title": "Merke dir das Bild!",
-      "timeLeft": "{{seconds}}s"
+      "timeLeft": "{{seconds}}s",
+      "imageInfo": "Level {{level}} • {{strokeCount}} Striche"
     },
     "draw": {
       "title": "Male das Bild nach!",
@@ -64,6 +65,7 @@
       "title": "Bewerte selbst:",
       "howWell": "Wie gut hast du's getroffen?",
       "tapStars": "Tippe auf die Sterne, um dich zu bewerten!",
+      "starAccessibilityLabel": "{{rating}} Stern{{plural}}",
       "template": "Vorlage",
       "feedback5": "Perfekt! Du bist ein Gedächtnis-Meister!",
       "feedback4": "Sehr gut! Fast perfekt!",

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -32,7 +32,8 @@
   "game": {
     "memorize": {
       "title": "Remember the picture!",
-      "timeLeft": "{{seconds}}s"
+      "timeLeft": "{{seconds}}s",
+      "imageInfo": "Level {{level}} • {{strokeCount}} strokes"
     },
     "draw": {
       "title": "Draw the picture!",
@@ -64,6 +65,7 @@
       "title": "Rate yourself:",
       "howWell": "How well did you do?",
       "tapStars": "Tap the stars to rate yourself!",
+      "starAccessibilityLabel": "{{rating}} star{{plural}}",
       "template": "Reference",
       "feedback5": "Perfect! You are a memory master!",
       "feedback4": "Very good! Almost perfect!",


### PR DESCRIPTION
## Summary

- **#206** — `app/game.tsx` refactored: 1270 → 438 LOC, drei Phase-Komponenten unter `components/game/` extrahiert (`MemorizePhase`, `DrawPhase`, `ResultPhase`) + 14 neue Tests
- **#207** — Daily Challenge Datum-Fix nach Mitternacht; Draw/Result-Tab-Navigation per Feature-Flag (`ENABLE_GAME_PHASE_TABS: false`) ausgeblendet
- Copilot-PR-Review-Suggestions für beide PRs umgesetzt (i18n, Dead Props, redundanter useEffect)

## Test plan

- [x] 356/356 Tests grün
- [x] `npx tsc --noEmit` sauber
- [x] CI alle Jobs grün (beide PRs)
- [ ] Manuell: Memorize → Draw → Result-Flow
- [ ] Daily Challenge Button zeigt korrektes Datum nach Mitternacht

🤖 Generated with [Claude Code](https://claude.com/claude-code)