### PR TITLE
feat: Phase C+D visual polish — TimerArc, phase crossfade, 4★ confetti, animated stats counter

### DIFF
--- a/__mocks__/@shopify/react-native-skia.js
+++ b/__mocks__/@shopify/react-native-skia.js
@@ -31,6 +31,7 @@ module.exports = {
         moveTo: jest.fn(),
         lineTo: jest.fn(),
         close: jest.fn(),
+        addArc: jest.fn(),
       })),
     },
     Paint: jest.fn(() => ({

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Modal, Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useScreenLayout } from '@utils/useScreenLayout';
@@ -26,6 +26,15 @@ import storageManager from '@services/StorageManager';
 import MemorizePhase from '@components/game/MemorizePhase';
 import DrawPhase from '@components/game/DrawPhase';
 import ResultPhase from '@components/game/ResultPhase';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  runOnJS,
+} from 'react-native-reanimated';
+import { useReduceMotion } from '../utils/useReduceMotion';
+import type { GamePhase } from '../types';
+import type { ConfettiIntensity } from '@components/ConfettiBurst';
 
 export default function GameScreen() {
   const { t } = useTranslation();
@@ -35,14 +44,21 @@ export default function GameScreen() {
   const insets = useSafeAreaInsets();
   const layout = useScreenLayout();
   const { screenWidth, isSmall } = layout;
+  const reduceMotion = useReduceMotion();
   const [showSettings, setShowSettings] = useState(false);
   const [showHintModal, setShowHintModal] = useState(false);
   const [hasUsedHint, setHasUsedHint] = useState(false);
   const [showConfetti, setShowConfetti] = useState(false);
   const [celebrationEnabled, setCelebrationEnabled] = useState(true);
+  const [confettiIntensity, setConfettiIntensity] = useState<ConfettiIntensity>('full');
   const [unlockedBadge, setUnlockedBadge] = useState<AchievementDef | null>(null);
-  const lastCheckedRatingRef = React.useRef<number>(0);
+  const lastCheckedRatingRef = useRef<number>(0);
   const handleBadgeToastHide = useCallback(() => setUnlockedBadge(null), []);
+
+  // Phase crossfade
+  const [visiblePhase, setVisiblePhase] = useState<GamePhase>('memorize');
+  const phaseOpacity = useSharedValue(1);
+  const phaseAnimStyle = useAnimatedStyle(() => ({ opacity: phaseOpacity.value, flex: 1 }));
 
   const drawing = useDrawingCanvas();
   const currentLang = getLanguage();
@@ -62,6 +78,7 @@ export default function GameScreen() {
     levelNumber,
     currentImage,
     timeRemaining,
+    displayDuration,
     userRating,
     revealStep,
     savedToGallery,
@@ -80,6 +97,23 @@ export default function GameScreen() {
     clearCanvas: drawing.clearCanvas,
     isDailyChallenge,
   });
+
+  useEffect(() => {
+    if (phase === visiblePhase) return;
+
+    if (reduceMotion) {
+      setVisiblePhase(phase);
+      return;
+    }
+
+    phaseOpacity.value = withTiming(0, { duration: 150 }, (finished) => {
+      'worklet';
+      if (finished) {
+        runOnJS(setVisiblePhase)(phase);
+        phaseOpacity.value = withTiming(1, { duration: 250 });
+      }
+    });
+  }, [phase]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleRestartCurrentLevel = () => {
     setHasUsedHint(false);
@@ -110,9 +144,12 @@ export default function GameScreen() {
     lastCheckedRatingRef.current = userRating;
 
     if (userRating >= 4 && FeatureFlags.ENABLE_CONFETTI && celebrationEnabled) {
+      const intensity: ConfettiIntensity = userRating === 5 ? 'full' : 'light';
+      const clearAfter = userRating === 5 ? 2700 : 1700;
+      setConfettiIntensity(intensity);
       setShowConfetti(true);
       SoundManager.playCelebration();
-      const timer = setTimeout(() => setShowConfetti(false), 2700);
+      const timer = setTimeout(() => setShowConfetti(false), clearAfter);
       checkAchievements(userRating);
       return () => clearTimeout(timer);
     }
@@ -241,66 +278,74 @@ export default function GameScreen() {
         </TouchableOpacity>
       </Modal>
 
-      {/* Phase Content */}
-      {phase === 'memorize' && (
-        <MemorizePhase
-          timeRemaining={timeRemaining}
-          currentImage={currentImage}
-          levelNumber={levelNumber}
-          currentLang={currentLang}
-          memorizeImageSize={layout.memorizeImageSize}
-          imagePlaceholderMinSize={layout.imagePlaceholderMinSize}
-          revealStep={revealStep}
-        />
-      )}
-      {phase === 'draw' && (
-        <DrawPhase
-          currentImage={currentImage}
-          currentLang={currentLang}
-          hasUsedHint={hasUsedHint}
-          onUseHint={() => setHasUsedHint(true)}
-          onShowHintModal={() => setShowHintModal(true)}
-          drawing={drawing}
-          layout={{
-            canvasMaxHeight: layout.canvasMaxHeight,
-            canvasMinHeight: layout.canvasMinHeight,
-            canvasMarginVertical: layout.canvasMarginVertical,
-            toolbarMarginVertical: layout.toolbarMarginVertical,
-            buttonMinHeight: layout.buttonMinHeight,
-            buttonPaddingVertical: layout.buttonPaddingVertical,
-            isSmall,
-          }}
-          onDone={() => {
-            SoundManager.playPhaseTransition();
-            setPhase('result');
-          }}
-        />
-      )}
-      {phase === 'result' && (
-        <ResultPhase
-          currentImage={currentImage}
-          levelNumber={levelNumber}
-          currentLang={currentLang}
-          userRating={userRating}
-          savedToGallery={savedToGallery}
-          isReplaying={isReplaying}
-          replayPaths={replayPaths}
-          drawingPaths={drawing.paths}
-          screenWidth={screenWidth}
-          isSmall={isSmall}
-          onRatingSubmit={handleRatingSubmit}
-          onSaveToGallery={saveToGallery}
-          onStartReplay={startReplay}
-          onStopReplay={() => setIsReplaying(false)}
-          onNextLevel={handleStartNextLevel}
-          onRestartFromLevel1={handleRestartFromLevel1}
-        />
-      )}
+      {/* Phase Content — crossfade on transition */}
+      <Animated.View style={phaseAnimStyle}>
+        {visiblePhase === 'memorize' && (
+          <MemorizePhase
+            timeRemaining={timeRemaining}
+            totalTime={displayDuration}
+            currentImage={currentImage}
+            levelNumber={levelNumber}
+            currentLang={currentLang}
+            memorizeImageSize={layout.memorizeImageSize}
+            imagePlaceholderMinSize={layout.imagePlaceholderMinSize}
+            revealStep={revealStep}
+          />
+        )}
+        {visiblePhase === 'draw' && (
+          <DrawPhase
+            currentImage={currentImage}
+            currentLang={currentLang}
+            hasUsedHint={hasUsedHint}
+            onUseHint={() => setHasUsedHint(true)}
+            onShowHintModal={() => setShowHintModal(true)}
+            drawing={drawing}
+            layout={{
+              canvasMaxHeight: layout.canvasMaxHeight,
+              canvasMinHeight: layout.canvasMinHeight,
+              canvasMarginVertical: layout.canvasMarginVertical,
+              toolbarMarginVertical: layout.toolbarMarginVertical,
+              buttonMinHeight: layout.buttonMinHeight,
+              buttonPaddingVertical: layout.buttonPaddingVertical,
+              isSmall,
+            }}
+            onDone={() => {
+              SoundManager.playPhaseTransition();
+              setPhase('result');
+            }}
+          />
+        )}
+        {visiblePhase === 'result' && (
+          <ResultPhase
+            currentImage={currentImage}
+            levelNumber={levelNumber}
+            currentLang={currentLang}
+            userRating={userRating}
+            savedToGallery={savedToGallery}
+            isReplaying={isReplaying}
+            replayPaths={replayPaths}
+            drawingPaths={drawing.paths}
+            screenWidth={screenWidth}
+            isSmall={isSmall}
+            onRatingSubmit={handleRatingSubmit}
+            onSaveToGallery={saveToGallery}
+            onStartReplay={startReplay}
+            onStopReplay={() => setIsReplaying(false)}
+            onNextLevel={handleStartNextLevel}
+            onRestartFromLevel1={handleRestartFromLevel1}
+          />
+        )}
+      </Animated.View>
 
       {/* Delight overlays */}
       {phase === 'result' && (
         <View pointerEvents="none" style={StyleSheet.absoluteFill}>
-          <ConfettiBurst width={screenWidth} height={layout.canvasMaxHeight + 200} active={showConfetti} />
+          <ConfettiBurst
+            width={screenWidth}
+            height={layout.canvasMaxHeight + 200}
+            active={showConfetti}
+            intensity={confettiIntensity}
+          />
         </View>
       )}
       <BadgeUnlockToast achievement={unlockedBadge} onHide={handleBadgeToastHide} />

--- a/components/ConfettiBurst.native.tsx
+++ b/components/ConfettiBurst.native.tsx
@@ -12,6 +12,7 @@ import {
 import {
   buildParticles,
   CONFETTI_DURATION_MS,
+  CONFETTI_LIGHT_DURATION_MS,
   type ConfettiBurstProps,
   type ConfettiParticle,
 } from './ConfettiBurst.shared';
@@ -25,9 +26,10 @@ function Particle({ p, progress }: { p: ConfettiParticle; progress: { value: num
   return <Circle cx={cx} cy={cy} r={p.size / 2} color={p.color} opacity={opacity} />;
 }
 
-export function ConfettiBurst({ width, height, active }: ConfettiBurstProps) {
+export function ConfettiBurst({ width, height, active, intensity = 'full' }: ConfettiBurstProps) {
   const reduceMotion = useReduceMotion();
   const progress = useSharedValue(0);
+  const duration = intensity === 'light' ? CONFETTI_LIGHT_DURATION_MS : CONFETTI_DURATION_MS;
 
   useEffect(() => {
     if (!active || reduceMotion) {
@@ -37,11 +39,14 @@ export function ConfettiBurst({ width, height, active }: ConfettiBurstProps) {
     progress.value = 0;
     progress.value = withDelay(
       0,
-      withTiming(1, { duration: CONFETTI_DURATION_MS, easing: Easing.out(Easing.cubic) }),
+      withTiming(1, { duration, easing: Easing.out(Easing.cubic) }),
     );
-  }, [active, reduceMotion, progress]);
+  }, [active, reduceMotion, progress, duration]);
 
-  const particles = useMemo(() => buildParticles(width, height, Math.floor(width + height)), [width, height]);
+  const particles = useMemo(
+    () => buildParticles(width, height, Math.floor(width + height), intensity),
+    [width, height, intensity],
+  );
 
   if (!active || reduceMotion) return null;
 

--- a/components/ConfettiBurst.shared.ts
+++ b/components/ConfettiBurst.shared.ts
@@ -1,9 +1,12 @@
 import Colors from '../constants/Colors';
 
+export type ConfettiIntensity = 'full' | 'light';
+
 export interface ConfettiBurstProps {
   width: number;
   height: number;
   active: boolean;
+  intensity?: ConfettiIntensity;
 }
 
 export interface ConfettiParticle {
@@ -19,7 +22,9 @@ export interface ConfettiParticle {
 }
 
 export const CONFETTI_DURATION_MS = 2500;
+export const CONFETTI_LIGHT_DURATION_MS = 1500;
 export const CONFETTI_COUNT = 40;
+export const CONFETTI_LIGHT_COUNT = 20;
 
 const CONFETTI_COLORS = [
   Colors.gradient.cta[0],
@@ -29,19 +34,32 @@ const CONFETTI_COLORS = [
   Colors.gradient.teal[0],
 ];
 
-export function buildParticles(width: number, height: number, seed = 0): ConfettiParticle[] {
+const CONFETTI_LIGHT_COLORS = [
+  '#C8C8E8',
+  '#E8E8F8',
+  '#FFFFFF',
+  '#D4C8FF',
+  '#B8B4E0',
+];
+
+export function buildParticles(width: number, height: number, seed = 0, intensity: ConfettiIntensity = 'full'): ConfettiParticle[] {
   // simple deterministic PRNG so tests / SSR stay stable
   let s = seed || 1;
   const rand = () => {
     s = (s * 1664525 + 1013904223) % 0xffffffff;
     return s / 0xffffffff;
   };
-  return Array.from({ length: CONFETTI_COUNT }, () => ({
+  const count = intensity === 'light' ? CONFETTI_LIGHT_COUNT : CONFETTI_COUNT;
+  const colors = intensity === 'light' ? CONFETTI_LIGHT_COLORS : CONFETTI_COLORS;
+  const maxSize = intensity === 'light' ? 8 : 12;
+  const minSize = intensity === 'light' ? 4 : 6;
+
+  return Array.from({ length: count }, () => ({
     x: rand() * width,
     startY: -20 - rand() * 60,
     endY: height + 40,
-    color: CONFETTI_COLORS[Math.floor(rand() * CONFETTI_COLORS.length)],
-    size: 6 + rand() * 6,
+    color: colors[Math.floor(rand() * colors.length)],
+    size: minSize + rand() * (maxSize - minSize),
     drift: (rand() - 0.5) * 80,
     duration: 1800 + rand() * 700,
     delay: rand() * 400,

--- a/components/ConfettiBurst.tsx
+++ b/components/ConfettiBurst.tsx
@@ -1,3 +1,3 @@
 // Platform dispatcher — Metro/Webpack pick `.native.tsx` or `.web.tsx`.
 export { ConfettiBurst as default } from './ConfettiBurst.native';
-export type { ConfettiBurstProps } from './ConfettiBurst.shared';
+export type { ConfettiBurstProps, ConfettiIntensity } from './ConfettiBurst.shared';

--- a/components/ConfettiBurst.web.tsx
+++ b/components/ConfettiBurst.web.tsx
@@ -10,6 +10,7 @@ import Animated, {
 import {
   buildParticles,
   CONFETTI_DURATION_MS,
+  CONFETTI_LIGHT_DURATION_MS,
   type ConfettiBurstProps,
   type ConfettiParticle,
 } from './ConfettiBurst.shared';
@@ -32,9 +33,10 @@ function Particle({ p, progress }: { p: ConfettiParticle; progress: { value: num
   return <Animated.View style={style} />;
 }
 
-export function ConfettiBurst({ width, height, active }: ConfettiBurstProps) {
+export function ConfettiBurst({ width, height, active, intensity = 'full' }: ConfettiBurstProps) {
   const reduceMotion = useReduceMotion();
   const progress = useSharedValue(0);
+  const duration = intensity === 'light' ? CONFETTI_LIGHT_DURATION_MS : CONFETTI_DURATION_MS;
 
   useEffect(() => {
     if (!active || reduceMotion) {
@@ -43,12 +45,15 @@ export function ConfettiBurst({ width, height, active }: ConfettiBurstProps) {
     }
     progress.value = 0;
     progress.value = withTiming(1, {
-      duration: CONFETTI_DURATION_MS,
+      duration,
       easing: Easing.out(Easing.cubic),
     });
-  }, [active, reduceMotion, progress]);
+  }, [active, reduceMotion, progress, duration]);
 
-  const particles = useMemo(() => buildParticles(width, height, Math.floor(width + height)), [width, height]);
+  const particles = useMemo(
+    () => buildParticles(width, height, Math.floor(width + height), intensity),
+    [width, height, intensity],
+  );
 
   if (!active || reduceMotion) return null;
 

--- a/components/QuickStatsCards.tsx
+++ b/components/QuickStatsCards.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { View, Text, StyleSheet, useWindowDimensions } from 'react-native';
 import { useRouter, useFocusEffect } from 'expo-router';
 import { GlassCard } from '@components/AnimatedPrimitives';
 import { useTheme } from '@services/ThemeContext';
 import { useTranslation } from '@services/i18n';
+import { useReduceMotion } from '../utils/useReduceMotion';
 import storageManager from '@services/StorageManager';
 import { getStreakData } from '@services/StreakManager';
 import { getTotalLevels } from '@services/LevelManager';
@@ -16,12 +17,18 @@ interface Stats {
   levelsCompleted: number;
 }
 
+const ZERO_STATS: Stats = { totalStars: 0, currentStreak: 0, levelsCompleted: 0 };
+const COUNTER_DURATION_MS = 600;
+const COUNTER_STEPS = 20;
+
 export default function QuickStatsCards() {
   const { t } = useTranslation();
   const { theme, colors } = useTheme();
   const router = useRouter();
   const { width } = useWindowDimensions();
-  const [stats, setStats] = useState<Stats>({ totalStars: 0, currentStreak: 0, levelsCompleted: 0 });
+  const reduceMotion = useReduceMotion();
+  const [stats, setStats] = useState<Stats>(ZERO_STATS);
+  const [displayStats, setDisplayStats] = useState<Stats>(ZERO_STATS);
 
   const glassSurface = theme === 'dark' ? Colors.glass.darkSurface : Colors.glass.lightSurface;
   const glassBorder  = theme === 'dark' ? Colors.glass.darkBorder  : Colors.glass.lightBorder;
@@ -51,6 +58,38 @@ export default function QuickStatsCards() {
     }, [])
   );
 
+  // Animate displayed values from 0 to the loaded targets
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+
+    if (reduceMotion || (stats.totalStars === 0 && stats.currentStreak === 0 && stats.levelsCompleted === 0)) {
+      setDisplayStats(stats);
+      return;
+    }
+
+    setDisplayStats(ZERO_STATS);
+    let step = 0;
+    intervalRef.current = setInterval(() => {
+      step++;
+      const t = Math.min(1, step / COUNTER_STEPS);
+      setDisplayStats({
+        totalStars: Math.round(t * stats.totalStars),
+        currentStreak: Math.round(t * stats.currentStreak),
+        levelsCompleted: Math.round(t * stats.levelsCompleted),
+      });
+      if (step >= COUNTER_STEPS) {
+        if (intervalRef.current) clearInterval(intervalRef.current);
+        setDisplayStats(stats);
+      }
+    }, COUNTER_DURATION_MS / COUNTER_STEPS);
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [stats.totalStars, stats.currentStreak, stats.levelsCompleted, reduceMotion]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Below 340px: wrap into 2 rows; otherwise all 3 in one row
   const narrow = width < 340;
   const totalLevels = getTotalLevels();
@@ -66,7 +105,7 @@ export default function QuickStatsCards() {
     {
       emoji: '⭐',
       label: t('home.stats.stars'),
-      value: String(stats.totalStars),
+      value: String(displayStats.totalStars),
       sub: null,
       onPress: () => router.push('/gallery'),
       index: 0,
@@ -74,7 +113,7 @@ export default function QuickStatsCards() {
     {
       emoji: '🔥',
       label: t('home.stats.streak'),
-      value: String(stats.currentStreak),
+      value: String(displayStats.currentStreak),
       sub: stats.currentStreak > 0
         ? t(stats.currentStreak === 1 ? 'home.stats.streakDay' : 'home.stats.streakDays')
         : null,
@@ -84,7 +123,7 @@ export default function QuickStatsCards() {
     {
       emoji: '🏆',
       label: t('home.stats.levels'),
-      value: String(stats.levelsCompleted),
+      value: String(displayStats.levelsCompleted),
       sub: t('home.stats.levelOf', { total: String(totalLevels) }),
       onPress: () => router.push('/levels'),
       index: 2,

--- a/components/__tests__/ConfettiBurst.test.tsx
+++ b/components/__tests__/ConfettiBurst.test.tsx
@@ -1,9 +1,14 @@
-import { buildParticles, CONFETTI_COUNT } from '../ConfettiBurst.shared';
+import { buildParticles, CONFETTI_COUNT, CONFETTI_LIGHT_COUNT } from '../ConfettiBurst.shared';
 
 describe('ConfettiBurst.shared', () => {
-  it('builds the expected number of particles', () => {
+  it('builds the expected number of particles (full)', () => {
     const particles = buildParticles(300, 600, 42);
     expect(particles).toHaveLength(CONFETTI_COUNT);
+  });
+
+  it('builds reduced particle count for light intensity', () => {
+    const particles = buildParticles(300, 600, 42, 'light');
+    expect(particles).toHaveLength(CONFETTI_LIGHT_COUNT);
   });
 
   it('keeps particles roughly inside the canvas X range', () => {
@@ -27,5 +32,13 @@ describe('ConfettiBurst.shared', () => {
       expect(p.startY).toBeLessThan(0);
       expect(p.endY).toBeGreaterThan(600);
     });
+  });
+
+  it('light intensity produces smaller particles than full', () => {
+    const full = buildParticles(300, 600, 42, 'full');
+    const light = buildParticles(300, 600, 42, 'light');
+    const avgSizeFull = full.reduce((s, p) => s + p.size, 0) / full.length;
+    const avgSizeLight = light.reduce((s, p) => s + p.size, 0) / light.length;
+    expect(avgSizeLight).toBeLessThanOrEqual(avgSizeFull);
   });
 });

--- a/components/__tests__/GamePhaseComponents.test.tsx
+++ b/components/__tests__/GamePhaseComponents.test.tsx
@@ -85,6 +85,19 @@ jest.mock('../../components/AnimatedPrimitives', () => {
   };
 });
 
+jest.mock('../../components/game/TimerArc', () => {
+  const { View, Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ timeRemaining }: any) => (
+      <View testID="timer-arc-container"><Text testID="timer-arc">{String(Math.max(0, Math.ceil(timeRemaining)))}</Text></View>
+    ),
+    TimerArc: ({ timeRemaining }: any) => (
+      <View testID="timer-arc-container"><Text testID="timer-arc">{String(Math.max(0, Math.ceil(timeRemaining)))}</Text></View>
+    ),
+  };
+});
+
 // ─── MemorizePhase ────────────────────────────────────────────────────────────
 
 import MemorizePhase from '../../components/game/MemorizePhase';
@@ -108,6 +121,7 @@ const getAllTexts = (UNSAFE_getAllByType: any): any[] => {
 describe('MemorizePhase', () => {
   const baseProps = {
     timeRemaining: 5,
+    totalTime: 5,
     currentImage: null,
     levelNumber: 1,
     currentLang: 'en',
@@ -116,10 +130,10 @@ describe('MemorizePhase', () => {
     revealStep: 0,
   };
 
-  it('renders timer with i18n translation key', () => {
-    const { UNSAFE_getAllByType } = render(<MemorizePhase {...baseProps} timeRemaining={3} />);
+  it('renders timer arc countdown value', () => {
+    const { UNSAFE_getAllByType } = render(<MemorizePhase {...baseProps} timeRemaining={3} totalTime={5} />);
     const texts = getAllTexts(UNSAFE_getAllByType);
-    expect(texts).toContain('game.memorize.timeLeft');
+    expect(texts).toContain('3');
   });
 
   it('renders title translation key', () => {

--- a/components/__tests__/GameScreen.test.tsx
+++ b/components/__tests__/GameScreen.test.tsx
@@ -104,6 +104,35 @@ jest.mock('../../components/ConfettiBurst', () => {
   return { __esModule: true, default: () => <View testID="confetti-burst" /> };
 });
 
+jest.mock('../../components/game/TimerArc', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: () => <View testID="timer-arc" />,
+    TimerArc: () => <View testID="timer-arc" />,
+  };
+});
+
+jest.mock('react-native-reanimated', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: { View, createAnimatedComponent: (c: any) => c },
+    useSharedValue: (v: any) => ({ value: v }),
+    useAnimatedStyle: (_fn: any) => ({}),
+    withTiming: (_v: any, _config?: any, cb?: (finished: boolean) => void) => {
+      if (cb) cb(true);
+      return _v;
+    },
+    runOnJS: (fn: any) => fn,
+    Easing: { out: (fn: any) => fn, cubic: (t: number) => t, linear: (t: number) => t },
+  };
+});
+
+jest.mock('../../utils/useReduceMotion', () => ({
+  useReduceMotion: () => false,
+}));
+
 jest.mock('../../components/BadgeUnlockToast', () => {
   const { View } = require('react-native');
   return { __esModule: true, default: () => <View testID="badge-unlock-toast" /> };
@@ -134,6 +163,7 @@ jest.mock('../../services/useGamePhase', () => ({
     levelNumber: 1,
     currentImage: null,
     timeRemaining: 5,
+    displayDuration: 5,
     userRating: 0,
     revealStep: 0,
     savedToGallery: false,

--- a/components/__tests__/QuickStatsCards.test.tsx
+++ b/components/__tests__/QuickStatsCards.test.tsx
@@ -82,15 +82,23 @@ jest.mock('react-native-reanimated', () => {
   };
 });
 
+jest.mock('../../utils/useReduceMotion', () => ({
+  useReduceMotion: () => false,
+}));
+
 const getAllTexts = (getAllByType: (type: any) => any[]) =>
   getAllByType(Text).map((n: any) => n.props.children).flat();
 
 import QuickStatsCards from '../QuickStatsCards';
 
 describe('QuickStatsCards', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
   it('renders stat labels for stars, streak, and levels', async () => {
     const { UNSAFE_getAllByType } = render(<QuickStatsCards />);
     await act(async () => {});
+    act(() => { jest.advanceTimersByTime(700); });
     const texts = getAllTexts(UNSAFE_getAllByType);
     expect(texts).toContain('home.stats.stars');
     expect(texts).toContain('home.stats.streak');
@@ -100,6 +108,7 @@ describe('QuickStatsCards', () => {
   it('displays correct values after data load', async () => {
     const { UNSAFE_getAllByType } = render(<QuickStatsCards />);
     await act(async () => {});
+    act(() => { jest.advanceTimersByTime(700); });
     const texts = getAllTexts(UNSAFE_getAllByType);
     // Total stars: 4 + 3 = 7
     expect(texts).toContain('7');
@@ -112,6 +121,7 @@ describe('QuickStatsCards', () => {
   it('shows streak days label when streak > 0', async () => {
     const { UNSAFE_getAllByType } = render(<QuickStatsCards />);
     await act(async () => {});
+    act(() => { jest.advanceTimersByTime(700); });
     const texts = getAllTexts(UNSAFE_getAllByType);
     expect(texts).toContain('home.stats.streakDays');
   });
@@ -119,6 +129,7 @@ describe('QuickStatsCards', () => {
   it('shows level-of sub label for the levels card', async () => {
     const { UNSAFE_getAllByType } = render(<QuickStatsCards />);
     await act(async () => {});
+    act(() => { jest.advanceTimersByTime(700); });
     const texts = getAllTexts(UNSAFE_getAllByType);
     // t('home.stats.levelOf', { total: '10' }) → key unchanged since key has no {{total}} placeholder
     expect(texts).toContain('home.stats.levelOf');

--- a/components/game/MemorizePhase.tsx
+++ b/components/game/MemorizePhase.tsx
@@ -2,14 +2,16 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import LevelImageDisplay from '@components/LevelImageDisplay';
 import { ErrorBoundary } from '@components/ErrorBoundary';
-import Colors from '../../constants/Colors';
 import { Spacing, FontSize, FontWeight, BorderRadius } from '../../constants/Layout';
+import Colors from '../../constants/Colors';
 import type { MemorizePhaseProps } from './game.shared';
 import { useTranslation } from '@services/i18n';
 import { useTheme } from '@services/ThemeContext';
+import TimerArc from './TimerArc';
 
 export default function MemorizePhase({
   timeRemaining,
+  totalTime,
   currentImage,
   levelNumber,
   currentLang,
@@ -24,9 +26,7 @@ export default function MemorizePhase({
     <View style={styles.phaseContainer}>
       <Text style={[styles.phaseTitle, { color: colors.text.primary }]}>{t('game.memorize.title')}</Text>
 
-      <View style={styles.timerContainer}>
-        <Text style={styles.timerText}>{t('game.memorize.timeLeft', { seconds: Math.max(0, Math.ceil(timeRemaining)) })}</Text>
-      </View>
+      <TimerArc timeRemaining={timeRemaining} totalTime={totalTime} />
 
       <View style={styles.imageContainer}>
         {currentImage && (
@@ -59,22 +59,6 @@ const styles = StyleSheet.create({
     marginTop: 0,
     marginBottom: Spacing.xs,
     textAlign: 'center',
-  },
-  timerContainer: {
-    alignSelf: 'center',
-    backgroundColor: Colors.primary,
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginBottom: Spacing.md,
-    ...Colors.shadow.large,
-  },
-  timerText: {
-    fontSize: FontSize.huge,
-    fontWeight: FontWeight.bold,
-    color: '#ffffff',
   },
   imageContainer: {
     flex: 1,

--- a/components/game/TimerArc.native.tsx
+++ b/components/game/TimerArc.native.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useMemo } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Canvas, Path, Skia } from '@shopify/react-native-skia';
+import {
+  Easing,
+  useSharedValue,
+  useDerivedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import { useReduceMotion } from '../../utils/useReduceMotion';
+import Colors from '../../constants/Colors';
+import { FontSize, FontWeight } from '../../constants/Layout';
+
+const SIZE = 80;
+const STROKE_WIDTH = 6;
+const PADDING = STROKE_WIDTH / 2;
+const OVAL = { x: PADDING, y: PADDING, width: SIZE - STROKE_WIDTH, height: SIZE - STROKE_WIDTH };
+
+export interface TimerArcProps {
+  timeRemaining: number;
+  totalTime: number;
+}
+
+export function TimerArc({ timeRemaining, totalTime }: TimerArcProps) {
+  const reduceMotion = useReduceMotion();
+  const progress = useSharedValue(totalTime > 0 ? timeRemaining / totalTime : 1);
+
+  useEffect(() => {
+    const target = totalTime > 0 ? Math.max(0, timeRemaining) / totalTime : 0;
+    if (reduceMotion) {
+      progress.value = target;
+    } else {
+      progress.value = withTiming(target, { duration: 900, easing: Easing.linear });
+    }
+  }, [timeRemaining, totalTime, reduceMotion, progress]);
+
+  const trackPath = useMemo(() => {
+    const p = Skia.Path.Make();
+    p.addArc(OVAL, -90, 360);
+    return p;
+  }, []);
+
+  const arcPath = useDerivedValue(() => {
+    const p = Skia.Path.Make();
+    const sweep = progress.value * 360;
+    if (sweep > 0.5) {
+      p.addArc(OVAL, -90, sweep);
+    }
+    return p;
+  });
+
+  const isUrgent = timeRemaining <= 3;
+  const arcColor = timeRemaining <= 1 ? '#FF6B6B' : timeRemaining <= 3 ? '#FFD700' : '#FFFFFF';
+
+  return (
+    <View style={styles.container}>
+      <Canvas style={styles.canvas}>
+        <Path
+          path={trackPath}
+          color="rgba(255,255,255,0.20)"
+          style="stroke"
+          strokeWidth={STROKE_WIDTH}
+          strokeCap="round"
+        />
+        <Path
+          path={arcPath}
+          color={arcColor}
+          style="stroke"
+          strokeWidth={STROKE_WIDTH}
+          strokeCap="round"
+        />
+      </Canvas>
+      <View style={StyleSheet.absoluteFill} pointerEvents="none">
+        <Text style={[styles.timerText, isUrgent && styles.timerTextUrgent]}>
+          {Math.max(0, Math.ceil(timeRemaining))}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+export default TimerArc;
+
+const styles = StyleSheet.create({
+  container: {
+    width: SIZE,
+    height: SIZE,
+    alignSelf: 'center',
+    backgroundColor: Colors.primary,
+    borderRadius: SIZE / 2,
+    justifyContent: 'center',
+    alignItems: 'center',
+    ...Colors.shadow.large,
+  },
+  canvas: {
+    position: 'absolute',
+    width: SIZE,
+    height: SIZE,
+  },
+  timerText: {
+    fontSize: FontSize.huge,
+    fontWeight: FontWeight.bold,
+    color: '#ffffff',
+    textAlign: 'center',
+    lineHeight: SIZE,
+  },
+  timerTextUrgent: {
+    color: '#FFD700',
+  },
+});

--- a/components/game/TimerArc.tsx
+++ b/components/game/TimerArc.tsx
@@ -1,0 +1,3 @@
+// Platform dispatcher — Metro picks .native.tsx, webpack picks .web.tsx.
+export { TimerArc as default, TimerArc } from './TimerArc.native';
+export type { TimerArcProps } from './TimerArc.native';

--- a/components/game/TimerArc.web.tsx
+++ b/components/game/TimerArc.web.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import Svg, { Circle } from 'react-native-svg';
+import Colors from '../../constants/Colors';
+import { FontSize, FontWeight } from '../../constants/Layout';
+
+const SIZE = 80;
+const STROKE_WIDTH = 6;
+const RADIUS = (SIZE - STROKE_WIDTH) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+const CENTER = SIZE / 2;
+
+export interface TimerArcProps {
+  timeRemaining: number;
+  totalTime: number;
+}
+
+export function TimerArc({ timeRemaining, totalTime }: TimerArcProps) {
+  const progress = totalTime > 0 ? Math.max(0, timeRemaining) / totalTime : 0;
+  const strokeDashoffset = CIRCUMFERENCE * (1 - progress);
+  const isUrgent = timeRemaining <= 3;
+  const arcColor = timeRemaining <= 1 ? '#FF6B6B' : timeRemaining <= 3 ? '#FFD700' : '#FFFFFF';
+
+  return (
+    <View style={styles.container}>
+      <Svg
+        width={SIZE}
+        height={SIZE}
+        style={StyleSheet.absoluteFill}
+        viewBox={`0 0 ${SIZE} ${SIZE}`}
+      >
+        <Circle
+          cx={CENTER}
+          cy={CENTER}
+          r={RADIUS}
+          fill="none"
+          stroke="rgba(255,255,255,0.20)"
+          strokeWidth={STROKE_WIDTH}
+        />
+        <Circle
+          cx={CENTER}
+          cy={CENTER}
+          r={RADIUS}
+          fill="none"
+          stroke={arcColor}
+          strokeWidth={STROKE_WIDTH}
+          strokeDasharray={CIRCUMFERENCE}
+          strokeDashoffset={strokeDashoffset}
+          strokeLinecap="round"
+          rotation={-90}
+          origin={`${CENTER}, ${CENTER}`}
+          // @ts-ignore — web-only CSS transition
+          style={{ transition: 'stroke-dashoffset 0.9s linear, stroke 0.3s' }}
+        />
+      </Svg>
+      <Text style={[styles.timerText, isUrgent && styles.timerTextUrgent]}>
+        {Math.max(0, Math.ceil(timeRemaining))}
+      </Text>
+    </View>
+  );
+}
+
+export default TimerArc;
+
+const styles = StyleSheet.create({
+  container: {
+    width: SIZE,
+    height: SIZE,
+    alignSelf: 'center',
+    backgroundColor: Colors.primary,
+    borderRadius: SIZE / 2,
+    justifyContent: 'center',
+    alignItems: 'center',
+    ...Colors.shadow.large,
+  },
+  timerText: {
+    fontSize: FontSize.huge,
+    fontWeight: FontWeight.bold,
+    color: '#ffffff',
+    textAlign: 'center',
+  },
+  timerTextUrgent: {
+    color: '#FFD700',
+  },
+});

--- a/components/game/game.shared.ts
+++ b/components/game/game.shared.ts
@@ -3,6 +3,7 @@ import type { LevelImage } from '../../types';
 
 export interface MemorizePhaseProps {
   timeRemaining: number;
+  totalTime: number;
   currentImage: LevelImage | null;
   levelNumber: number;
   currentLang: string;

--- a/services/useGamePhase.ts
+++ b/services/useGamePhase.ts
@@ -279,6 +279,7 @@ export function useGamePhase({
     levelNumber,
     currentImage,
     timeRemaining,
+    displayDuration: getDisplayDuration(levelNumber, extraTimeMode),
     userRating,
     revealStep,
     savedToGallery,


### PR DESCRIPTION
## Summary

- **Animated Timer Arc** — Depleting countdown ring in Memorize phase (Skia native / SVG web). Turns gold at ≤3 s, red at ≤1 s.
- **Phase Crossfade Transitions** — Opacity fade-out/in (150 ms / 250 ms) between memorize → draw → result via Reanimated; respects `prefers-reduced-motion`.
- **4-Star Confetti Variant** — Light silver sparkle burst (20 particles, 1.5 s) triggered at ≥4★ in addition to the existing 5-star full burst (40 particles, 2.5 s). Uses new `intensity: 'full' | 'light'` prop on `ConfettiBurst`.
- **Animated Stats Counter** — Home screen numbers count from 0 to target over 600 ms on load (`setInterval`-based, 20 steps). Respects `prefers-reduced-motion`.

## New files

- `components/game/TimerArc.tsx` — platform re-export
- `components/game/TimerArc.native.tsx` — Skia arc implementation
- `components/game/TimerArc.web.tsx` — SVG `strokeDashoffset` implementation

## Modified files

| File | Change |
|---|---|
| `components/game/MemorizePhase.tsx` | Replace static timer text with `<TimerArc>` |
| `components/game/game.shared.ts` | Add `totalTime` prop to `MemorizePhaseProps` |
| `services/useGamePhase.ts` | Expose `displayDuration` for `totalTime` passthrough |
| `app/game.tsx` | Crossfade via `phaseOpacity` SharedValue; confetti trigger at ≥4★ with `intensity` |
| `components/ConfettiBurst.shared.ts` | `ConfettiIntensity` type, `buildParticles(intensity)`, light palette |
| `components/ConfettiBurst.{tsx,native,web}.tsx` | Accept and forward `intensity` prop |
| `components/QuickStatsCards.tsx` | `displayStats` state + `setInterval` counter animation |
| `__mocks__/@shopify/react-native-skia.js` | Add `addArc` to Path mock |
| `components/__tests__/*` | Mocks + fake timers for new behaviour |

## Test plan

- [ ] Home screen: stats numbers animate from 0 on first load
- [ ] Memorize phase: circular arc depletes, turns gold at ≤3 s, red at ≤1 s
- [ ] Phase transitions: soft opacity crossfade between all three phases
- [ ] 4-star result: small silver sparkle burst appears
- [ ] 5-star result: full confetti burst as before
- [ ] `npm test` — all tests green (375+)
- [ ] `npx tsc --noEmit` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2ycUiXM6GRiBE7fhCWrfj

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2ycUiXM6GRiBE7fhCWrfj)_