### PR TITLE
fix: Dark als Default-Theme, Auge-Button 1x-Label, macOS Build-Symlink-Fix

### DIFF
--- a/__tests__/StorageManager.test.ts
+++ b/__tests__/StorageManager.test.ts
@@ -200,7 +200,7 @@ describe('StorageManager', () => {
       const settings = await storageManager.getSettings();
 
       expect(settings).toEqual({
-        theme: 'system',
+        theme: 'dark',
         language: 'de',
         soundEnabled: true,
         musicEnabled: false,

--- a/components/game/DrawPhase.tsx
+++ b/components/game/DrawPhase.tsx
@@ -56,7 +56,7 @@ export default function DrawPhase({
           accessibilityLabel={hasUsedHint ? t('game.draw.hintUsed') : t('game.draw.hintButton')}
           accessibilityRole="button"
         >
-          <Text style={styles.hintButtonIcon}>👁</Text>
+          <Text style={styles.hintButtonIcon}>{hasUsedHint ? '👁' : t('game.draw.hintButton')}</Text>
         </TouchableOpacity>
       </View>
 
@@ -246,8 +246,9 @@ const styles = StyleSheet.create({
     fontWeight: FontWeight.bold,
   },
   hintButton: {
-    width: 40,
+    minWidth: 52,
     height: 40,
+    paddingHorizontal: Spacing.sm,
     borderRadius: BorderRadius.md,
     backgroundColor: Colors.primary,
     flexShrink: 0,
@@ -260,7 +261,9 @@ const styles = StyleSheet.create({
     opacity: 0.5,
   },
   hintButtonIcon: {
-    fontSize: 20,
+    fontSize: 16,
+    fontWeight: FontWeight.bold,
+    color: '#FFFFFF',
   },
   canvasContainer: {
     flex: 1,

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -49,6 +49,12 @@ fi
 # Output-Verzeichnis anlegen
 mkdir -p build
 
+# macOS /tmp ist ein Symlink → /private/tmp; CMake/Ninja vermischen logische und physische
+# Pfade, was zu "missing libworklets.so"-Fehlern führt. EAS_LOCAL_BUILD_WORKINGDIR auf einen
+# echten Pfad zeigen vermeidet das. (Refs: expo/expo#42893)
+export EAS_LOCAL_BUILD_WORKINGDIR="$HOME/tmp/eas-build"
+mkdir -p "$EAS_LOCAL_BUILD_WORKINGDIR"
+
 # Sentry Source Map Upload deaktivieren (kein Sentry-Projekt lokal konfiguriert)
 # Sentry lädt Source Maps nur in CI hoch, wo SENTRY_DSN/Org gesetzt sind
 export SENTRY_DISABLE_AUTO_UPLOAD=true

--- a/services/StorageManager.ts
+++ b/services/StorageManager.ts
@@ -275,7 +275,7 @@ class StorageManager {
       };
 
       return {
-        theme: (theme as 'light' | 'dark' | 'system') || 'system',
+        theme: (theme as 'light' | 'dark' | 'system') || 'dark',
         language: (language as 'de' | 'en') || 'de',
         soundEnabled: parseSafely(sound, true),
         musicEnabled: parseSafely(music, false),
@@ -287,7 +287,7 @@ class StorageManager {
 
     // Return defaults
     return {
-      theme: 'system',
+      theme: 'dark',
       language: 'de',
       soundEnabled: true,
       musicEnabled: false,

--- a/services/ThemeContext.tsx
+++ b/services/ThemeContext.tsx
@@ -189,7 +189,7 @@ interface ThemeProviderProps {
 }
 
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
-  const [themeSetting, setThemeSetting] = useState<Theme>('system');
+  const [themeSetting, setThemeSetting] = useState<Theme>('dark');
   // Always start with 'light' to ensure consistent SSR/client hydration
   const [systemTheme, setSystemTheme] = useState<'light' | 'dark'>('light');
 

--- a/services/__tests__/ThemeContext.test.tsx
+++ b/services/__tests__/ThemeContext.test.tsx
@@ -43,15 +43,15 @@ describe('ThemeContext', () => {
     spy.mockRestore();
   });
 
-  it('defaults to light theme', () => {
+  it('defaults to dark theme', () => {
     const { result } = renderHook(() => useTheme(), { wrapper });
-    expect(result.current.theme).toBe('light');
-    expect(result.current.themeSetting).toBe('system');
+    expect(result.current.theme).toBe('dark');
+    expect(result.current.themeSetting).toBe('dark');
   });
 
-  it('returns light colors for light theme', () => {
+  it('returns dark colors for dark theme (default)', () => {
     const { result } = renderHook(() => useTheme(), { wrapper });
-    expect(result.current.colors.background).toBe('#FAFAFA');
+    expect(result.current.colors.background).toBe('#1F1B2E');
   });
 
   it('uses dark theme when setting is dark', async () => {
@@ -93,8 +93,14 @@ describe('ThemeContext', () => {
     expect(result.current.theme).toBe('dark');
   });
 
-  it('responds to system appearance changes', async () => {
+  it('responds to system appearance changes when theme is set to system', async () => {
+    storageManager.getSetting.mockResolvedValue('system');
+    (Appearance.getColorScheme as jest.Mock).mockReturnValue('light');
     const { result } = renderHook(() => useTheme(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.themeSetting).toBe('system');
+    });
     expect(result.current.theme).toBe('light');
 
     // Simulate system theme change via the listener callback
@@ -121,15 +127,15 @@ describe('ThemeContext', () => {
     await waitFor(() => {
       expect(spy).toHaveBeenCalled();
     });
-    // Falls back to system/light
-    expect(result.current.theme).toBe('light');
+    // Falls back to initial default (dark)
+    expect(result.current.theme).toBe('dark');
     spy.mockRestore();
   });
 
   it('handles null colorScheme gracefully', () => {
     (Appearance.getColorScheme as jest.Mock).mockReturnValue(null);
     const { result } = renderHook(() => useTheme(), { wrapper });
-    // null defaults to 'light'
-    expect(result.current.theme).toBe('light');
+    // themeSetting defaults to 'dark', so null colorScheme doesn't affect the result
+    expect(result.current.theme).toBe('dark');
   });
 });


### PR DESCRIPTION
## Summary

- **Issue #228 — Dark als Default**: Theme-Default von `'system'` auf `'dark'` geändert in `ThemeContext.tsx` und `StorageManager.ts`. Neue Nutzer sehen sofort Dark Mode ohne Umweg über System-Einstellung.
- **Issue #228 — Auge-Button**: Hint-Button im Draw-Screen zeigt jetzt `👁 1x` solange er noch nicht benutzt wurde, nach Nutzung nur noch `👁` (deaktiviert). Die Translation-Keys `game.draw.hintButton = "👁 1x"` waren bereits vorhanden, wurden aber nicht gerendert.
- **Issue #227 — macOS Build-Symlink**: `scripts/build-local.sh` setzt `EAS_LOCAL_BUILD_WORKINGDIR=$HOME/tmp/eas-build` vor dem EAS-Aufruf. Behebt `libworklets.so`-Fehler durch `/tmp` → `/private/tmp` Symlink auf macOS.

## Test plan

- [ ] 373 Tests grün (`npm run test:ci`)
- [ ] Pre-commit-Hooks grün
- [ ] Neue App-Installation → Dark Mode aktiv
- [ ] Draw-Screen: Auge-Button zeigt `👁 1x`, nach Tippen deaktiviert (`👁` grau)
- [ ] Lokaler Android-Build auf macOS (`npm run build:android:local`) schlägt nicht mehr mit `libworklets.so` fehl

Closes #227, closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)