### PR TITLE
docs: CLAUDE.md aktualisieren (Fahrzeuge v1, ShareService, 51 Bilder)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Spieler sehen ein Bild kurz, zeichnen es aus dem Gedächtnis, vergleichen das Er
 | Theming | ThemeContext (light / dark / system) |
 | Sound | Web Audio API (web) + `expo-haptics` (native) |
 | i18n | Custom `services/i18n.ts` (de/en), Locales in `locales/` |
-| Tests | Jest 29 + jest-expo ~55 (372+ Tests, jsdom-Environment) |
+| Tests | Jest 29 + jest-expo ~55 (373+ Tests, jsdom-Environment) |
 | CI | GitHub Actions (`.github/workflows/ci-cd.yml`) |
 | Build (Native) | EAS Build (`eas.json`) |
 | Crash Reporting | Sentry via `EXPO_PUBLIC_SENTRY_DSN` (optional, no-op on Web) |
@@ -75,6 +75,8 @@ services/
   ThemeContext.tsx            # ThemeProvider + useTheme Hook (light/dark/system)
   i18n.ts                    # Übersetzungs-Service (de/en) mit listener-basiertem Reload
   ReviewManager.ts           # In-App-Review-Trigger: 5-Sterne oder 3. Daily Challenge, 90-Tage-Cooldown — deaktiviert via EXPO_PUBLIC_ENABLE_IN_APP_REVIEW
+  ShareService.ts            # PNG-Export (Web): Off-Screen-Canvas → Web Share API / Download-Fallback
+  ShareService.native.ts     # PNG-Export (Native): Skia Surface → expo-file-system + expo-sharing
   useGamePhase.ts            # Spielphasen-Hook: memorize / draw / result + Replay
   useTimer.ts                # Timer-Hook (Countdown, pause/resume via phase)
 
@@ -174,7 +176,7 @@ memorize  →  draw  →  result
 3. **Result**: Sternbewertung (1–5), Replay-Animation, Speichern in Galerie möglich.
 
 Level-Anzahl: 20 (Difficulty 1–5). Alle Level haben 3 s Anzeigezeit.
-Bilderpool: `ImagePoolManager.ts` wählt zufällig nach Difficulty-Klasse aus. Aktuell **41 Bilder** (inkl. Tiere v1 Pack — 10 Tiere, PR #221).
+Bilderpool: `ImagePoolManager.ts` wählt zufällig nach Difficulty-Klasse aus. Aktuell **51 Bilder** (inkl. Tiere v1 Pack — 10 Tiere, PR #221 + Fahrzeuge v1 Pack — 10 Fahrzeuge, PR #254).
 
 ---
 
@@ -236,15 +238,15 @@ Gespeicherte Felder: `progress`, `theme`, `language`, `sound_enabled`, `music_en
 
 ## UI/UX Design System (Issue #176)
 
-Stand `staging`: Phase A + B abgeschlossen.
+Stand `testing`: Phase A + B abgeschlossen, Phase D (Konfetti + Jubel-Sound) teilweise umgesetzt.
 
 ### Phase-Übersicht
 | Phase | Status | Branch/PR |
 |---|---|---|
-| **A: Foundation** — Farbpalette, Dark Mode, Nunito-Font, Typografie | ✅ in `staging` | PR merged |
-| **B: Components** — Gradient-Buttons, Glassmorphism-Cards, Sterne-Animation | ✅ in `staging` | PR #178 merged |
+| **A: Foundation** — Farbpalette, Dark Mode, Nunito-Font, Typografie | ✅ in `testing` | PR merged |
+| **B: Components** — Gradient-Buttons, Glassmorphism-Cards, Sterne-Animation | ✅ in `testing` | PR #178 merged |
 | **C: Screens** — Timer-Visualisierung, Phase-Übergänge, Home-Refresh | 🔲 offen | — |
-| **D: Delight** — Lottie, Konfetti, Mikro-Sounds | 🔲 offen | — |
+| **D: Delight** — Lottie, Konfetti, Mikro-Sounds | 🔶 teilweise (Konfetti + Jubel-Sound in PR #253) | — |
 | **E: Onboarding** — First-Run-Tour | 🔲 offen | — |
 
 ### Neue Primitiven (Phase B)
@@ -341,7 +343,7 @@ Web-APIs über `utils/platform.ts` absichern (`safeWebAPI`, `isWeb`-Guard). Für
 ## Wachstums-Roadmap (Issue #219)
 
 Übergeordneter Plan, um aus der App eine dauerhaft wachsende Kids-App im Play Store zu machen.
-Stand: `main` @ v1.7.0 / versionCode 66. `staging` = `main` (keine offenen Features).
+Stand: `main` @ v1.7.0 / versionCode 66. `testing` hat Fahrzeuge v1 + PNG-Export (noch nicht in main).
 
 ### P0 — Foundation für Wachstum
 | Task | Status |
@@ -356,7 +358,8 @@ Stand: `main` @ v1.7.0 / versionCode 66. `staging` = `main` (keine offenen Featu
 | Task | Status |
 |---|---|
 | **Themen-Pack Tiere v1** (10 Bilder, #222) | ✅ in main (v1.7.0) |
-| Themen-Pack Fahrzeuge / Natur / Märchen | 🔲 offen |
+| **Themen-Pack Fahrzeuge v1** (10 Bilder, PR #254) | ✅ in testing |
+| Themen-Pack Natur / Märchen / weitere | 🔲 offen |
 | Avatar & Personalisierung | 🔲 offen |
 | XP- & Level-System | 🔲 offen |
 | Wöchentliche Challenge | 🔲 offen |
@@ -366,14 +369,14 @@ Stand: `main` @ v1.7.0 / versionCode 66. `staging` = `main` (keine offenen Featu
 |---|---|
 | Designed for Families Programm | 🔲 offen |
 | Weitere Sprachen (ES/FR/IT/NL/PL) | 🔲 offen |
-| Sharing-Feature (PNG-Export) | 🔲 offen |
+| **Sharing-Feature / PNG-Export** (ShareService, PR #255) | ✅ in testing |
 | Push-Notifications (opt-in) | 🔲 offen |
 
 ### Themen-Pack Architektur (ab PR #221)
 - `LevelImage.pack?: string` — optionaler Tag (z.B. `'tiere-v1'`)
 - Bilder ohne `minLevel` sind ab dem passenden Difficulty-Level verfügbar
 - Neue Packs: einfach neue Cases in `LevelImageDisplay.tsx` + Einträge in `ImagePoolManager.ts` + `IMAGE_ELEMENT_COUNTS`
-- Pflicht nach jedem neuen SVG: `npm run validate:svg-counts` (derzeit 41 Einträge)
+- Pflicht nach jedem neuen SVG: `npm run validate:svg-counts` (derzeit 51 Einträge)
 
 ---
 


### PR DESCRIPTION
Bringt CLAUDE.md auf den aktuellen Stand nach den PRs #253–#255.

- Bilderpool: 41 → **51 Bilder** (Fahrzeuge v1 Pack, PR #254)
- Services-Liste: `ShareService.ts` + `ShareService.native.ts` eingetragen
- Tests: 372+ → 373+
- Roadmap P1: Fahrzeuge v1 ✅ in testing
- Roadmap P2: Sharing-Feature ✅ in testing
- Design-System: Phase D teilweise erledigt (Konfetti PR #253)
- `staging`-Referenzen → `testing` (staging seit #7 entfernt)
- validate:svg-counts-Hinweis: 41 → 51 Einträge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EP6KLZDxuZYoAZe75pTXNG

---
_Generated by [Claude Code](https://claude.ai/code/session_01EP6KLZDxuZYoAZe75pTXNG)_