### PR TITLE
Sync staging → main: Standards-Audit-Listener + lokale Checks + Dark-Theme-Fix (Issue #7)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig – kanonische Basis für alle Projekte (Issue #7)
+# https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/standards-audit.yml
+++ b/.github/workflows/standards-audit.yml
@@ -1,0 +1,38 @@
+name: Standards Audit
+
+# Konsumiert die zentralen Reusable Workflows aus project-templates
+# (S540d/project-templates#7 – Cross-Project-Standardisierung).
+# Läuft bei:
+#   - PRs (Audits gaten Code-Änderungen)
+#   - weekly-self-audit Dispatch (von project-templates/weekly-audit.yml, Mo 08:00)
+#   - manuell (workflow_dispatch)
+#
+# Alle uses-Referenzen sind auf @v1 gepinnt (nie @main – S540d/project-templates#7, Punkt 1).
+
+on:
+  pull_request:
+    branches: [main, staging]
+  repository_dispatch:
+    types: [weekly-self-audit]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  security-scan:
+    uses: S540d/project-templates/.github/workflows/reusable-security-scan.yml@v1
+    with:
+      fail_on_findings: true
+
+  gitignore-audit:
+    uses: S540d/project-templates/.github/workflows/reusable-gitignore-audit.yml@v1
+    with:
+      fail_on_missing: true
+
+  # Rein informativ: der Audit-Step im Reusable Workflow ist intern non-blocking
+  # (läuft auch bei Abweichungen grün durch). Ein job-level continue-on-error ist
+  # auf uses:-Jobs nicht erlaubt – die Non-Blocking-Semantik muss daher im Template
+  # bleiben; security-scan und gitignore-audit (fail_on_*: true) gaten den Merge.
+  dev-standards-audit:
+    uses: S540d/project-templates/.github/workflows/reusable-dev-standards-audit.yml@v1

--- a/.github/workflows/standards-audit.yml
+++ b/.github/workflows/standards-audit.yml
@@ -11,7 +11,7 @@ name: Standards Audit
 
 on:
   pull_request:
-    branches: [main, staging]
+    branches: [main, testing]
   repository_dispatch:
     types: [weekly-self-audit]
   workflow_dispatch: {}

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ temp/
 
 expo-env.d.ts
 # @end expo-cli
+# Security – Pflicht-Einträge (Issue #7 / reusable-gitignore-audit)
+credentials.json
+*.p12
+*.p8

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -69,4 +69,23 @@ if git diff --cached | grep "^+" | grep -Eiq "keystorePassword[[:space:]]*=[[:sp
   exit 1
 fi
 
+# ============================================================================
+# GITIGNORE AUDIT: Pflicht-Einträge (spiegelt reusable-gitignore-audit.yml)
+# ============================================================================
+echo "Checking .gitignore for required entries..."
+GITIGNORE_PROBLEMS=0
+set -f
+REQUIRED_GITIGNORE_ENTRIES=".env .env.local credentials.json *.jks *.keystore *.p12 *.p8 docs/private/"
+for entry in $REQUIRED_GITIGNORE_ENTRIES; do
+  if ! grep -Fxq "$entry" .gitignore 2>/dev/null; then
+    echo "❌ ERROR: Missing required .gitignore entry: '$entry'"
+    GITIGNORE_PROBLEMS=1
+  fi
+done
+set +f
+if [ "$GITIGNORE_PROBLEMS" -ne 0 ]; then
+  echo "Add the missing entries to .gitignore before committing."
+  exit 1
+fi
+
 echo "✅ Pre-commit checks passed!"

--- a/__tests__/StorageManager.test.ts
+++ b/__tests__/StorageManager.test.ts
@@ -200,7 +200,7 @@ describe('StorageManager', () => {
       const settings = await storageManager.getSettings();
 
       expect(settings).toEqual({
-        theme: 'system',
+        theme: 'dark',
         language: 'de',
         soundEnabled: true,
         musicEnabled: false,

--- a/components/game/DrawPhase.tsx
+++ b/components/game/DrawPhase.tsx
@@ -56,7 +56,7 @@ export default function DrawPhase({
           accessibilityLabel={hasUsedHint ? t('game.draw.hintUsed') : t('game.draw.hintButton')}
           accessibilityRole="button"
         >
-          <Text style={styles.hintButtonIcon}>👁</Text>
+          <Text style={styles.hintButtonIcon}>{hasUsedHint ? '👁' : t('game.draw.hintButton')}</Text>
         </TouchableOpacity>
       </View>
 
@@ -246,8 +246,9 @@ const styles = StyleSheet.create({
     fontWeight: FontWeight.bold,
   },
   hintButton: {
-    width: 40,
+    minWidth: 52,
     height: 40,
+    paddingHorizontal: Spacing.sm,
     borderRadius: BorderRadius.md,
     backgroundColor: Colors.primary,
     flexShrink: 0,
@@ -260,7 +261,9 @@ const styles = StyleSheet.create({
     opacity: 0.5,
   },
   hintButtonIcon: {
-    fontSize: 20,
+    fontSize: 16,
+    fontWeight: FontWeight.bold,
+    color: '#FFFFFF',
   },
   canvasContainer: {
     flex: 1,

--- a/components/game/DrawPhase.tsx
+++ b/components/game/DrawPhase.tsx
@@ -56,7 +56,7 @@ export default function DrawPhase({
           accessibilityLabel={hasUsedHint ? t('game.draw.hintUsed') : t('game.draw.hintButton')}
           accessibilityRole="button"
         >
-          <Text style={styles.hintButtonIcon}>{hasUsedHint ? '👁' : t('game.draw.hintButton')}</Text>
+          <Text style={[styles.hintButtonIcon, hasUsedHint && styles.hintButtonIconUsed]}>{hasUsedHint ? '👁' : t('game.draw.hintButton')}</Text>
         </TouchableOpacity>
       </View>
 
@@ -264,6 +264,9 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: FontWeight.bold,
     color: '#FFFFFF',
+  },
+  hintButtonIconUsed: {
+    color: Colors.text.secondary,
   },
   canvasContainer: {
     flex: 1,

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -49,6 +49,12 @@ fi
 # Output-Verzeichnis anlegen
 mkdir -p build
 
+# macOS /tmp ist ein Symlink → /private/tmp; CMake/Ninja vermischen logische und physische
+# Pfade, was zu "missing libworklets.so"-Fehlern führt. EAS_LOCAL_BUILD_WORKINGDIR auf einen
+# echten Pfad zeigen vermeidet das. (Refs: expo/expo#42893)
+export EAS_LOCAL_BUILD_WORKINGDIR="$HOME/tmp/eas-build"
+mkdir -p "$EAS_LOCAL_BUILD_WORKINGDIR"
+
 # Sentry Source Map Upload deaktivieren (kein Sentry-Projekt lokal konfiguriert)
 # Sentry lädt Source Maps nur in CI hoch, wo SENTRY_DSN/Org gesetzt sind
 export SENTRY_DISABLE_AUTO_UPLOAD=true

--- a/services/StorageManager.ts
+++ b/services/StorageManager.ts
@@ -275,7 +275,7 @@ class StorageManager {
       };
 
       return {
-        theme: (theme as 'light' | 'dark' | 'system') || 'system',
+        theme: (theme as 'light' | 'dark' | 'system') || 'dark',
         language: (language as 'de' | 'en') || 'de',
         soundEnabled: parseSafely(sound, true),
         musicEnabled: parseSafely(music, false),
@@ -287,7 +287,7 @@ class StorageManager {
 
     // Return defaults
     return {
-      theme: 'system',
+      theme: 'dark',
       language: 'de',
       soundEnabled: true,
       musicEnabled: false,

--- a/services/ThemeContext.tsx
+++ b/services/ThemeContext.tsx
@@ -189,7 +189,7 @@ interface ThemeProviderProps {
 }
 
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
-  const [themeSetting, setThemeSetting] = useState<Theme>('system');
+  const [themeSetting, setThemeSetting] = useState<Theme>('dark');
   // Always start with 'light' to ensure consistent SSR/client hydration
   const [systemTheme, setSystemTheme] = useState<'light' | 'dark'>('light');
 

--- a/services/__tests__/ThemeContext.test.tsx
+++ b/services/__tests__/ThemeContext.test.tsx
@@ -43,15 +43,15 @@ describe('ThemeContext', () => {
     spy.mockRestore();
   });
 
-  it('defaults to light theme', () => {
+  it('defaults to dark theme', () => {
     const { result } = renderHook(() => useTheme(), { wrapper });
-    expect(result.current.theme).toBe('light');
-    expect(result.current.themeSetting).toBe('system');
+    expect(result.current.theme).toBe('dark');
+    expect(result.current.themeSetting).toBe('dark');
   });
 
-  it('returns light colors for light theme', () => {
+  it('returns dark colors for dark theme (default)', () => {
     const { result } = renderHook(() => useTheme(), { wrapper });
-    expect(result.current.colors.background).toBe('#FAFAFA');
+    expect(result.current.colors.background).toBe('#1F1B2E');
   });
 
   it('uses dark theme when setting is dark', async () => {
@@ -93,8 +93,14 @@ describe('ThemeContext', () => {
     expect(result.current.theme).toBe('dark');
   });
 
-  it('responds to system appearance changes', async () => {
+  it('responds to system appearance changes when theme is set to system', async () => {
+    storageManager.getSetting.mockResolvedValue('system');
+    (Appearance.getColorScheme as jest.Mock).mockReturnValue('light');
     const { result } = renderHook(() => useTheme(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.themeSetting).toBe('system');
+    });
     expect(result.current.theme).toBe('light');
 
     // Simulate system theme change via the listener callback
@@ -121,15 +127,15 @@ describe('ThemeContext', () => {
     await waitFor(() => {
       expect(spy).toHaveBeenCalled();
     });
-    // Falls back to system/light
-    expect(result.current.theme).toBe('light');
+    // Falls back to initial default (dark)
+    expect(result.current.theme).toBe('dark');
     spy.mockRestore();
   });
 
   it('handles null colorScheme gracefully', () => {
     (Appearance.getColorScheme as jest.Mock).mockReturnValue(null);
     const { result } = renderHook(() => useTheme(), { wrapper });
-    // null defaults to 'light'
-    expect(result.current.theme).toBe('light');
+    // themeSetting defaults to 'dark', so null colorScheme doesn't affect the result
+    expect(result.current.theme).toBe('dark');
   });
 });


### PR DESCRIPTION
## Summary

- ci: Standards-Audit-Listener (project-templates#7) (#231)
- fix: Dark als Default-Theme, Auge-Button zeigt 1x, macOS-Build-Symlink-Fix (#230)
- ci: lokale Checks – gitignore-Audit, .editorconfig (#232)

## Ziel

Vorbereitung auf neue Branch-Strategie: `main` + `testing` only (kein `staging` mehr).
Nach Merge wird `testing`-Branch aus `main` angelegt und `staging` gelöscht.

## Test plan
- [ ] CI muss durchlaufen
- [ ] Keine Merge-Konflikte