### PR TITLE
fix: Dark Mode auf allen Screens (game, levels, gallery, settings)

### DIFF
--- a/app/gallery.tsx
+++ b/app/gallery.tsx
@@ -138,18 +138,15 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     padding: Spacing.lg,
     borderBottomWidth: 1,
-    borderBottomColor: Colors.surface,
   },
   backButton: {
     fontSize: FontSize.md,
     fontWeight: FontWeight.semibold,
-    color: Colors.primary,
     minWidth: 80,
   },
   title: {
     fontSize: FontSize.lg,
     fontWeight: FontWeight.bold,
-    color: Colors.text.primary,
   },
   scrollContent: {
     padding: Spacing.md,
@@ -167,7 +164,6 @@ const styles = StyleSheet.create({
   },
   emptyText: {
     fontSize: FontSize.md,
-    color: Colors.text.secondary,
     textAlign: 'center',
     paddingHorizontal: Spacing.xl,
   },
@@ -196,16 +192,13 @@ const styles = StyleSheet.create({
   cardTitle: {
     fontSize: FontSize.sm,
     fontWeight: FontWeight.semibold,
-    color: Colors.text.primary,
   },
   cardMeta: {
     fontSize: FontSize.xs,
-    color: Colors.text.secondary,
     marginTop: 2,
   },
   cardDate: {
     fontSize: FontSize.xs,
-    color: Colors.text.light,
     marginTop: 2,
   },
   deleteButton: {

--- a/app/gallery.tsx
+++ b/app/gallery.tsx
@@ -60,7 +60,7 @@ export default function GalleryScreen() {
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       {/* Header */}
-      <View style={styles.header}>
+      <View style={[styles.header, { borderBottomColor: colors.border }]}>
         <TouchableOpacity onPress={() => router.back()}>
           <Text style={[styles.backButton, { color: colors.primary }]}>
             ← {t('common.back')}

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -212,7 +212,7 @@ export default function GameScreen() {
         onRequestClose={() => setShowHintModal(false)}
       >
         <TouchableOpacity
-          style={styles.modalOverlay}
+          style={[styles.modalOverlay, { backgroundColor: colors.modalOverlay }]}
           activeOpacity={1}
           onPress={() => setShowHintModal(false)}
           accessibilityRole="button"
@@ -384,7 +384,6 @@ const styles = StyleSheet.create({
   },
   modalOverlay: {
     flex: 1,
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
     justifyContent: 'center',
     alignItems: 'center',
     padding: Spacing.lg,

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -145,7 +145,7 @@ export default function GameScreen() {
   const levelName = currentLang === 'en' ? currentImage?.displayNameEn : currentImage?.displayName;
 
   return (
-    <View style={[styles.container, { paddingBottom: insets.bottom }]}>
+    <View style={[styles.container, { paddingBottom: insets.bottom, backgroundColor: colors.background }]}>
       {/* Header */}
       <View style={[styles.header, { paddingTop: insets.top + 8, paddingHorizontal: layout.headerPaddingHorizontal, paddingBottom: Spacing.sm }]}>
         <TouchableOpacity
@@ -154,7 +154,7 @@ export default function GameScreen() {
           accessibilityRole="button"
           accessibilityLabel={t('common.back')}
         >
-          <Text style={styles.headerTitle}>Level {levelNumber}{levelName ? ` · ${levelName}` : ''}</Text>
+          <Text style={[styles.headerTitle, { color: colors.text.primary }]}>Level {levelNumber}{levelName ? ` · ${levelName}` : ''}</Text>
         </TouchableOpacity>
         <View style={styles.headerRight}>
           <View style={styles.progressDots}>
@@ -175,27 +175,27 @@ export default function GameScreen() {
             accessibilityLabel={t('common.settings')}
             accessibilityRole="button"
           >
-            <Text style={styles.settingsIcon}>⋮</Text>
+            <Text style={[styles.settingsIcon, { color: colors.text.primary }]}>⋮</Text>
           </TouchableOpacity>
         </View>
       </View>
 
       {/* Pill-Tabs: Zeichnen / Ergebnis */}
       {FeatureFlags.ENABLE_GAME_PHASE_TABS && (phase === 'draw' || phase === 'result') && (
-        <View style={styles.tabBar}>
+        <View style={[styles.tabBar, { backgroundColor: colors.surfaceAlt }]}>
           <TouchableOpacity
-            style={[styles.tab, phase === 'draw' && styles.tabActive]}
+            style={[styles.tab, phase === 'draw' && [styles.tabActive, { backgroundColor: colors.surface }]]}
             onPress={() => phase === 'result' && setPhase('draw')}
             accessibilityRole="tab"
           >
-            <Text style={[styles.tabText, phase === 'draw' && styles.tabTextActive]}>✏️ {t('game.tabs.draw')}</Text>
+            <Text style={[styles.tabText, { color: colors.text.secondary }, phase === 'draw' && [styles.tabTextActive, { color: colors.text.primary }]]}>✏️ {t('game.tabs.draw')}</Text>
           </TouchableOpacity>
           <TouchableOpacity
-            style={[styles.tab, phase === 'result' && styles.tabActive]}
+            style={[styles.tab, phase === 'result' && [styles.tabActive, { backgroundColor: colors.surface }]]}
             onPress={() => phase === 'draw' && setPhase('result')}
             accessibilityRole="tab"
           >
-            <Text style={[styles.tabText, phase === 'result' && styles.tabTextActive]}>🎨 {t('game.tabs.result')}</Text>
+            <Text style={[styles.tabText, { color: colors.text.secondary }, phase === 'result' && [styles.tabTextActive, { color: colors.text.primary }]]}>🎨 {t('game.tabs.result')}</Text>
           </TouchableOpacity>
         </View>
       )}
@@ -218,11 +218,11 @@ export default function GameScreen() {
           accessibilityRole="button"
           accessibilityLabel={t('common.close')}
         >
-          <View style={styles.hintModal}>
+          <View style={[styles.hintModal, { backgroundColor: colors.background }]}>
             <View style={styles.hintModalHeader}>
-              <Text style={styles.hintModalTitle}>{t('game.draw.hintModalTitle')}</Text>
+              <Text style={[styles.hintModalTitle, { color: colors.text.primary }]}>{t('game.draw.hintModalTitle')}</Text>
               <TouchableOpacity onPress={() => setShowHintModal(false)} style={styles.closeButton}>
-                <Text style={styles.closeText}>✕</Text>
+                <Text style={[styles.closeText, { color: colors.text.secondary }]}>✕</Text>
               </TouchableOpacity>
             </View>
             {currentImage && (
@@ -303,7 +303,6 @@ export default function GameScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: Colors.background,
   },
   header: {
     flexDirection: 'row',
@@ -317,7 +316,6 @@ const styles = StyleSheet.create({
   headerTitle: {
     fontSize: FontSize.xl,
     fontWeight: FontWeight.bold,
-    color: Colors.text.primary,
     lineHeight: 26,
   },
   headerRight: {
@@ -353,7 +351,6 @@ const styles = StyleSheet.create({
     marginHorizontal: Spacing.lg,
     marginTop: Spacing.sm,
     marginBottom: Spacing.xs,
-    backgroundColor: Colors.surfaceAlt,
     borderRadius: BorderRadius.lg,
     padding: 4,
     gap: 0,
@@ -366,17 +363,14 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
   },
   tabActive: {
-    backgroundColor: Colors.surface,
     ...Colors.shadow.small,
   },
   tabText: {
     fontSize: FontSize.sm,
     fontWeight: FontWeight.semibold,
-    color: Colors.text.secondary,
   },
   tabTextActive: {
     fontWeight: FontWeight.bold,
-    color: Colors.text.primary,
   },
   settingsButton: {
     width: 44,
@@ -387,17 +381,15 @@ const styles = StyleSheet.create({
   },
   settingsIcon: {
     fontSize: 24,
-    color: Colors.text.primary,
   },
   modalOverlay: {
     flex: 1,
-    backgroundColor: Colors.modalOverlay,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
     justifyContent: 'center',
     alignItems: 'center',
     padding: Spacing.lg,
   },
   hintModal: {
-    backgroundColor: Colors.background,
     borderRadius: BorderRadius.xxl,
     padding: Spacing.lg,
     width: '90%',
@@ -416,7 +408,6 @@ const styles = StyleSheet.create({
   hintModalTitle: {
     fontSize: FontSize.lg,
     fontWeight: FontWeight.semibold,
-    color: Colors.text.primary,
   },
   closeButton: {
     width: 44,
@@ -426,6 +417,5 @@ const styles = StyleSheet.create({
   },
   closeText: {
     fontSize: 24,
-    color: Colors.text.secondary,
   },
 });

--- a/app/levels.tsx
+++ b/app/levels.tsx
@@ -126,26 +126,22 @@ export default function LevelsScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: Colors.background,
   },
   header: {
     paddingHorizontal: Spacing.lg,
     paddingTop: Spacing.xl,
     paddingBottom: Spacing.lg,
     borderBottomWidth: 1,
-    borderBottomColor: Colors.surface,
   },
   backButton: {
     fontSize: FontSize.md,
     fontFamily: FontFamily.semibold,
-    color: Colors.primary,
     marginBottom: Spacing.sm,
   },
   title: {
     fontSize: FontSize.xxl,
     fontWeight: FontWeight.bold,
     fontFamily: FontFamily.extraBold,
-    color: Colors.text.primary,
   },
   listContent: {
     padding: Spacing.lg,
@@ -166,7 +162,6 @@ const styles = StyleSheet.create({
   levelNumber: {
     fontSize: FontSize.xl,
     fontWeight: FontWeight.bold,
-    color: Colors.text.primary,
   },
   difficultyBadge: {
     marginBottom: Spacing.sm,

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -60,6 +60,5 @@ const styles = StyleSheet.create({
   },
   content: {
     flex: 1,
-    backgroundColor: Colors.background,
   },
 });

--- a/components/__tests__/GamePhaseComponents.test.tsx
+++ b/components/__tests__/GamePhaseComponents.test.tsx
@@ -9,6 +9,20 @@ jest.mock('../../services/i18n', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
+jest.mock('../../services/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#f7f2eb',
+      surface: '#ffffff',
+      surfaceAlt: '#ede7dd',
+      border: '#e8e0d5',
+      text: { primary: '#2c2c2c', secondary: '#9c8b7a', light: '#717171' },
+      primary: '#7C5CFF',
+    },
+    theme: 'light',
+  }),
+}));
+
 jest.mock('../../services/LevelManager', () => ({
   getTotalLevels: () => 10,
 }));

--- a/components/game/DrawPhase.tsx
+++ b/components/game/DrawPhase.tsx
@@ -7,6 +7,7 @@ import Colors from '../../constants/Colors';
 import { Spacing, FontSize, FontWeight, BorderRadius } from '../../constants/Layout';
 import type { DrawPhaseProps } from './game.shared';
 import { useTranslation } from '@services/i18n';
+import { useTheme } from '@services/ThemeContext';
 
 export default function DrawPhase({
   currentImage,
@@ -19,6 +20,7 @@ export default function DrawPhase({
   onDone,
 }: DrawPhaseProps) {
   const { t } = useTranslation();
+  const { colors } = useTheme();
 
   const levelName = currentLang === 'en' ? currentImage?.displayNameEn : currentImage?.displayName;
 
@@ -35,10 +37,10 @@ export default function DrawPhase({
   return (
     <View style={styles.phaseContainer}>
       {/* Info-Streifen: Aufgabe + Hint-Joker */}
-      <View style={styles.infoStrip}>
+      <View style={[styles.infoStrip, { backgroundColor: colors.surface, borderColor: colors.border }]}>
         <View style={styles.infoStripCenter}>
-          <Text style={styles.infoStripLabel}>{t('game.draw.referenceLabel')}</Text>
-          <Text style={styles.infoStripText} numberOfLines={2}>
+          <Text style={[styles.infoStripLabel, { color: colors.text.secondary }]}>{t('game.draw.referenceLabel')}</Text>
+          <Text style={[styles.infoStripText, { color: colors.text.primary }]} numberOfLines={2}>
             {t('game.draw.drawFromMemory')}{levelName ? ` — ${levelName}` : ''}
           </Text>
         </View>
@@ -73,7 +75,7 @@ export default function DrawPhase({
       </View>
 
       {/* Toolbar-Gruppe */}
-      <View style={[styles.toolbarGroup, dynToolbar]}>
+      <View style={[styles.toolbarGroup, dynToolbar, { backgroundColor: colors.surfaceAlt }]}>
         {/* Reihe 1: Inline-Farbreihe */}
         <FlatList
           data={DrawingColors}
@@ -105,7 +107,7 @@ export default function DrawPhase({
         {/* Reihe 2: Pen/Fill + Strichstärken */}
         <View style={styles.toolRow}>
           <TouchableOpacity
-            style={[styles.toolToggleButton, drawing.tool === 'brush' && styles.toolToggleButtonActive]}
+            style={[styles.toolToggleButton, { backgroundColor: colors.surface, borderColor: colors.border }, drawing.tool === 'brush' && styles.toolToggleButtonActive]}
             onPress={() => drawing.setTool('brush')}
             accessibilityLabel={t('game.draw.toolBrush')}
             accessibilityRole="button"
@@ -113,7 +115,7 @@ export default function DrawPhase({
             <Text style={styles.toolToggleIcon}>✏️</Text>
           </TouchableOpacity>
           <TouchableOpacity
-            style={[styles.toolToggleButton, drawing.tool === 'fill' && styles.toolToggleButtonActive]}
+            style={[styles.toolToggleButton, { backgroundColor: colors.surface, borderColor: colors.border }, drawing.tool === 'fill' && styles.toolToggleButtonActive]}
             onPress={() => drawing.setTool('fill')}
             accessibilityLabel={t('game.draw.toolFill')}
             accessibilityRole="button"
@@ -142,7 +144,7 @@ export default function DrawPhase({
                   height: size === 2 ? 10 : size === 3 ? 16 : 22,
                   backgroundColor: drawing.strokeWidth === size && drawing.tool !== 'fill'
                     ? drawing.color
-                    : Colors.text.secondary,
+                    : colors.text.secondary,
                 },
               ]} />
             </TouchableOpacity>
@@ -153,7 +155,7 @@ export default function DrawPhase({
       {/* Buttons */}
       <View style={styles.buttonRow}>
         <TouchableOpacity
-          style={styles.secondaryButton}
+          style={[styles.secondaryButton, { backgroundColor: colors.surface, borderColor: Colors.primary }]}
           onPress={drawing.undo}
           disabled={drawing.paths.length === 0}
           accessibilityLabel={t('game.draw.undo')}
@@ -167,7 +169,7 @@ export default function DrawPhase({
           >{t('game.draw.undo')}</Text>
         </TouchableOpacity>
         <TouchableOpacity
-          style={[styles.secondaryButton, drawing.paths.length === 0 && styles.buttonDisabled]}
+          style={[styles.secondaryButton, { backgroundColor: colors.surface, borderColor: Colors.primary }, drawing.paths.length === 0 && styles.buttonDisabled]}
           accessibilityLabel={t('game.draw.clear')}
           accessibilityRole="button"
           onPress={() => {
@@ -223,12 +225,10 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: Spacing.sm,
-    backgroundColor: Colors.surface,
     borderRadius: BorderRadius.xl,
     padding: Spacing.sm,
     marginBottom: Spacing.xs,
     borderWidth: 1,
-    borderColor: Colors.border,
     ...Colors.shadow.small,
   },
   infoStripCenter: {
@@ -237,7 +237,6 @@ const styles = StyleSheet.create({
   infoStripLabel: {
     fontSize: FontSize.xs,
     fontWeight: FontWeight.bold,
-    color: Colors.text.secondary,
     textTransform: 'uppercase',
     letterSpacing: 0.6,
     marginBottom: 2,
@@ -245,7 +244,6 @@ const styles = StyleSheet.create({
   infoStripText: {
     fontSize: FontSize.sm,
     fontWeight: FontWeight.bold,
-    color: Colors.text.primary,
   },
   hintButton: {
     width: 40,
@@ -270,7 +268,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   toolbarGroup: {
-    backgroundColor: Colors.surfaceAlt,
     borderRadius: BorderRadius.xl,
     padding: Spacing.sm,
     marginVertical: Spacing.sm,
@@ -287,7 +284,7 @@ const styles = StyleSheet.create({
     height: 32,
     borderRadius: BorderRadius.md,
     borderWidth: 2,
-    borderColor: Colors.border,
+    borderColor: '#e8e0d5',
     justifyContent: 'center',
     alignItems: 'center',
     overflow: 'hidden',
@@ -303,14 +300,14 @@ const styles = StyleSheet.create({
   inlineColorCheckmark: {
     fontSize: 16,
     fontWeight: FontWeight.bold,
-    color: Colors.text.primary,
-    textShadowColor: Colors.background,
+    color: '#2c2c2c',
+    textShadowColor: '#f7f2eb',
     textShadowOffset: { width: 0, height: 0 },
     textShadowRadius: 3,
   },
   toolbarDivider: {
     height: 1,
-    backgroundColor: Colors.border,
+    backgroundColor: '#e8e0d5',
     marginHorizontal: Spacing.xs,
   },
   toolRow: {
@@ -324,11 +321,9 @@ const styles = StyleSheet.create({
     width: 40,
     height: 40,
     borderRadius: BorderRadius.md,
-    backgroundColor: Colors.surface,
     alignItems: 'center',
     justifyContent: 'center',
     borderWidth: 2,
-    borderColor: Colors.border,
   },
   toolToggleButtonActive: {
     backgroundColor: Colors.primary,
@@ -344,7 +339,7 @@ const styles = StyleSheet.create({
   toolRowSeparator: {
     width: 1,
     height: 28,
-    backgroundColor: Colors.border,
+    backgroundColor: '#e8e0d5',
     marginHorizontal: Spacing.xs,
   },
   strokeCircleButton: {
@@ -381,13 +376,11 @@ const styles = StyleSheet.create({
   },
   secondaryButton: {
     flex: 1,
-    backgroundColor: Colors.surface,
     paddingVertical: Spacing.md,
     paddingHorizontal: Spacing.lg,
     borderRadius: BorderRadius.lg,
     alignItems: 'center',
     borderWidth: 2,
-    borderColor: Colors.primary,
     minHeight: 48,
     justifyContent: 'center',
     ...Colors.shadow.small,
@@ -399,7 +392,6 @@ const styles = StyleSheet.create({
   },
   buttonDisabled: {
     opacity: 0.4,
-    borderColor: Colors.text.light,
   },
   buttonTextSmall: {
     fontSize: FontSize.md,

--- a/components/game/DrawPhase.tsx
+++ b/components/game/DrawPhase.tsx
@@ -87,7 +87,7 @@ export default function DrawPhase({
             <TouchableOpacity
               style={[
                 styles.inlineColorSwatch,
-                item.border && { borderColor: item.border },
+                { borderColor: item.border ?? colors.border },
                 drawing.color === item.hex && styles.inlineColorSwatchActive,
               ]}
               onPress={() => drawing.setColor(item.hex)}
@@ -102,7 +102,7 @@ export default function DrawPhase({
           )}
         />
 
-        <View style={styles.toolbarDivider} />
+        <View style={[styles.toolbarDivider, { backgroundColor: colors.border }]} />
 
         {/* Reihe 2: Pen/Fill + Strichstärken */}
         <View style={styles.toolRow}>
@@ -123,7 +123,7 @@ export default function DrawPhase({
             <Text style={styles.toolToggleIcon}>🪣</Text>
           </TouchableOpacity>
 
-          <View style={styles.toolRowSeparator} />
+          <View style={[styles.toolRowSeparator, { backgroundColor: colors.border }]} />
 
           {([2, 3, 5] as const).map((size) => (
             <TouchableOpacity
@@ -284,7 +284,6 @@ const styles = StyleSheet.create({
     height: 32,
     borderRadius: BorderRadius.md,
     borderWidth: 2,
-    borderColor: '#e8e0d5',
     justifyContent: 'center',
     alignItems: 'center',
     overflow: 'hidden',
@@ -307,7 +306,6 @@ const styles = StyleSheet.create({
   },
   toolbarDivider: {
     height: 1,
-    backgroundColor: '#e8e0d5',
     marginHorizontal: Spacing.xs,
   },
   toolRow: {
@@ -339,7 +337,6 @@ const styles = StyleSheet.create({
   toolRowSeparator: {
     width: 1,
     height: 28,
-    backgroundColor: '#e8e0d5',
     marginHorizontal: Spacing.xs,
   },
   strokeCircleButton: {

--- a/components/game/MemorizePhase.tsx
+++ b/components/game/MemorizePhase.tsx
@@ -25,7 +25,7 @@ export default function MemorizePhase({
       <Text style={[styles.phaseTitle, { color: colors.text.primary }]}>{t('game.memorize.title')}</Text>
 
       <View style={styles.timerContainer}>
-        <Text style={[styles.timerText, { color: colors.background }]}>{t('game.memorize.timeLeft', { seconds: Math.max(0, Math.ceil(timeRemaining)) })}</Text>
+        <Text style={styles.timerText}>{t('game.memorize.timeLeft', { seconds: Math.max(0, Math.ceil(timeRemaining)) })}</Text>
       </View>
 
       <View style={styles.imageContainer}>
@@ -74,6 +74,7 @@ const styles = StyleSheet.create({
   timerText: {
     fontSize: FontSize.huge,
     fontWeight: FontWeight.bold,
+    color: '#ffffff',
   },
   imageContainer: {
     flex: 1,

--- a/components/game/MemorizePhase.tsx
+++ b/components/game/MemorizePhase.tsx
@@ -6,6 +6,7 @@ import Colors from '../../constants/Colors';
 import { Spacing, FontSize, FontWeight, BorderRadius } from '../../constants/Layout';
 import type { MemorizePhaseProps } from './game.shared';
 import { useTranslation } from '@services/i18n';
+import { useTheme } from '@services/ThemeContext';
 
 export default function MemorizePhase({
   timeRemaining,
@@ -17,25 +18,26 @@ export default function MemorizePhase({
   revealStep,
 }: MemorizePhaseProps) {
   const { t } = useTranslation();
+  const { colors } = useTheme();
 
   return (
     <View style={styles.phaseContainer}>
-      <Text style={styles.phaseTitle}>{t('game.memorize.title')}</Text>
+      <Text style={[styles.phaseTitle, { color: colors.text.primary }]}>{t('game.memorize.title')}</Text>
 
       <View style={styles.timerContainer}>
-        <Text style={styles.timerText}>{t('game.memorize.timeLeft', { seconds: Math.max(0, Math.ceil(timeRemaining)) })}</Text>
+        <Text style={[styles.timerText, { color: colors.background }]}>{t('game.memorize.timeLeft', { seconds: Math.max(0, Math.ceil(timeRemaining)) })}</Text>
       </View>
 
       <View style={styles.imageContainer}>
         {currentImage && (
-          <View style={[styles.imagePlaceholder, { minWidth: imagePlaceholderMinSize, minHeight: imagePlaceholderMinSize }]}>
+          <View style={[styles.imagePlaceholder, { minWidth: imagePlaceholderMinSize, minHeight: imagePlaceholderMinSize, backgroundColor: colors.surface }]}>
             <ErrorBoundary>
               <LevelImageDisplay image={currentImage} size={memorizeImageSize} revealStep={revealStep} />
             </ErrorBoundary>
-            <Text style={styles.imageName}>
+            <Text style={[styles.imageName, { color: colors.text.primary }]}>
               {currentLang === 'en' ? currentImage.displayNameEn : currentImage.displayName}
             </Text>
-            <Text style={styles.imageInfo}>
+            <Text style={[styles.imageInfo, { color: colors.text.secondary }]}>
               {t('game.memorize.imageInfo', { level: levelNumber, strokeCount: currentImage.strokeCount })}
             </Text>
           </View>
@@ -54,7 +56,6 @@ const styles = StyleSheet.create({
   phaseTitle: {
     fontSize: FontSize.lg,
     fontWeight: FontWeight.bold,
-    color: Colors.text.primary,
     marginTop: 0,
     marginBottom: Spacing.xs,
     textAlign: 'center',
@@ -73,7 +74,6 @@ const styles = StyleSheet.create({
   timerText: {
     fontSize: FontSize.huge,
     fontWeight: FontWeight.bold,
-    color: Colors.background,
   },
   imageContainer: {
     flex: 1,
@@ -81,7 +81,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   imagePlaceholder: {
-    backgroundColor: Colors.surface,
     padding: Spacing.lg,
     borderRadius: BorderRadius.xxl,
     alignItems: 'center',
@@ -91,11 +90,9 @@ const styles = StyleSheet.create({
   imageName: {
     fontSize: FontSize.lg,
     fontWeight: FontWeight.bold,
-    color: Colors.text.primary,
     marginBottom: Spacing.sm,
   },
   imageInfo: {
     fontSize: FontSize.sm,
-    color: Colors.text.secondary,
   },
 });

--- a/components/game/ResultPhase.tsx
+++ b/components/game/ResultPhase.tsx
@@ -8,6 +8,7 @@ import { Spacing, FontSize, FontWeight, BorderRadius } from '../../constants/Lay
 import { getTotalLevels } from '@services/LevelManager';
 import type { ResultPhaseProps } from './game.shared';
 import { useTranslation } from '@services/i18n';
+import { useTheme } from '@services/ThemeContext';
 
 export default function ResultPhase({
   currentImage,
@@ -27,6 +28,7 @@ export default function ResultPhase({
   onRestartFromLevel1,
 }: ResultPhaseProps) {
   const { t } = useTranslation();
+  const { colors } = useTheme();
   const isLastLevel = levelNumber >= getTotalLevels();
   const [showCompletionModal, setShowCompletionModal] = useState(false);
 
@@ -57,10 +59,10 @@ export default function ResultPhase({
         onRequestClose={() => setShowCompletionModal(false)}
       >
         <View style={styles.completionOverlay}>
-          <View style={styles.completionModalBox}>
+          <View style={[styles.completionModalBox, { backgroundColor: colors.surface }]}>
             <Text style={styles.completionEmoji}>🏆</Text>
-            <Text style={styles.completionTitle}>{t('game.result.allLevelsComplete')}</Text>
-            <Text style={styles.completionMessage}>{t('game.result.allLevelsCompleteMessage')}</Text>
+            <Text style={[styles.completionTitle, { color: colors.text.primary }]}>{t('game.result.allLevelsComplete')}</Text>
+            <Text style={[styles.completionMessage, { color: colors.text.secondary }]}>{t('game.result.allLevelsCompleteMessage')}</Text>
             <TouchableOpacity
               style={styles.completionButton}
               onPress={() => { setShowCompletionModal(false); onRestartFromLevel1(); }}
@@ -73,7 +75,7 @@ export default function ResultPhase({
               onPress={() => setShowCompletionModal(false)}
               accessibilityRole="button"
             >
-              <Text style={styles.completionCloseText}>{t('common.close')}</Text>
+              <Text style={[styles.completionCloseText, { color: colors.text.secondary }]}>{t('common.close')}</Text>
             </TouchableOpacity>
           </View>
         </View>
@@ -87,7 +89,7 @@ export default function ResultPhase({
       {/* 1. Side-by-side Vergleich */}
       <View style={styles.comparisonContainer}>
         {/* Vorlage */}
-        <View style={[styles.comparisonCard, { width: imageSize }]}>
+        <View style={[styles.comparisonCard, { width: imageSize, backgroundColor: colors.surface, borderColor: colors.border }]}>
           <View style={[styles.comparisonCardHeader, styles.comparisonCardHeaderTemplate]}>
             <Text style={[styles.comparisonCardLabel, { color: Colors.primary }]}>
               {t('game.result.template').toUpperCase()}
@@ -102,7 +104,7 @@ export default function ResultPhase({
 
         {/* Deine Zeichnung + kontextuelle Aktionen */}
         <View style={{ width: imageSize, gap: Spacing.xs }}>
-          <View style={[styles.comparisonCard, { width: imageSize }]}>
+          <View style={[styles.comparisonCard, { width: imageSize, backgroundColor: colors.surface, borderColor: colors.border }]}>
             <View style={[styles.comparisonCardHeader, styles.comparisonCardHeaderDrawing]}>
               <Text style={[styles.comparisonCardLabel, { color: Colors.secondary }]}>
                 {t('game.result.yourDrawing').toUpperCase()}
@@ -122,18 +124,18 @@ export default function ResultPhase({
           {/* Replay + Speichern direkt unter der eigenen Zeichnung */}
           <View style={styles.drawingActionRow}>
             <TouchableOpacity
-              style={styles.drawingActionButton}
+              style={[styles.drawingActionButton, { backgroundColor: colors.surface, borderColor: colors.border }]}
               onPress={isReplaying ? onStopReplay : onStartReplay}
               accessibilityRole="button"
             >
               <Text style={styles.drawingActionIcon}>{isReplaying ? '⏹' : '🎬'}</Text>
-              <Text style={styles.drawingActionLabel}>
+              <Text style={[styles.drawingActionLabel, { color: colors.text.secondary }]}>
                 {isReplaying ? t('game.result.replayStop') : t('game.result.replay')}
               </Text>
             </TouchableOpacity>
 
             <TouchableOpacity
-              style={[styles.drawingActionButton, savedToGallery && styles.drawingActionSaved]}
+              style={[styles.drawingActionButton, { backgroundColor: colors.surface, borderColor: colors.border }, savedToGallery && styles.drawingActionSaved]}
               onPress={onSaveToGallery}
               disabled={savedToGallery}
               accessibilityRole="button"
@@ -141,7 +143,7 @@ export default function ResultPhase({
               accessibilityState={{ disabled: savedToGallery }}
             >
               <Text style={styles.drawingActionIcon}>{savedToGallery ? '✓' : '🖼'}</Text>
-              <Text style={[styles.drawingActionLabel, savedToGallery && styles.drawingActionLabelSaved]}>
+              <Text style={[styles.drawingActionLabel, { color: colors.text.secondary }, savedToGallery && styles.drawingActionLabelSaved]}>
                 {savedToGallery ? t('gallery.saved') : t('gallery.save')}
               </Text>
             </TouchableOpacity>
@@ -150,8 +152,8 @@ export default function ResultPhase({
       </View>
 
       {/* 2. Sterne-Bewertung */}
-      <View style={[styles.starsContainer, isSmall && styles.starsContainerSmall]}>
-        <Text style={styles.starsTitle}>{t('game.result.howWell')}</Text>
+      <View style={[styles.starsContainer, { backgroundColor: colors.surface }, isSmall && styles.starsContainerSmall]}>
+        <Text style={[styles.starsTitle, { color: colors.text.primary }]}>{t('game.result.howWell')}</Text>
         <View style={styles.starsRow} testID="stars-container">
           {[1, 2, 3, 4, 5].map((star) => (
             <AnimatedStar
@@ -164,7 +166,7 @@ export default function ResultPhase({
           ))}
         </View>
         <AnimatedFeedback visible={userRating > 0}>
-          <Text style={styles.feedbackText}>{getFeedbackText(userRating)}</Text>
+          <Text style={[styles.feedbackText, { color: colors.text.secondary }]}>{getFeedbackText(userRating)}</Text>
         </AnimatedFeedback>
       </View>
 
@@ -198,11 +200,9 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   comparisonCard: {
-    backgroundColor: Colors.surface,
     borderRadius: BorderRadius.xl,
     overflow: 'hidden',
     borderWidth: 1,
-    borderColor: Colors.border,
     ...Colors.shadow.medium,
   },
   comparisonCardHeader: {
@@ -229,7 +229,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   starsContainer: {
-    backgroundColor: Colors.surface,
     borderRadius: BorderRadius.xxl,
     padding: Spacing.lg,
     alignItems: 'center',
@@ -242,7 +241,6 @@ const styles = StyleSheet.create({
   starsTitle: {
     fontSize: FontSize.lg,
     fontWeight: FontWeight.bold,
-    color: Colors.text.primary,
     marginBottom: Spacing.md,
     textAlign: 'center',
   },
@@ -253,7 +251,6 @@ const styles = StyleSheet.create({
   },
   feedbackText: {
     fontSize: FontSize.md,
-    color: Colors.text.secondary,
     textAlign: 'center',
     paddingHorizontal: Spacing.lg,
   },
@@ -265,7 +262,6 @@ const styles = StyleSheet.create({
     padding: Spacing.lg,
   },
   completionModalBox: {
-    backgroundColor: Colors.surface,
     borderRadius: BorderRadius.xxl,
     padding: Spacing.xl,
     alignItems: 'center',
@@ -280,12 +276,10 @@ const styles = StyleSheet.create({
   completionTitle: {
     fontSize: FontSize.xl,
     fontWeight: FontWeight.bold,
-    color: Colors.text.primary,
     textAlign: 'center',
   },
   completionMessage: {
     fontSize: FontSize.md,
-    color: Colors.text.secondary,
     textAlign: 'center',
     lineHeight: 22,
   },
@@ -298,7 +292,7 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   completionButtonText: {
-    color: Colors.background,
+    color: '#ffffff',
     fontSize: FontSize.md,
     fontWeight: FontWeight.bold,
   },
@@ -307,7 +301,6 @@ const styles = StyleSheet.create({
   },
   completionCloseText: {
     fontSize: FontSize.sm,
-    color: Colors.text.secondary,
   },
   drawingActionRow: {
     flexDirection: 'row',
@@ -315,12 +308,10 @@ const styles = StyleSheet.create({
   },
   drawingActionButton: {
     flex: 1,
-    backgroundColor: Colors.surface,
     paddingVertical: Spacing.xs,
     borderRadius: BorderRadius.md,
     alignItems: 'center',
     borderWidth: 1.5,
-    borderColor: Colors.border,
     minHeight: 44,
     justifyContent: 'center',
     gap: 2,
@@ -337,7 +328,6 @@ const styles = StyleSheet.create({
   drawingActionLabel: {
     fontSize: FontSize.xs,
     fontWeight: FontWeight.semibold,
-    color: Colors.text.secondary,
     textAlign: 'center',
   },
   drawingActionLabelSaved: {
@@ -356,7 +346,7 @@ const styles = StyleSheet.create({
     ...Colors.shadow.medium,
   },
   nextLevelButtonText: {
-    color: Colors.background,
+    color: '#ffffff',
     fontSize: FontSize.md,
     fontWeight: FontWeight.bold,
   },


### PR DESCRIPTION
## Problem
Dark Mode hat nur auf dem Home Screen funktioniert. Alle anderen Screens und Game-Phasen-Komponenten nutzten statische `Colors.*`-Werte in `StyleSheet.create()` — die kennen keinen Theme-Wechsel.

## Ursache
`StyleSheet.create()` wird einmal beim Modul-Load ausgeführt. Statische Werte wie `Colors.background` oder `Colors.text.primary` sind Light-Mode-Konstanten und reagieren nicht auf `useTheme()`.

## Fix
In allen betroffenen Dateien:
- `useTheme()` importiert und `colors` destrukturiert
- Alle theme-sensitiven Werte (`background`, `surface`, `surfaceAlt`, `border`, `text.*`) als Inline-Styles übergeben
- StyleSheet-Definitionen von statischen Farbwerten bereinigt

**Betroffene Dateien:**
- `components/game/MemorizePhase.tsx`
- `components/game/DrawPhase.tsx`
- `components/game/ResultPhase.tsx`
- `app/game.tsx`
- `app/levels.tsx`
- `app/gallery.tsx`
- `app/settings.tsx`
- `components/__tests__/GamePhaseComponents.test.tsx` — ThemeContext-Mock ergänzt

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run test:ci` — 362/362 Tests grün
- [ ] Manuell: Dark Mode in Settings aktivieren → alle Screens prüfen

🤖 Generated with [Claude Code](https://claude.com/claude-code)