### PR TITLE
ci: pr-review.yml contents write→read

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   pull-requests: write
-  contents: write
+  contents: read
   statuses: write
 
 jobs:


### PR DESCRIPTION
## Was

`pr-review.yml`: `contents: write` → `contents: read` — der Review-Job pusht keine Commits mehr, write war zu weit gefasst.

## Warum

`feature/issue-31-track-claude-commands` hatte diesen Fix als einzige echte Änderung vs. testing. Branch wird nach Merge gelöscht.