### PR TITLE
Sync testing → main: PR-Review-Workflow + review-gate

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,9 +2,9 @@ name: CI/CD - Automated Quality Checks
 
 on:
   push:
-    branches: [main, staging]
+    branches: [main, testing]
   pull_request:
-    branches: [main, staging]
+    branches: [main, testing]
 
 # Security: Explicitly set minimal permissions
 permissions:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,22 @@
+name: PR Review (Claude)
+
+# Automatischer Code-Review via Anthropic API bei jedem PR.
+# Voraussetzung: ANTHROPIC_API_KEY als Repository- oder Org-Secret gesetzt.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  pr-review:
+    uses: S540d/project-templates/.github/workflows/reusable-pr-review.yml@v1
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    with:
+      language: 'de'
+      # model: 'claude-sonnet-4-6'            # tiefere Analyse (default)
+      # model: 'claude-haiku-4-5-20251001'    # schnell + günstig

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   pull-requests: write
   contents: read
+  statuses: write
 
 jobs:
   pr-review:

--- a/.github/workflows/review-gate-resolve.yml
+++ b/.github/workflows/review-gate-resolve.yml
@@ -1,0 +1,17 @@
+name: Review Gate Resolve
+
+# Setzt den Commit-Status "review-gate" je nachdem, ob das Quittierungs-Label
+# gesetzt ist. Reagiert auf labeled/unlabeled, damit das Gate sofort umspringt,
+# ohne neuen Commit. Siehe reusable-pr-review.yml (Gate-Erzeugung).
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+permissions:
+  statuses: write
+  pull-requests: read
+
+jobs:
+  resolve:
+    uses: S540d/project-templates/.github/workflows/reusable-review-gate-resolve.yml@v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,18 +138,15 @@ npm run validate                   # Vollständige Release-Validierung
 npm run deploy:ghpages             # Deployment auf GitHub Pages
 ```
 
-**Branch-Strategie:** Feature-Branches → PR → `staging` (Pre-Production, Sammelbranch) → `main` (Produktion bei Release).
-Die zwei Branches `main` und `staging` müssen immer existieren und dürfen nie gelöscht werden. Features werden in separaten Branches entwickelt und in `staging` gesammelt bis zu einem neuen Release.
+**Branch-Strategie:** `feature/issue-XXX → testing → main` (`staging` entfernt 2026-06-03, Issue #7).
 
-> **⚠️ REGEL FÜR AI-ASSISTENTEN:** Merges auf `main` sind VERBOTEN ohne explizite schriftliche Freigabe durch den Nutzer in der aktuellen Konversation. Das gilt auch für `staging → main`. Feature-PRs gehen immer gegen `staging`. `main` ist production — nur der Nutzer entscheidet, wann etwas dort landet.
-
-> **⚠️ REGEL FÜR AI-ASSISTENTEN:** Merges auf `main` sind VERBOTEN ohne explizite schriftliche Freigabe durch den Nutzer in der aktuellen Konversation. Das gilt auch für `staging → main`. Immer nach `testing → staging` stoppen und auf Freigabe warten. `main` ist production — nur der Nutzer entscheidet, wann etwas dort landet.
+> **⚠️ REGEL FÜR AI-ASSISTENTEN:** Merges auf `main` sind VERBOTEN ohne explizite schriftliche Freigabe durch den Nutzer in der aktuellen Konversation. Feature-PRs gehen immer gegen `testing`. `main` ist production — nur der Nutzer entscheidet, wann etwas dort landet.
 
 ---
 
 ## CI/CD (`.github/workflows/ci-cd.yml`)
 
-Läuft auf `push` und `pull_request` gegen `main` und `staging` (kein `testing`-Branch mehr).
+Läuft auf `push` und `pull_request` gegen `main` und `testing`.
 
 | Job | Name | Inhalt |
 |---|---|---|


### PR DESCRIPTION
## Was & Warum

Bringt den ausstehenden testing-Stand nach main, inkl.:
- automatischem Claude-PR-Review (`pr-review.yml`)
- neuem **review-gate** (Merge-Gate über Commit-Status, project-templates@v1)
- `review-gate-resolve.yml` (Label-Auflösung)

Löst das Problem ungelesener Review-Suggestions (vgl. EnergyPriceGermany #324).

## Gate-Verhalten
Findings → `review-gate` rot → Label `suggestions gelesen und verstanden` setzen → grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)