### PR TITLE
ci(#16): Remove staging from workflow triggers (DrawFromMemory)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,9 +2,9 @@ name: CI/CD - Automated Quality Checks
 
 on:
   push:
-    branches: [main, staging]
+    branches: [main, testing]
   pull_request:
-    branches: [main, staging]
+    branches: [main, testing]
 
 # Security: Explicitly set minimal permissions
 permissions:


### PR DESCRIPTION
Part of project-templates#16 – new branch strategy: `main` + `testing` only.