### PR TITLE
feat: In-App-Review-Prompt per Feature-Flag deaktivierbar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,6 +294,20 @@ Colors.glass.darkShadow    // { boxShadow, elevation } — dunkel
 
 ---
 
+## Feature Flags (Env-Vars)
+
+Alle `EXPO_PUBLIC_*`-Flags sind zur Build-Zeit eingefroren (Expo bündelt sie statisch).
+
+| Env-Var | Default | Bedeutung |
+|---|---|---|
+| `EXPO_PUBLIC_SENTRY_DSN` | — | Sentry-Reporting aktivieren (leer = no-op) |
+| `EXPO_PUBLIC_ENABLE_IN_APP_REVIEW` | `false` | In-App-Review-Prompt via `expo-store-review` — **deaktiviert bis Play-Store-Listing auditiert** (Issue #219 P0) |
+
+> **Aktivieren:** In `.env` oder EAS-Build-Profil `EXPO_PUBLIC_ENABLE_IN_APP_REVIEW=true` setzen.  
+> Der Flag wird in `services/ReviewManager.ts` ausgewertet; kein Code-Change nötig.
+
+---
+
 ## Konventionen für AI-Assistenten
 
 ### Verboten (wird von CI geprüft)
@@ -337,7 +351,7 @@ Ausgangspunkt: `staging` @ v1.6.3 / versionCode 65.
 |---|---|
 | Galerie-Persistenz (#215) | ✅ erledigt (v1.6.3) |
 | Play-Store-Listing-Audit | ⏭ extern — teilweise umgesetzt |
-| **In-App-Review-Prompt** (`expo-store-review`) | ✅ PR #223 merged in staging |
+| **In-App-Review-Prompt** (`expo-store-review`) | ✅ PR #223 merged in staging — per Feature-Flag deaktiviert (`EXPO_PUBLIC_ENABLE_IN_APP_REVIEW`) |
 | Analytics-Setup (COPPA-konform) | 🔲 offen — Tool-Entscheidung nötig |
 | Crash-Rate-Baseline (Sentry) | 🔲 offen — manuell |
 

--- a/services/ReviewManager.ts
+++ b/services/ReviewManager.ts
@@ -3,10 +3,16 @@
  *
  * Trigger: 5-Sterne-Bewertung ODER 3. abgeschlossene Daily Challenge
  * Guard:   max. 1× alle 90 Tage; kein Web-Support (native only)
+ *
+ * Feature-Flag: EXPO_PUBLIC_ENABLE_IN_APP_REVIEW=true aktiviert den Dialog.
+ * Standardmäßig deaktiviert — erst aktivieren, wenn Play-Store-Listing auditiert.
  */
 
 import { Platform } from 'react-native';
 import storageManager from './StorageManager';
+
+// Deactivated until Play Store listing is audited (Issue #219 P0)
+const ENABLE_IN_APP_REVIEW = process.env.EXPO_PUBLIC_ENABLE_IN_APP_REVIEW === 'true';
 
 const REVIEW_COOLDOWN_DAYS = 90;
 
@@ -40,6 +46,7 @@ export async function requestReviewIfEligible(
   hasFiveStar: boolean,
   isDailyChallenge: boolean
 ): Promise<void> {
+  if (!ENABLE_IN_APP_REVIEW) return;
   if (Platform.OS === 'web') return;
 
   let shouldTrigger = hasFiveStar;

--- a/services/ReviewManager.ts
+++ b/services/ReviewManager.ts
@@ -11,8 +11,10 @@
 import { Platform } from 'react-native';
 import storageManager from './StorageManager';
 
-// Deactivated until Play Store listing is audited (Issue #219 P0)
-const ENABLE_IN_APP_REVIEW = process.env.EXPO_PUBLIC_ENABLE_IN_APP_REVIEW === 'true';
+// Deactivated until Play Store listing is audited (Issue #219 P0).
+// Read at call-time so Jest tests can control the flag via process.env.
+// Metro inlines this to a literal in production builds — no runtime overhead.
+const isReviewEnabled = () => process.env.EXPO_PUBLIC_ENABLE_IN_APP_REVIEW === 'true';
 
 const REVIEW_COOLDOWN_DAYS = 90;
 
@@ -46,7 +48,7 @@ export async function requestReviewIfEligible(
   hasFiveStar: boolean,
   isDailyChallenge: boolean
 ): Promise<void> {
-  if (!ENABLE_IN_APP_REVIEW) return;
+  if (!isReviewEnabled()) return;
   if (Platform.OS === 'web') return;
 
   let shouldTrigger = hasFiveStar;

--- a/services/__tests__/ReviewManager.test.ts
+++ b/services/__tests__/ReviewManager.test.ts
@@ -41,11 +41,21 @@ const daysAgo = (days: number) =>
 describe('ReviewManager', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.EXPO_PUBLIC_ENABLE_IN_APP_REVIEW = 'true';
     (Platform as { OS: string }).OS = 'android';
     sm.getReviewLastShown.mockResolvedValue(null);
     sm.setReviewLastShown.mockResolvedValue(undefined);
     sm.incrementReviewDailyCount.mockResolvedValue(1);
     sm.resetReviewDailyCount.mockResolvedValue(undefined);
+  });
+
+  describe('feature flag', () => {
+    it('tut nichts wenn EXPO_PUBLIC_ENABLE_IN_APP_REVIEW nicht gesetzt', async () => {
+      delete process.env.EXPO_PUBLIC_ENABLE_IN_APP_REVIEW;
+      await requestReviewIfEligible(true, false);
+      expect(sm.getReviewLastShown).not.toHaveBeenCalled();
+      expect(sm.setReviewLastShown).not.toHaveBeenCalled();
+    });
   });
 
   describe('web platform guard', () => {


### PR DESCRIPTION
## Summary

- `EXPO_PUBLIC_ENABLE_IN_APP_REVIEW=true` aktiviert den nativen Review-Dialog (Standard: `false` → deaktiviert)
- Guard in `services/ReviewManager.ts`: früher Return wenn Flag nicht gesetzt
- CLAUDE.md: neue Feature-Flags-Tabelle + Roadmap-Eintrag für In-App-Review aktualisiert

## Hintergrund

Der In-App-Review-Prompt (PR #223) ist technisch fertig, soll aber erst aktiviert werden, wenn das Play-Store-Listing vollständig auditiert ist (Issue #219 P0). Das Feature-Flag erlaubt es, die Funktion im Build zu haben, ohne sie für Nutzer auszulösen.

## Aktivieren

In `.env` oder EAS-Build-Profil:
```
EXPO_PUBLIC_ENABLE_IN_APP_REVIEW=true
```

## Test plan

- [ ] Review-Prompt wird **nicht** ausgelöst (Standard, kein Flag gesetzt)
- [ ] Review-Prompt wird ausgelöst wenn `EXPO_PUBLIC_ENABLE_IN_APP_REVIEW=true` gesetzt
- [ ] Bestehende ReviewManager-Tests bleiben grün
- [ ] CI grün

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBVbLUxxhPQo56FgeUjhiJ)_