### PR TITLE
ci: add automated PR review workflow via Anthropic API

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,22 @@
+name: PR Review (Claude)
+
+# Automatischer Code-Review via Anthropic API bei jedem PR.
+# Voraussetzung: ANTHROPIC_API_KEY als Repository- oder Org-Secret gesetzt.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  pr-review:
+    uses: S540d/project-templates/.github/workflows/reusable-pr-review.yml@v1
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    with:
+      language: 'de'
+      # model: 'claude-sonnet-4-6'            # tiefere Analyse (default)
+      # model: 'claude-haiku-4-5-20251001'    # schnell + günstig


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr-review.yml` that calls the reusable `reusable-pr-review.yml@v1` from project-templates
- Posts an automated Claude code review comment on every PR (opened, synchronize, reopened)
- Uses `ANTHROPIC_API_KEY` repository/org secret with model `claude-sonnet-4-6` (default)

## Part of
Issue S540d/project-templates#16 – PR-Review rollout to all repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)