### PR TITLE
fix: UX-Followup nach Telefon-Test (Home-Hero, Canvas-Overlap, Settings)

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -16,7 +16,6 @@ import { Spacing, FontSize, FontWeight, FontFamily, BorderRadius } from '../cons
 import SettingsModal from '@components/SettingsModal';
 import QuickStatsCards from '@components/QuickStatsCards';
 import { FloatingStars } from '@components/FloatingStars';
-import { AnimatedHero } from '@components/AnimatedHero';
 import OnboardingModal from '@components/OnboardingModal';
 import { isOnboardingDone } from '@services/OnboardingManager';
 
@@ -90,11 +89,8 @@ export default function HomeScreen() {
         </View>
       </View>
 
-      {/* Center hero — flex:1 fills space above the bottom section */}
-      <View style={styles.hero}>
-        <AnimatedHero />
-        <Text style={[styles.heroTitle, { color: colors.text.primary }]}>{t('home.title')}</Text>
-      </View>
+      {/* Center spacer — flex:1 fills space above the bottom section */}
+      <View style={styles.hero} />
 
       {/* Bottom section: stats + buttons — always anchored at the bottom */}
       <View style={styles.bottomSection}>
@@ -217,21 +213,11 @@ const styles = StyleSheet.create({
   },
   hero: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    gap: Spacing.lg,
-    minHeight: 80,
+    minHeight: Spacing.md,
   },
   bottomSection: {
     marginTop: 'auto',
     gap: Spacing.md,
-  },
-  heroTitle: {
-    fontSize: FontSize.display,
-    fontWeight: FontWeight.bold,
-    fontFamily: FontFamily.extraBold,
-    textAlign: 'center',
-    lineHeight: 48,
   },
   buttonContainer: {
     gap: Spacing.sm,

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -287,8 +287,8 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
               style={[
                 styles.actionGridItem,
                 { borderColor: colors.border },
-                idx < 2 && styles.actionGridItemTop,
-                idx % 2 === 1 && styles.actionGridItemRight,
+                idx < 3 && styles.actionGridItemTop,
+                idx % 3 !== 0 && styles.actionGridItemRight,
               ]}
               onPress={onPress}
               accessibilityRole="button"
@@ -457,9 +457,9 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
   },
   actionGridItem: {
-    width: '50%',
-    paddingVertical: Spacing.sm,
-    paddingHorizontal: Spacing.sm,
+    width: '33.333%',
+    paddingVertical: Spacing.xs,
+    paddingHorizontal: Spacing.xs,
     alignItems: 'center',
     justifyContent: 'center',
     gap: 2,
@@ -472,7 +472,7 @@ const styles = StyleSheet.create({
     borderLeftWidth: StyleSheet.hairlineWidth,
   },
   actionGridIcon: {
-    fontSize: 18,
+    fontSize: 16,
   },
   actionGridLabel: {
     fontSize: FontSize.xs,

--- a/components/game/DrawPhase.tsx
+++ b/components/game/DrawPhase.tsx
@@ -62,6 +62,7 @@ export default function DrawPhase({
       <View style={[styles.canvasContainer, dynCanvasContainer]}>
         <ErrorBoundary>
           <DrawingCanvas
+            height={Math.floor(layout.canvasMaxHeight)}
             strokeColor={drawing.color}
             strokeWidth={drawing.strokeWidth}
             tool={drawing.tool}


### PR DESCRIPTION
## Summary
Folge-Fixes nach dem Telefon-Test — drei Punkte, die in PR #214 / #216 noch nicht (vollständig) umgesetzt waren:

- **Home Screen**: `AnimatedHero` (Gehirn + Stift) und doppelten Titel entfernt. "Merke und Male" steht jetzt nur noch einmal in der Top-Bar, darunter die Tagline.
- **Nexus 6 Canvas-Overlap**: `DrawingCanvas` in der Draw-Phase bekommt jetzt `height={Math.floor(layout.canvasMaxHeight)}` statt des hart codierten 400px-Defaults. Das verhindert, dass der Canvas den "Vorlage ansehen"-Info-Streifen auf kleinen Geräten überlappt.
- **Settings "Über & Support"**: Action-Grid auf 3 Spalten × 2 Zeilen (statt 2 × 3), Padding `xs` statt `sm`, Icons 16 statt 18 — halbiert die Höhe dieses Bereichs.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run test:ci` — 360/360 Tests grün
- [ ] Manuell auf Nexus 6: Canvas überlappt "Vorlage ansehen" nicht mehr
- [ ] Manuell auf Nexus 6: Home zeigt Titel nur einmal, kein Gehirn/Stift mehr
- [ ] Manuell: Settings-Modal "Über & Support" passt kompakter

🤖 Generated with [Claude Code](https://claude.com/claude-code)