### PR TITLE
refactor(#213): Settings-Modal kompakter gestalten

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Merke und Male",
     "slug": "merke-und-male",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "platforms": [
       "ios",
       "android",
@@ -43,7 +43,7 @@
       },
       "package": "com.s540d.merkeundmale",
       "permissions": [],
-      "versionCode": 63,
+      "versionCode": 64,
       "minSdkVersion": 26,
       "newArchEnabled": false,
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.s540d.merkeundmale",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merke-und-male",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "main": "expo-router/entry",
   "homepage": "https://s540d.github.io/DrawFromMemory/",
   "repository": {


### PR DESCRIPTION
Closes #213

## Summary

- `maxHeight` 85 % → 75 %, kleinerer `BorderRadius` (xl statt xxl) am Modal-Container
- Header-Padding deutlich reduziert, Titel `fontSize md` statt `lg`
- Section-Header: weniger Abstand oben/unten
- Cards: `BorderRadius md` statt `lg`
- Zeilen: kleineres Padding (`xs`/`sm`), kein festes `minHeight: 44`, Label-Font `xs`
- Segment-Controls: weniger Padding + kleinere `minWidth`
- Action-Grid: Icons 18 px statt 22 px, engerer Gap
- About-Modal: kompakteres Padding und kleinere Schrift durchgehend
- Die bisherige separate "Daten"-Sektion (nur "Fortschritt zurücksetzen") wird in die Support-Card integriert → eine Section weniger, weniger Scrolling

Alle Funktionen bleiben erhalten. Responsive auf kleinen Screens durch `maxHeight: 75 %` + ScrollView.

## Test plan

- [x] 360 Tests grün (`npm run test:ci`)
- [x] TypeScript clean (`npx tsc --noEmit`)
- [x] Lint + Pre-Commit-Checks bestanden
- [ ] Visuell auf Gerät/Emulator validieren

🤖 Generated with [Claude Code](https://claude.com/claude-code)