### PR TITLE
fix(#215): Home-Layout neu (Hero-CTA + Side-by-Side), Stats kompakter, Galerie-Persistenz gefixt

### DIFF
--- a/__tests__/GalleryStorageManager.test.ts
+++ b/__tests__/GalleryStorageManager.test.ts
@@ -56,6 +56,36 @@ describe('StorageManager – Gallery', () => {
       // so a later version or manual recovery can still access it.
       expect(mockAsyncStorage.removeItem).not.toHaveBeenCalled();
     });
+
+    it('should filter out malformed entries but keep valid ones', async () => {
+      const validEntry: GalleryEntry = {
+        id: 'valid1',
+        levelNumber: 3,
+        imageFilename: 'fish.svg',
+        imageName: 'Fisch',
+        paths: makePaths(),
+        rating: 5,
+        savedAt: new Date().toISOString(),
+      };
+      const mixed = [
+        validEntry,
+        { id: 'no-paths', levelNumber: 1, imageFilename: 'x.svg', imageName: 'X', rating: 2, savedAt: 'x' }, // missing paths
+        { id: 'bad-rating', levelNumber: 1, imageFilename: 'x.svg', imageName: 'X', paths: [], rating: 'oops', savedAt: 'x' }, // rating not a number
+        null,
+        'not-an-object',
+        { id: 42, levelNumber: 1, imageFilename: 'x.svg', imageName: 'X', paths: [], rating: 2, savedAt: 'x' }, // id not a string
+      ];
+      mockAsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify(mixed));
+      const gallery = await storageManager.getGallery();
+      expect(gallery).toHaveLength(1);
+      expect(gallery[0].id).toBe('valid1');
+    });
+
+    it('should return empty array when parsed payload is not an array', async () => {
+      mockAsyncStorage.getItem.mockResolvedValueOnce(JSON.stringify({ not: 'an array' }));
+      const gallery = await storageManager.getGallery();
+      expect(gallery).toEqual([]);
+    });
   });
 
   describe('saveToGallery', () => {

--- a/__tests__/GalleryStorageManager.test.ts
+++ b/__tests__/GalleryStorageManager.test.ts
@@ -48,11 +48,13 @@ describe('StorageManager – Gallery', () => {
       expect(gallery[0].imageName).toBe('Hund');
     });
 
-    it('should return empty array and clear on corrupt JSON', async () => {
+    it('should return empty array on corrupt JSON without wiping storage', async () => {
       mockAsyncStorage.getItem.mockResolvedValueOnce('not-valid-json{{{');
       const gallery = await storageManager.getGallery();
       expect(gallery).toEqual([]);
-      expect(mockAsyncStorage.removeItem).toHaveBeenCalled();
+      // Issue #215: gallery must NOT be wiped on parse failure — keep raw data
+      // so a later version or manual recovery can still access it.
+      expect(mockAsyncStorage.removeItem).not.toHaveBeenCalled();
     });
   });
 

--- a/__tests__/StorageManager.test.ts
+++ b/__tests__/StorageManager.test.ts
@@ -175,7 +175,7 @@ describe('StorageManager', () => {
       expect(AsyncStorage.removeItem).toHaveBeenCalledWith('@merke_male:progress');
     });
 
-    it('should handle corrupt JSON data gracefully', async () => {
+    it('should handle corrupt JSON data gracefully without wiping storage', async () => {
       (AsyncStorage.getItem as jest.Mock).mockResolvedValue('{ invalid json }');
       (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
 
@@ -187,7 +187,9 @@ describe('StorageManager', () => {
         totalLevelsCompleted: 0,
         averageRating: 0,
       });
-      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('@merke_male:progress');
+      // Issue #215: progress must NOT be wiped on parse failure — keep raw data
+      // so a later version or manual recovery can still access it.
+      expect(AsyncStorage.removeItem).not.toHaveBeenCalledWith('@merke_male:progress');
     });
   });
 

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -16,7 +16,6 @@ import { Spacing, FontSize, FontWeight, FontFamily, BorderRadius } from '../cons
 import SettingsModal from '@components/SettingsModal';
 import QuickStatsCards from '@components/QuickStatsCards';
 import { FloatingStars } from '@components/FloatingStars';
-import { AnimatedHero } from '@components/AnimatedHero';
 import OnboardingModal from '@components/OnboardingModal';
 import { isOnboardingDone } from '@services/OnboardingManager';
 
@@ -90,74 +89,74 @@ export default function HomeScreen() {
         </View>
       </View>
 
-      {/* Center hero — animated brain+pencil illustration */}
-      <View style={styles.hero}>
-        <AnimatedHero />
+      {/* Hero CTA — "Spiel starten" als dominanter zentraler Button */}
+      <View style={styles.heroSlot}>
+        <TouchableOpacity
+          onPress={() => router.push('/game')}
+          accessibilityRole="button"
+          accessibilityLabel={t('home.startButton')}
+          style={styles.heroCtaWrapper}
+          activeOpacity={0.85}
+        >
+          <LinearGradient
+            colors={Colors.gradient.cta as [string, string]}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={styles.heroCtaPill}
+          >
+            <Text style={styles.heroCtaIcon}>▶</Text>
+            <Text style={styles.heroCtaText}>{t('home.startButton')}</Text>
+          </LinearGradient>
+        </TouchableOpacity>
       </View>
 
-      {/* Bottom section: stats + buttons — always anchored at the bottom */}
+      {/* Bottom section: sekundär-Aktionen + Stats — versetzt, nicht statisch gestapelt */}
       <View style={styles.bottomSection}>
-        {/* Quick Stats */}
-        <QuickStatsCards />
+        {/* Daily Challenge — breite Karte, abgesetzt von den anderen */}
+        <TouchableOpacity
+          style={[
+            styles.dailyChallengeButton,
+            { backgroundColor: colors.surface, borderColor: dailyCompleted ? colors.text.light : '#F59E0B' },
+            dailyCompleted && styles.dailyChallengeCompleted,
+          ]}
+          onPress={() => !dailyCompleted && router.push(`/game?level=${dailyLevel}&daily=1`)}
+          accessibilityRole="button"
+          disabled={dailyCompleted}
+        >
+          <Text style={styles.dailyChallengeEmoji}>⚡</Text>
+          <View style={styles.dailyChallengeInfo}>
+            <Text style={[styles.dailyChallengeTitle, { color: dailyCompleted ? colors.text.secondary : '#D97706' }]}>
+              {t('dailyChallenge.title')}
+            </Text>
+            <Text style={[styles.dailyChallengeMeta, { color: colors.text.secondary }]}>
+              {dailyCompleted
+                ? t('dailyChallenge.completed')
+                : `${t('dailyChallenge.level', { number: String(dailyLevel) })} · ${t('dailyChallenge.countdown', { hours: String(countdownHours), minutes: String(countdownMinutes) })}`}
+            </Text>
+          </View>
+        </TouchableOpacity>
 
-        {/* Buttons */}
-        <View style={styles.buttonContainer}>
+        {/* Levels + Galerie — Side-by-Side statt untereinander */}
+        <View style={styles.secondaryRow}>
           <TouchableOpacity
-            onPress={() => router.push('/game')}
-            accessibilityRole="button"
-            accessibilityLabel={t('home.startButton')}
-            style={styles.gradientWrapper}
-          >
-            <LinearGradient
-              colors={Colors.gradient.cta as [string, string]}
-              start={{ x: 0, y: 0 }}
-              end={{ x: 1, y: 0 }}
-              style={styles.gradientButton}
-            >
-              <Text style={styles.gradientButtonText}>{t('home.startButton')}</Text>
-            </LinearGradient>
-          </TouchableOpacity>
-
-          {/* Daily Challenge */}
-          <TouchableOpacity
-            style={[
-              styles.dailyChallengeButton,
-              { backgroundColor: colors.surface, borderColor: dailyCompleted ? colors.text.light : '#F59E0B' },
-              dailyCompleted && styles.dailyChallengeCompleted,
-            ]}
-            onPress={() => !dailyCompleted && router.push(`/game?level=${dailyLevel}&daily=1`)}
-            accessibilityRole="button"
-            disabled={dailyCompleted}
-          >
-            <Text style={styles.dailyChallengeEmoji}>⚡</Text>
-            <View style={styles.dailyChallengeInfo}>
-              <Text style={[styles.dailyChallengeTitle, { color: dailyCompleted ? colors.text.secondary : '#D97706' }]}>
-                {t('dailyChallenge.title')}
-              </Text>
-              <Text style={[styles.dailyChallengeMeta, { color: colors.text.secondary }]}>
-                {dailyCompleted
-                  ? t('dailyChallenge.completed')
-                  : `${t('dailyChallenge.level', { number: String(dailyLevel) })} · ${t('dailyChallenge.countdown', { hours: String(countdownHours), minutes: String(countdownMinutes) })}`}
-              </Text>
-            </View>
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            style={[styles.secondaryButton, { backgroundColor: colors.surface, borderColor: colors.primary }]}
+            style={[styles.secondaryTile, { backgroundColor: colors.surface, borderColor: colors.primary }]}
             onPress={() => router.push('/levels')}
             accessibilityRole="button"
           >
-            <Text style={[styles.secondaryButtonText, { color: colors.primary }]}>{t('home.levelsButton')}</Text>
+            <Text style={[styles.secondaryTileText, { color: colors.primary }]}>{t('home.levelsButton')}</Text>
           </TouchableOpacity>
 
           <TouchableOpacity
-            style={[styles.secondaryButton, { backgroundColor: colors.surface, borderColor: colors.primary }]}
+            style={[styles.secondaryTile, { backgroundColor: colors.surface, borderColor: colors.primary }]}
             onPress={() => router.push('/gallery')}
             accessibilityRole="button"
           >
-            <Text style={[styles.secondaryButtonText, { color: colors.primary }]}>{t('home.galleryButton')}</Text>
+            <Text style={[styles.secondaryTileText, { color: colors.primary }]}>{t('home.galleryButton')}</Text>
           </TouchableOpacity>
         </View>
+
+        {/* Quick Stats — dezent am unteren Rand */}
+        <QuickStatsCards />
       </View>
 
       <SettingsModal visible={showSettings} onClose={() => setShowSettings(false)} />
@@ -214,40 +213,50 @@ const styles = StyleSheet.create({
   settingsIcon: {
     fontSize: 24,
   },
-  hero: {
+  heroSlot: {
     flex: 1,
-    minHeight: Spacing.md,
+    minHeight: 140,
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  heroCtaWrapper: {
+    borderRadius: BorderRadius.round,
+    overflow: 'hidden',
+    ...Colors.shadow.large,
+  },
+  heroCtaPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: Spacing.sm,
+    paddingVertical: Spacing.lg,
+    paddingHorizontal: Spacing.xxl,
+    minHeight: 80,
+    minWidth: 240,
+  },
+  heroCtaIcon: {
+    fontSize: 22,
+    color: '#fff',
+  },
+  heroCtaText: {
+    fontSize: FontSize.xl,
+    fontWeight: FontWeight.bold,
+    fontFamily: FontFamily.extraBold,
+    color: '#fff',
+    letterSpacing: 0.5,
   },
   bottomSection: {
     marginTop: 'auto',
     gap: Spacing.md,
   },
-  buttonContainer: {
+  secondaryRow: {
+    flexDirection: 'row',
     gap: Spacing.sm,
   },
-  gradientWrapper: {
-    borderRadius: BorderRadius.lg,
-    overflow: 'hidden',
-    ...Colors.shadow.large,
-  },
-  gradientButton: {
+  secondaryTile: {
+    flex: 1,
     paddingVertical: Spacing.md,
-    paddingHorizontal: Spacing.xl,
-    alignItems: 'center',
-    minHeight: 52,
-    justifyContent: 'center',
-  },
-  gradientButtonText: {
-    fontSize: FontSize.md,
-    fontWeight: FontWeight.bold,
-    color: '#fff',
-    letterSpacing: 0.3,
-  },
-  secondaryButton: {
-    paddingVertical: Spacing.md,
-    paddingHorizontal: Spacing.xl,
+    paddingHorizontal: Spacing.md,
     borderRadius: BorderRadius.lg,
     borderWidth: 2,
     alignItems: 'center',
@@ -255,9 +264,10 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     ...Colors.shadow.small,
   },
-  secondaryButtonText: {
+  secondaryTileText: {
     fontSize: FontSize.md,
     fontWeight: FontWeight.semibold,
+    fontFamily: FontFamily.semibold,
   },
   dailyChallengeButton: {
     flexDirection: 'row',

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -16,6 +16,7 @@ import { Spacing, FontSize, FontWeight, FontFamily, BorderRadius } from '../cons
 import SettingsModal from '@components/SettingsModal';
 import QuickStatsCards from '@components/QuickStatsCards';
 import { FloatingStars } from '@components/FloatingStars';
+import { AnimatedHero } from '@components/AnimatedHero';
 import OnboardingModal from '@components/OnboardingModal';
 import { isOnboardingDone } from '@services/OnboardingManager';
 
@@ -89,8 +90,10 @@ export default function HomeScreen() {
         </View>
       </View>
 
-      {/* Center spacer — flex:1 fills space above the bottom section */}
-      <View style={styles.hero} />
+      {/* Center hero — animated brain+pencil illustration */}
+      <View style={styles.hero}>
+        <AnimatedHero />
+      </View>
 
       {/* Bottom section: stats + buttons — always anchored at the bottom */}
       <View style={styles.bottomSection}>
@@ -214,6 +217,8 @@ const styles = StyleSheet.create({
   hero: {
     flex: 1,
     minHeight: Spacing.md,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   bottomSection: {
     marginTop: 'auto',

--- a/components/QuickStatsCards.tsx
+++ b/components/QuickStatsCards.tsx
@@ -102,10 +102,10 @@ export default function QuickStatsCards() {
           accessibilityLabel={`${card.label}: ${card.value}${card.sub ? ' ' + card.sub : ''}`}
         >
           <Text style={styles.emoji}>{card.emoji}</Text>
-          <Text style={[styles.value, { color: colors.text.primary }]} numberOfLines={1} adjustsFontSizeToFit>{card.value}</Text>
-          <Text style={[styles.label, { color: colors.text.secondary }]} numberOfLines={1} adjustsFontSizeToFit>{card.label}</Text>
+          <Text style={[styles.value, { color: colors.text.primary }]} numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.7}>{card.value}</Text>
+          <Text style={[styles.label, { color: colors.text.secondary }]} numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.7}>{card.label}</Text>
           {card.sub !== null && (
-            <Text style={[styles.sub, { color: colors.text.secondary }]} numberOfLines={1} adjustsFontSizeToFit>{card.sub}</Text>
+            <Text style={[styles.sub, { color: colors.text.secondary }]} numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.7}>{card.sub}</Text>
           )}
         </GlassCard>
       ))}

--- a/components/QuickStatsCards.tsx
+++ b/components/QuickStatsCards.tsx
@@ -102,10 +102,10 @@ export default function QuickStatsCards() {
           accessibilityLabel={`${card.label}: ${card.value}${card.sub ? ' ' + card.sub : ''}`}
         >
           <Text style={styles.emoji}>{card.emoji}</Text>
-          <Text style={[styles.value, { color: colors.text.primary }]}>{card.value}</Text>
-          <Text style={[styles.label, { color: colors.text.secondary }]}>{card.label}</Text>
+          <Text style={[styles.value, { color: colors.text.primary }]} numberOfLines={1} adjustsFontSizeToFit>{card.value}</Text>
+          <Text style={[styles.label, { color: colors.text.secondary }]} numberOfLines={1} adjustsFontSizeToFit>{card.label}</Text>
           {card.sub !== null && (
-            <Text style={[styles.sub, { color: colors.text.secondary }]}>{card.sub}</Text>
+            <Text style={[styles.sub, { color: colors.text.secondary }]} numberOfLines={1} adjustsFontSizeToFit>{card.sub}</Text>
           )}
         </GlassCard>
       ))}
@@ -126,11 +126,11 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    paddingVertical: Spacing.md,
+    paddingVertical: Spacing.sm,
     paddingHorizontal: Spacing.xs,
     borderRadius: BorderRadius.xl,
     minWidth: 80,
-    gap: 2,
+    gap: 1,
   },
   cardWide: {
     minWidth: 0,
@@ -140,13 +140,13 @@ const styles = StyleSheet.create({
     flexGrow: 1,
   },
   emoji: {
-    fontSize: 22,
+    fontSize: 20,
   },
   value: {
-    fontSize: FontSize.lg,
+    fontSize: FontSize.md,
     fontWeight: FontWeight.bold,
     fontFamily: FontFamily.bold,
-    lineHeight: 26,
+    lineHeight: 22,
   },
   label: {
     fontSize: FontSize.xs,

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -13,7 +13,7 @@
     "streakBadge": "🔥 {{count}}",
     "stats": {
       "stars": "Sterne",
-      "streak": "Streak",
+      "streak": "Serie",
       "levels": "Level",
       "streakDay": "Tag",
       "streakDays": "Tage",

--- a/services/StorageManager.ts
+++ b/services/StorageManager.ts
@@ -162,9 +162,9 @@ class StorageManager {
         try {
           return JSON.parse(data);
         } catch (parseError) {
-          // Invalid JSON, return default and clear corrupt data
-          console.error('Failed to parse progress data, resetting:', parseError);
-          await safeStorageOps.removeItem(KEYS.PROGRESS);
+          // Invalid JSON — return defaults but KEEP the raw data so a later
+          // version or manual recovery can still access it. Don't wipe.
+          console.error('Failed to parse progress data, using defaults (raw data kept):', parseError);
         }
       }
     } catch (error) {
@@ -328,10 +328,19 @@ class StorageManager {
       const data = await safeStorageOps.getItem(KEYS.GALLERY);
       if (data) {
         try {
-          return JSON.parse(data);
+          const parsed = JSON.parse(data);
+          if (Array.isArray(parsed)) {
+            // Defensive: skip entries that don't match the expected shape,
+            // but keep the rest. Never wipe the entire gallery.
+            return parsed.filter(
+              (e): e is GalleryEntry =>
+                e && typeof e === 'object' && typeof e.id === 'string' && Array.isArray(e.paths)
+            );
+          }
         } catch (parseError) {
-          console.error('Failed to parse gallery data, resetting:', parseError);
-          await safeStorageOps.removeItem(KEYS.GALLERY);
+          // Invalid JSON — return empty but KEEP the raw data so a later
+          // version or manual recovery can still access it. Don't wipe.
+          console.error('Failed to parse gallery data, using empty list (raw data kept):', parseError);
         }
       }
     } catch (error) {

--- a/services/StorageManager.ts
+++ b/services/StorageManager.ts
@@ -110,6 +110,23 @@ export interface GalleryEntry {
   isDailyChallenge?: boolean;
 }
 
+// Type-guard for defensively-loaded gallery entries. Validates every required
+// field so downstream UI code (e.g. `'★'.repeat(entry.rating)`) can't crash on
+// malformed persisted data. `isDailyChallenge` is optional and not checked.
+function isValidGalleryEntry(e: unknown): e is GalleryEntry {
+  if (!e || typeof e !== 'object') return false;
+  const r = e as Record<string, unknown>;
+  return (
+    typeof r.id === 'string' &&
+    typeof r.levelNumber === 'number' &&
+    typeof r.imageFilename === 'string' &&
+    typeof r.imageName === 'string' &&
+    Array.isArray(r.paths) &&
+    typeof r.rating === 'number' &&
+    typeof r.savedAt === 'string'
+  );
+}
+
 class StorageManager {
   // ========== Progress Management ==========
 
@@ -332,10 +349,7 @@ class StorageManager {
           if (Array.isArray(parsed)) {
             // Defensive: skip entries that don't match the expected shape,
             // but keep the rest. Never wipe the entire gallery.
-            return parsed.filter(
-              (e): e is GalleryEntry =>
-                e && typeof e === 'object' && typeof e.id === 'string' && Array.isArray(e.paths)
-            );
+            return parsed.filter(isValidGalleryEntry);
           }
         } catch (parseError) {
           // Invalid JSON — return empty but KEEP the raw data so a later


### PR DESCRIPTION
## Summary

Setzt Issue #215 um — drei Punkte aus dem User-Feedback zur Staging-Version:

### 1. Home-Screen war "langweilig" → neues Layout-Konzept

> Hinweis: Erste Version dieses PRs hatte AnimatedHero (Brain+Pencil) zurückgebracht. User-Feedback: "hässlich, füllt den freien Raum nur". Aktueller Stand ist ein neues Konzept:

- **AnimatedHero komplett raus** — keine Emoji-Symbole im Hero-Bereich mehr
- **"Spiel starten" als dominanter Hero-CTA**: pillenförmig (`BorderRadius.round`), ▶-Icon + großer extraBold-Text, fülliges Padding, Gradient diagonal — visueller Mittelpunkt des Screens
- **Daily Challenge** abgesetzt darunter (eigene breite Karte, nicht direkt am CTA klebend)
- **Levels + Galerie** nebeneinander als 2-Spalten-Grid statt vier Kästen untereinander gestapelt
- **Stats-Karten** dezent am unteren Rand
- Der in #217 entfernte doppelte Titel bleibt entfernt — "Merke und Male" steht weiterhin nur einmal in der Top-Bar

### 2. Stats-Karten "Sterne / Streak / Level von 20" zu hoch + "strea"-Truncation
- **`Streak` → `Serie`** (DE): kürzer, selbsterklärend für deutsche Nutzer, fixt die `strea`-Abschneidung
- Defensive Absicherung: `numberOfLines={1}` + `adjustsFontSizeToFit` + `minimumFontScale={0.7}` auf allen Labels (konsistent mit `components/game/DrawPhase.tsx`)
- Karten kompakter:
  - `paddingVertical`: `Spacing.md` (16) → `Spacing.sm` (8)
  - `value` Fontgröße: `lg` (20) → `md` (16), `lineHeight` 26 → 22
  - `emoji`: 22 → 20

### 3. "Galerie geht mit jedem Update verloren"
Root cause: `StorageManager.getGallery()` und `getProgress()` haben bei `JSON.parse`-Fehler die gesamten Daten via `removeItem` gelöscht — _ein einziger transienter Fehler reicht für Total-Datenverlust._

- `getGallery()` / `getProgress()`: kein `removeItem` mehr bei Parse-Fehler. Rohdaten bleiben erhalten, damit eine spätere Version oder manuelle Recovery noch zugreifen kann.
- Neuer Type-Guard `isValidGalleryEntry` validiert **alle Pflichtfelder** (`id`, `levelNumber`, `imageFilename`, `imageName`, `paths`, `rating`, `savedAt`) — verhindert Crashes in der Galerie-UI bei malformierten Persisted-Entries (z.B. `'★'.repeat(entry.rating)` wenn `rating` kein number wäre).
- Malformierte Einträge werden gefiltert, der Rest bleibt erhalten.

## Test plan
- [x] Bestehende Tests an neues, nicht-destruktives Verhalten angepasst
- [x] Neue Tests: gemischtes valid/invalid Array wird sauber gefiltert; non-array Payload liefert `[]`
- [x] `npx jest` — alle Tests grün
- [x] `npx tsc --noEmit` — keine Fehler
- [x] `npm run lint` — sauber
- [x] `npm run validate:svg-counts` — OK
- [ ] **Manuell auf Gerät:** Home-Screen-Layout (Hero-CTA + Side-by-Side-Tiles) sieht gut aus, Stats-Karten passen ohne Truncation, Galerie überlebt App-Reload

## Copilot-Review-Suggestions
Alle drei Suggestions vom automatischen Reviewer adressiert (vollständige Type-Guard-Validierung, neue Filter-Tests, `minimumFontScale`).

https://claude.ai/code/session_013b2EevadfqUN9grokPKYBL