### PR TITLE
feat: Spielvarianten + 5 weitere Sprachen (Issue #247)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Spieler sehen ein Bild kurz, zeichnen es aus dem Gedächtnis, vergleichen das Er
 | State | React Hooks + AsyncStorage |
 | Theming | ThemeContext (light / dark / system) |
 | Sound | Web Audio API (web) + `expo-haptics` (native) |
-| i18n | Custom `services/i18n.ts` (de/en), Locales in `locales/` |
+| i18n | Custom `services/i18n.ts` (de/en/es/fr/it/nl/pl), Locales in `locales/`, automatische Geräte-Spracherkennung |
 | Tests | Jest 29 + jest-expo ~55 (373+ Tests, jsdom-Environment) |
 | CI | GitHub Actions (`.github/workflows/ci-cd.yml`) |
 | Build (Native) | EAS Build (`eas.json`) |
@@ -73,7 +73,7 @@ services/
   SoundManager.ts            # Web Audio API (Web) + expo-haptics (Native)
   SentryService.ts           # Sentry-Wrapper (init, captureException, etc.)
   ThemeContext.tsx            # ThemeProvider + useTheme Hook (light/dark/system)
-  i18n.ts                    # Übersetzungs-Service (de/en) mit listener-basiertem Reload
+  i18n.ts                    # Übersetzungs-Service (de/en/es/fr/it/nl/pl) mit listener-basiertem Reload + automatischer Geräte-Spracherkennung
   ReviewManager.ts           # In-App-Review-Trigger: 5-Sterne oder 3. Daily Challenge, 90-Tage-Cooldown — deaktiviert via EXPO_PUBLIC_ENABLE_IN_APP_REVIEW
   ShareService.ts            # PNG-Export (Web): Off-Screen-Canvas → Web Share API / Download-Fallback
   ShareService.native.ts     # PNG-Export (Native): Skia Surface → expo-file-system + expo-sharing
@@ -95,6 +95,7 @@ types/
 locales/
   de/translations.json       # Deutsche Übersetzungen
   en/translations.json       # Englische Übersetzungen
+  es/, fr/, it/, nl/, pl/     # Spanisch, Französisch, Italienisch, Niederländisch, Polnisch (Issue #247)
 
 assets/images/levels/        # Kanonische SVG-Bilder (level-01-sun.svg … extra-04-bird.svg)
 assets/images/levels-{1-5}/  # Level-sortierte Kopien der gleichen SVGs
@@ -177,6 +178,18 @@ memorize  →  draw  →  result
 
 Level-Anzahl: 20 (Difficulty 1–5). Alle Level haben 3 s Anzeigezeit.
 Bilderpool: `ImagePoolManager.ts` wählt zufällig nach Difficulty-Klasse aus. Aktuell **51 Bilder** (inkl. Tiere v1 Pack — 10 Tiere, PR #221 + Fahrzeuge v1 Pack — 10 Fahrzeuge, PR #254).
+
+### Spielvarianten (Issue #247)
+
+Auf dem Level-Auswahl-Screen (`app/levels.tsx`) wählbar (`GameVariant` in `types/index.ts`), wird als `?variant=` Query-Param an `/game` übergeben:
+
+| Variante | Effekt |
+|---|---|
+| `normal` | Standard — Bild wird unverändert gezeigt |
+| `outline` | Nur Umriss merken — `LevelImageDisplay` entfernt rekursiv alle Füllfarben (`mode="outline"`), nur eine einheitliche Kontur bleibt sichtbar |
+| `mirror` | Spiegelbild — `LevelImageDisplay` spiegelt die Anzeige horizontal (`mirror`, `transform: scaleX(-1)`) |
+
+Wirkt in Memorize-Phase und im Hinweis-Modal der Draw-Phase gleichermaßen. Kreativ-Modus (freies Malen ohne Vorlage, `app/creative.tsx`) ist eine eigenständige Route, kein `GameVariant`.
 
 ---
 
@@ -360,6 +373,7 @@ Stand: `main` @ v1.7.0 / versionCode 66. `testing` hat Fahrzeuge v1 + PNG-Export
 | **Themen-Pack Tiere v1** (10 Bilder, #222) | ✅ in main (v1.7.0) |
 | **Themen-Pack Fahrzeuge v1** (10 Bilder, PR #254) | ✅ in testing |
 | Themen-Pack Natur / Märchen / weitere | 🔲 offen |
+| **Spielvarianten** (Nur Umriss merken, Spiegelbild, Kreativ-Modus, #247) | ✅ in testing |
 | Avatar & Personalisierung | 🔲 offen |
 | XP- & Level-System | 🔲 offen |
 | Wöchentliche Challenge | 🔲 offen |
@@ -368,7 +382,7 @@ Stand: `main` @ v1.7.0 / versionCode 66. `testing` hat Fahrzeuge v1 + PNG-Export
 | Task | Status |
 |---|---|
 | Designed for Families Programm | 🔲 offen |
-| Weitere Sprachen (ES/FR/IT/NL/PL) | 🔲 offen |
+| **Weitere Sprachen** (ES/FR/IT/NL/PL, #247) | ✅ in testing — automatische Geräte-Spracherkennung |
 | **Sharing-Feature / PNG-Export** (ShareService, PR #255) | ✅ in testing |
 | Push-Notifications (opt-in) | 🔲 offen |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,16 +251,16 @@ Gespeicherte Felder: `progress`, `theme`, `language`, `sound_enabled`, `music_en
 
 ## UI/UX Design System (Issue #176)
 
-Stand `testing`: Phase A + B abgeschlossen, Phase D (Konfetti + Jubel-Sound) teilweise umgesetzt.
+Stand `testing`: Phase A, B, C und E abgeschlossen, Phase D (Konfetti + Jubel-Sound, TimerArc, Phasen-Crossfade, Stats-Counter) größtenteils umgesetzt — nur Lottie offen.
 
 ### Phase-Übersicht
 | Phase | Status | Branch/PR |
 |---|---|---|
 | **A: Foundation** — Farbpalette, Dark Mode, Nunito-Font, Typografie | ✅ in `testing` | PR merged |
 | **B: Components** — Gradient-Buttons, Glassmorphism-Cards, Sterne-Animation | ✅ in `testing` | PR #178 merged |
-| **C: Screens** — Timer-Visualisierung, Phase-Übergänge, Home-Refresh | 🔲 offen | — |
-| **D: Delight** — Lottie, Konfetti, Mikro-Sounds | 🔶 teilweise (Konfetti + Jubel-Sound in PR #253) | — |
-| **E: Onboarding** — First-Run-Tour | 🔲 offen | — |
+| **C: Screens** — Timer-Visualisierung, Phase-Übergänge, Home-Refresh | ✅ in `testing` | PR #257 merged |
+| **D: Delight** — Lottie, Konfetti, Mikro-Sounds | 🔶 größtenteils (Konfetti + Jubel-Sound PR #253, TimerArc/Phasen-Crossfade/Stats-Counter PR #257) — Lottie offen | — |
+| **E: Onboarding** — First-Run-Tour | ✅ in `testing` | PR #261 merged (In-Game Coach-Marks) |
 
 ### Neue Primitiven (Phase B)
 
@@ -356,7 +356,7 @@ Web-APIs über `utils/platform.ts` absichern (`safeWebAPI`, `isWeb`-Guard). Für
 ## Wachstums-Roadmap (Issue #219)
 
 Übergeordneter Plan, um aus der App eine dauerhaft wachsende Kids-App im Play Store zu machen.
-Stand: `main` @ v1.7.0 / versionCode 66. `testing` hat Fahrzeuge v1 + PNG-Export (noch nicht in main).
+Stand: `main` @ v1.7.0 / versionCode 66. `testing` hat Fahrzeuge v1, PNG-Export, Mini-Tutorial, Design-System Phase C/D-Polish, Spielvarianten und weitere Sprachen (noch nicht in main).
 
 ### P0 — Foundation für Wachstum
 | Task | Status |

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -35,7 +35,7 @@ import Animated, {
   runOnJS,
 } from 'react-native-reanimated';
 import { useReduceMotion } from '../utils/useReduceMotion';
-import type { GamePhase } from '../types';
+import type { GamePhase, GameVariant } from '../types';
 import type { ConfettiIntensity } from '@components/ConfettiBurst';
 
 export default function GameScreen() {
@@ -73,6 +73,8 @@ export default function GameScreen() {
       : 1;
 
   const isDailyChallenge = params.daily === '1';
+  const variant: GameVariant =
+    params.variant === 'outline' || params.variant === 'mirror' ? params.variant : 'normal';
   const [isTutorial, setIsTutorial] = useState(params.tutorial === '1');
   const [tutorialHintVisible, setTutorialHintVisible] = useState(true);
 
@@ -288,7 +290,12 @@ export default function GameScreen() {
             </View>
             {currentImage && (
               <ErrorBoundary>
-                <LevelImageDisplay image={currentImage} size={Math.min(screenWidth - 80, 280)} />
+                <LevelImageDisplay
+                  image={currentImage}
+                  size={Math.min(screenWidth - 80, 280)}
+                  mode={variant === 'outline' ? 'outline' : 'normal'}
+                  mirror={variant === 'mirror'}
+                />
               </ErrorBoundary>
             )}
           </View>
@@ -307,6 +314,7 @@ export default function GameScreen() {
             memorizeImageSize={layout.memorizeImageSize}
             imagePlaceholderMinSize={layout.imagePlaceholderMinSize}
             revealStep={revealStep}
+            variant={variant}
           />
         )}
         {visiblePhase === 'draw' && (

--- a/app/levels.tsx
+++ b/app/levels.tsx
@@ -10,9 +10,13 @@ import { Spacing, FontSize, FontWeight, FontFamily, BorderRadius } from '../cons
 import { GlassCard } from '@components/AnimatedPrimitives';
 import { Badge } from '@components/Badge';
 import { FloatingStars } from '@components/FloatingStars';
+import { ChipGroup } from '@components/Chip';
+import type { GameVariant } from '../types';
 
 // Default card width for SSR (will be recalculated on client)
 const DEFAULT_CARD_WIDTH = 150;
+
+const VARIANT_KEYS: GameVariant[] = ['normal', 'outline', 'mirror'];
 
 /**
  * Levels Screen - Level-Auswahl
@@ -24,6 +28,7 @@ export default function LevelsScreen() {
   const { colors, theme } = useTheme();
   const levels = useMemo(() => getAllLevels(), []);
   const [ratings, setRatings] = useState<Record<number, number | null>>({});
+  const [variant, setVariant] = useState<GameVariant>('normal');
   // Use hook for responsive dimensions (SSR-safe)
   const { width: screenWidth } = useWindowDimensions();
   const cardWidth = screenWidth > 0 ? (screenWidth - Spacing.lg * 3) / 2 : DEFAULT_CARD_WIDTH;
@@ -67,7 +72,7 @@ export default function LevelsScreen() {
     return (
       <GlassCard
         index={index}
-        onPress={() => router.push(`/game?level=${item.number}`)}
+        onPress={() => router.push(`/game?level=${item.number}&variant=${variant}`)}
         accessibilityLabel={`${t('levels.level', { number: item.number })} — ${difficultyText}`}
         style={[
           styles.levelCard,
@@ -108,6 +113,21 @@ export default function LevelsScreen() {
         <Text style={[styles.title, { color: colors.text.primary }]}>{t('levels.title')}</Text>
       </View>
 
+      {/* Spielvariante */}
+      <View style={styles.variantSection}>
+        <Text style={[styles.variantLabel, { color: colors.text.secondary }]}>
+          {t('levels.variant.title')}
+        </Text>
+        <ChipGroup
+          options={VARIANT_KEYS.map((v) => t(`levels.variant.${v}`))}
+          selected={t(`levels.variant.${variant}`)}
+          onSelect={(label) => {
+            const match = VARIANT_KEYS.find((v) => t(`levels.variant.${v}`) === label);
+            if (match) setVariant(match);
+          }}
+        />
+      </View>
+
       {/* Level-Grid */}
       <FlatList
         data={levels}
@@ -142,6 +162,15 @@ const styles = StyleSheet.create({
     fontSize: FontSize.xxl,
     fontWeight: FontWeight.bold,
     fontFamily: FontFamily.extraBold,
+  },
+  variantSection: {
+    paddingHorizontal: Spacing.lg,
+    paddingTop: Spacing.md,
+    gap: Spacing.xs,
+  },
+  variantLabel: {
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.semibold,
   },
   listContent: {
     padding: Spacing.lg,

--- a/components/LevelImageDisplay.tsx
+++ b/components/LevelImageDisplay.tsx
@@ -7,6 +7,30 @@ interface Props {
   image: LevelImage;
   size?: number;
   revealStep?: number; // If set, only show SVG children 0..revealStep (for progressive reveal)
+  mode?: 'normal' | 'outline'; // 'outline' strips colors, showing only the silhouette (game variant "Nur Umriss merken")
+  mirror?: boolean; // Horizontally flips the image (game variant "Spiegelbild")
+}
+
+const OUTLINE_COLOR = '#3a3a3a';
+
+/**
+ * Recursively strips fill colors from an SVG element tree and forces a uniform
+ * outline stroke, so only the silhouette remains visible (no color information).
+ */
+function toOutlineElement(node: React.ReactNode): React.ReactNode {
+  if (!React.isValidElement(node)) return node;
+  const props: Record<string, unknown> = { ...(node.props as Record<string, unknown>) };
+
+  if ('fill' in props) props.fill = 'none';
+  props.stroke = OUTLINE_COLOR;
+  if (!props.strokeWidth || Number(props.strokeWidth) < 2) props.strokeWidth = '2';
+  delete props.opacity;
+
+  if (props.children) {
+    props.children = React.Children.map(props.children as React.ReactNode, toOutlineElement);
+  }
+
+  return React.cloneElement(node, props);
 }
 
 /**
@@ -1546,15 +1570,29 @@ function renderSvgForImage(image: LevelImage, svgSize: number, viewBox: string):
  * Rendert die SVG-Bilder als React Native SVG Komponenten
  * Optional: revealStep für schrittweises Aufdecken
  */
-export default function LevelImageDisplay({ image, size = 300, revealStep }: Props) {
+export default function LevelImageDisplay({ image, size = 300, revealStep, mode = 'normal', mirror = false }: Props) {
   const svgSize = size;
   const viewBox = "0 0 200 200";
 
-  const svgElement = renderSvgForImage(image, svgSize, viewBox);
+  let svgElement = renderSvgForImage(image, svgSize, viewBox);
 
   if (!svgElement) {
     return <View style={[styles.container, { width: svgSize, height: svgSize }]} />;
   }
+
+  if (mode === 'outline') {
+    const outlinedChildren = React.Children.map(
+      (svgElement.props as React.ComponentProps<typeof Svg>).children,
+      toOutlineElement
+    );
+    svgElement = React.cloneElement(svgElement, {}, outlinedChildren);
+  }
+
+  const containerStyle = [
+    styles.container,
+    { width: svgSize, height: svgSize },
+    mirror && styles.mirrored,
+  ];
 
   // Progressive reveal: only show children up to revealStep
   if (revealStep !== undefined) {
@@ -1562,14 +1600,14 @@ export default function LevelImageDisplay({ image, size = 300, revealStep }: Pro
     const visibleChildren = children.slice(0, revealStep + 1);
     const cloned = React.cloneElement(svgElement, {}, ...visibleChildren);
     return (
-      <View style={[styles.container, { width: svgSize, height: svgSize }]}>
+      <View style={containerStyle}>
         {cloned}
       </View>
     );
   }
 
   return (
-    <View style={[styles.container, { width: svgSize, height: svgSize }]}>
+    <View style={containerStyle}>
       {svgElement}
     </View>
   );
@@ -1579,5 +1617,8 @@ const styles = StyleSheet.create({
   container: {
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  mirrored: {
+    transform: [{ scaleX: -1 }],
   },
 });

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Modal, Alert, Linking, Share, ScrollView } from 'react-native';
 import Constants from 'expo-constants';
-import { useTranslation, getLanguage, setLanguage } from '@services/i18n';
+import { useTranslation, getLanguage, setLanguage, type Language } from '@services/i18n';
 import { useTheme } from '@services/ThemeContext';
 import storageManager from '@services/StorageManager';
 import SoundManager from '@services/SoundManager';
@@ -41,7 +41,7 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
     storageManager.getSetting('celebrationEnabled').then(setCelebrationEnabled);
   }, [visible, themeSetting]);
 
-  const handleLanguageChange = async (lang: 'de' | 'en') => {
+  const handleLanguageChange = async (lang: Language) => {
     await setLanguage(lang);
     setCurrentLang(lang);
   };
@@ -247,14 +247,24 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
           currentTheme,
           (v) => handleThemeChange(v as 'light' | 'dark' | 'system')
         ))}
-        {renderRow(t('settings.language'), renderSegment(
-          [
-            { label: 'DE', value: 'de' },
-            { label: 'EN', value: 'en' },
-          ],
-          currentLang,
-          (v) => handleLanguageChange(v as 'de' | 'en')
-        ))}
+        <View style={[styles.row, styles.languageRow, { borderBottomColor: colors.border }]}>
+          <Text style={[styles.rowLabel, { color: colors.text.primary, marginBottom: Spacing.xs }]}>
+            {t('settings.language')}
+          </Text>
+          {renderSegment(
+            [
+              { label: 'DE', value: 'de' },
+              { label: 'EN', value: 'en' },
+              { label: 'ES', value: 'es' },
+              { label: 'FR', value: 'fr' },
+              { label: 'IT', value: 'it' },
+              { label: 'NL', value: 'nl' },
+              { label: 'PL', value: 'pl' },
+            ],
+            currentLang,
+            (v) => handleLanguageChange(v as Language)
+          )}
+        </View>
         {renderRow(t('settings.sound'), renderSegment(
           [
             { label: t('settings.soundOn'),  value: 'on'  },
@@ -459,6 +469,10 @@ const styles = StyleSheet.create({
     paddingVertical: Spacing.xs,
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
+  languageRow: {
+    flexDirection: 'column',
+    alignItems: 'stretch',
+  },
   rowLabel: {
     fontSize: FontSize.xs,
     fontWeight: FontWeight.medium,
@@ -503,6 +517,7 @@ const styles = StyleSheet.create({
   // ── Segment-Control ─────────────────────────────────────────────────────
   segment: {
     flexDirection: 'row',
+    flexWrap: 'wrap',
     borderRadius: BorderRadius.sm,
     overflow: 'hidden',
   },

--- a/components/__tests__/LevelImageDisplay.test.tsx
+++ b/components/__tests__/LevelImageDisplay.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import type { LevelImage } from '../../types';
+
+// react-native-svg's fabric native components aren't available under this
+// jsdom-based test environment. Mock with plain View stand-ins so we can
+// verify LevelImageDisplay's own prop-transformation logic (outline/mirror).
+jest.mock('react-native-svg', () => {
+  const { View } = require('react-native');
+  const passthrough = (name: string) => {
+    const Comp = (props: any) => <View {...props} testID={name} />;
+    Comp.displayName = name;
+    return Comp;
+  };
+  return {
+    __esModule: true,
+    default: passthrough('Svg'),
+    Circle: passthrough('Circle'),
+    Ellipse: passthrough('Ellipse'),
+    Rect: passthrough('Rect'),
+    Line: passthrough('Line'),
+    Path: passthrough('Path'),
+    Polygon: passthrough('Polygon'),
+  };
+});
+
+import LevelImageDisplay from '../LevelImageDisplay';
+
+const sunImage: LevelImage = {
+  filename: 'level-01-sun.svg',
+  difficulty: 1,
+  displayName: 'Sonne',
+  displayNameEn: 'Sun',
+  strokeCount: 9,
+  colors: ['#FFD700'],
+};
+
+describe('LevelImageDisplay', () => {
+  it('renders the full-color image by default', () => {
+    const { UNSAFE_root } = render(<LevelImageDisplay image={sunImage} />);
+    const filled = UNSAFE_root.findAll((node: any) => node.props.fill === '#FFD700');
+    expect(filled.length).toBeGreaterThan(0);
+  });
+
+  it('strips fills and forces a uniform stroke in outline mode', () => {
+    const { UNSAFE_root } = render(<LevelImageDisplay image={sunImage} mode="outline" />);
+    const stillColored = UNSAFE_root.findAll((node: any) => node.props.fill === '#FFD700');
+    expect(stillColored.length).toBe(0);
+    const outlined = UNSAFE_root.findAll((node: any) => node.props.stroke === '#3a3a3a');
+    expect(outlined.length).toBeGreaterThan(0);
+  });
+
+  it('applies a horizontal flip transform in mirror mode', () => {
+    const { UNSAFE_root } = render(<LevelImageDisplay image={sunImage} mirror />);
+    const flipped = UNSAFE_root.findAll(
+      (node: any) =>
+        Array.isArray(node.props.style) &&
+        node.props.style.some((s: any) => s && Array.isArray(s.transform) && s.transform[0]?.scaleX === -1)
+    );
+    expect(flipped.length).toBeGreaterThan(0);
+  });
+
+  it('combines outline mode with progressive reveal without crashing', () => {
+    expect(() =>
+      render(<LevelImageDisplay image={sunImage} mode="outline" revealStep={2} />)
+    ).not.toThrow();
+  });
+
+  it('renders an empty placeholder for an unknown image without crashing', () => {
+    const unknown: LevelImage = { ...sunImage, filename: 'does-not-exist.svg' };
+    expect(() => render(<LevelImageDisplay image={unknown} mode="outline" mirror />)).not.toThrow();
+  });
+});

--- a/components/__tests__/LevelsScreen.test.tsx
+++ b/components/__tests__/LevelsScreen.test.tsx
@@ -5,6 +5,27 @@ jest.mock('expo-router', () => ({
   useRouter: () => ({ back: jest.fn(), push: jest.fn() }),
 }));
 
+jest.mock('react-native-reanimated', () => {
+  const { View, Text: RNText } = require('react-native');
+  return {
+    __esModule: true,
+    default: {
+      View,
+      Text: RNText,
+      createAnimatedComponent: (c: any) => c,
+      call: () => {},
+    },
+    useSharedValue: (v: any) => ({ value: v }),
+    useAnimatedStyle: (_fn: any) => ({}),
+    withSpring: (v: any) => v,
+    withTiming: (v: any) => v,
+    withDelay: (_d: any, v: any) => v,
+    withSequence: (...args: any[]) => args[args.length - 1],
+    Easing: { out: () => () => {}, ease: {} },
+    runOnJS: (fn: any) => fn,
+  };
+});
+
 jest.mock('../../services/i18n', () => ({
   useTranslation: () => ({
     t: (key: string, opts?: any) => (opts?.number !== null && opts?.number !== undefined ? `Level ${opts.number}` : key),

--- a/components/game/MemorizePhase.tsx
+++ b/components/game/MemorizePhase.tsx
@@ -18,6 +18,7 @@ export default function MemorizePhase({
   memorizeImageSize,
   imagePlaceholderMinSize,
   revealStep,
+  variant = 'normal',
 }: MemorizePhaseProps) {
   const { t } = useTranslation();
   const { colors } = useTheme();
@@ -32,7 +33,13 @@ export default function MemorizePhase({
         {currentImage && (
           <View style={[styles.imagePlaceholder, { minWidth: imagePlaceholderMinSize, minHeight: imagePlaceholderMinSize, backgroundColor: colors.surface }]}>
             <ErrorBoundary>
-              <LevelImageDisplay image={currentImage} size={memorizeImageSize} revealStep={revealStep} />
+              <LevelImageDisplay
+                image={currentImage}
+                size={memorizeImageSize}
+                revealStep={revealStep}
+                mode={variant === 'outline' ? 'outline' : 'normal'}
+                mirror={variant === 'mirror'}
+              />
             </ErrorBoundary>
             <Text style={[styles.imageName, { color: colors.text.primary }]}>
               {currentLang === 'en' ? currentImage.displayNameEn : currentImage.displayName}

--- a/components/game/game.shared.ts
+++ b/components/game/game.shared.ts
@@ -1,5 +1,5 @@
 import type { DrawingPath } from '@components/DrawingCanvas';
-import type { LevelImage } from '../../types';
+import type { LevelImage, GameVariant } from '../../types';
 
 export interface MemorizePhaseProps {
   timeRemaining: number;
@@ -10,6 +10,7 @@ export interface MemorizePhaseProps {
   memorizeImageSize: number;
   imagePlaceholderMinSize: number;
   revealStep: number;
+  variant?: GameVariant;
 }
 
 export interface DrawPhaseProps {

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -28,7 +28,13 @@
     "displayTime": "{{seconds}}s Anzeigezeit",
     "stars": "{{count}} Sterne",
     "locked": "Gesperrt",
-    "unlockHint": "Schließe Level {{prev}} ab"
+    "unlockHint": "Schließe Level {{prev}} ab",
+    "variant": {
+      "title": "Spielvariante",
+      "normal": "Normal",
+      "outline": "Nur Umriss",
+      "mirror": "Spiegelbild"
+    }
   },
   "game": {
     "memorize": {

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -28,7 +28,13 @@
     "displayTime": "{{seconds}}s display time",
     "stars": "{{count}} stars",
     "locked": "Locked",
-    "unlockHint": "Complete level {{prev}}"
+    "unlockHint": "Complete level {{prev}}",
+    "variant": {
+      "title": "Game mode",
+      "normal": "Normal",
+      "outline": "Outline only",
+      "mirror": "Mirror image"
+    }
   },
   "game": {
     "memorize": {

--- a/locales/es/translations.json
+++ b/locales/es/translations.json
@@ -1,0 +1,263 @@
+{
+  "app": {
+    "name": "Recuerda y Dibuja"
+  },
+  "home": {
+    "title": "Recuerda y Dibuja",
+    "subtitle": "¡Entrena tu memoria!",
+    "startButton": "Empezar a jugar",
+    "continueButton": "Continuar",
+    "levelsButton": "Elegir nivel",
+    "galleryButton": "Mi galería",
+    "creativeButton": "Creativo",
+    "settingsButton": "Ajustes",
+    "streakBadge": "🔥 {{count}}",
+    "stats": {
+      "stars": "Estrellas",
+      "streak": "Racha",
+      "levels": "Niveles",
+      "streakDay": "día",
+      "streakDays": "días",
+      "levelOf": "de {{total}}"
+    }
+  },
+  "levels": {
+    "title": "Elegir nivel",
+    "level": "Nivel {{number}}",
+    "difficulty": "Dificultad: {{diff}}",
+    "displayTime": "{{seconds}}s de visualización",
+    "stars": "{{count}} estrellas",
+    "locked": "Bloqueado",
+    "unlockHint": "Completa el nivel {{prev}}",
+    "variant": {
+      "title": "Modo de juego",
+      "normal": "Normal",
+      "outline": "Solo contorno",
+      "mirror": "Imagen espejo"
+    }
+  },
+  "game": {
+    "memorize": {
+      "title": "¡Memoriza la imagen!",
+      "timeLeft": "{{seconds}}s",
+      "imageInfo": "Nivel {{level}} • {{strokeCount}} trazos"
+    },
+    "draw": {
+      "title": "¡Dibuja la imagen!",
+      "hint": "Usa los colores y dibuja lo que recuerdes",
+      "tool": "Herramienta",
+      "toolBrush": "🖊️ Pincel",
+      "toolFill": "💧 Rellenar",
+      "strokeWidth": "Grosor del trazo",
+      "strokeWidthThin": "Fino",
+      "strokeWidthNormal": "Normal",
+      "strokeWidthThick": "Grueso",
+      "color": "Color",
+      "selectColor": "Elegir color",
+      "undo": "Deshacer",
+      "clear": "Borrar todo",
+      "clearConfirm": "¿Seguro que quieres borrar todo?",
+      "done": "Listo",
+      "hintButton": "👁 1x",
+      "hintUsed": "Pista usada",
+      "hintModalTitle": "Referencia",
+      "drawFromMemory": "Dibuja el",
+      "referenceLabel": "Ver referencia"
+    },
+    "tabs": {
+      "draw": "Dibujar",
+      "result": "Resultado"
+    },
+    "result": {
+      "title": "Puntúate:",
+      "howWell": "¿Qué tal lo hiciste?",
+      "tapStars": "¡Toca las estrellas para puntuarte!",
+      "starAccessibilityLabel": "{{rating}} estrella{{plural}}",
+      "template": "Referencia",
+      "feedback5": "¡Perfecto! ¡Eres un maestro de la memoria!",
+      "feedback4": "¡Muy bien! ¡Casi perfecto!",
+      "feedback3": "¡Bien hecho! ¡Sigue así!",
+      "feedback1": "Ya fue mejor que antes, ¿quieres intentarlo de nuevo?",
+      "yourDrawing": "Tu dibujo",
+      "original": "Original",
+      "rating": "Tu puntuación",
+      "retry": "Otra vez",
+      "nextLevel": "Siguiente",
+      "backToMenu": "Menú",
+      "allLevelsComplete": "¡Todos los niveles completados!",
+      "allLevelsCompleteMessage": "Has superado los 20 niveles. ¡Eres un verdadero campeón de la memoria!",
+      "playAgain": "Reiniciar",
+      "replay": "▶ Repetir",
+      "replayStop": "⏹ Parar"
+    }
+  },
+  "settings": {
+    "title": "Ajustes",
+    "appearance": "Apariencia",
+    "theme": "Tema",
+    "themeLight": "Claro",
+    "themeDark": "Oscuro",
+    "themeSystem": "Sistema",
+    "language": "Idioma",
+    "sound": "Efectos de sonido",
+    "soundOn": "Activado",
+    "soundOff": "Desactivado",
+    "music": "Música de fondo",
+    "dataSection": "Datos",
+    "resetProgress": "Restablecer progreso",
+    "resetConfirm": "¿Seguro que quieres borrar todo el progreso?",
+    "resetConfirmMessage": "¿De verdad quieres restablecer tu progreso? Esta acción no se puede deshacer.",
+    "resetSuccess": "Progreso restablecido",
+    "resetSuccessMessage": "Tu progreso de juego se ha restablecido correctamente.",
+    "languageChanged": "Idioma cambiado",
+    "languageChangedMessage": "El idioma se ha cambiado a español. Reinicia la aplicación para que los cambios surtan efecto en todas partes.",
+    "feedbackEmailSubject": "Comentarios: Recuerda y Dibuja",
+    "feedbackEmailBody": "Hola,\n\nTengo comentarios sobre Recuerda y Dibuja:\n\n",
+    "feedbackEmailError": "No se pudo abrir el cliente de correo. Envía tus comentarios a: devsven@posteo.de",
+    "browserError": "No se pudo abrir el navegador. Visita: https://ko-fi.com/s540d",
+    "browserErrorGeneric": "No se pudo abrir el navegador.",
+    "shareMessage": "Prueba esta genial app de entrenamiento de memoria: ¡Recuerda y Dibuja! https://github.com/S540d/DrawFromMemory",
+    "aboutSupport": "Acerca de y soporte",
+    "feedback": "Comentarios",
+    "support": "Soporte",
+    "share": "Compartir",
+    "aboutButton": "Acerca de",
+    "aboutTitle": "Acerca de Recuerda y Dibuja",
+    "versionLabel": "Versión",
+    "licenseLabel": "Licencia",
+    "error": "Error",
+    "about": "Acerca de la app",
+    "version": "Versión",
+    "personalize": "Personalizar",
+    "celebration": "Momento de celebración (confeti y sonido)"
+  },
+  "difficulty": {
+    "1": "Muy fácil",
+    "2": "Fácil",
+    "3": "Medio",
+    "4": "Difícil",
+    "5": "Muy difícil"
+  },
+  "gallery": {
+    "title": "Mi galería",
+    "empty": "Todavía no hay dibujos guardados. ¡Dibuja algo y toca \"Guardar\"!",
+    "save": "Guardar en galería",
+    "saved": "¡Guardado!",
+    "delete": "Eliminar",
+    "deleteTitle": "Eliminar dibujo",
+    "deleteConfirm": "¿Seguro que quieres eliminar este dibujo?",
+    "dailyChallengeLabel": "Reto diario",
+    "creativeLabel": "Dibujo libre",
+    "share": "Compartir",
+    "shareError": "No se pudo compartir."
+  },
+  "creative": {
+    "title": "Dibujo libre",
+    "imageName": "Dibujo creativo"
+  },
+  "dailyChallenge": {
+    "title": "Reto diario",
+    "subtitle": "Imagen del día",
+    "start": "Empezar reto",
+    "completed": "Completado hoy ✓",
+    "countdown": "Nuevo en {{hours}}h {{minutes}}m",
+    "level": "Nivel {{number}}"
+  },
+  "errors": {
+    "skiaUnavailableTitle": "Superficie de dibujo no disponible",
+    "skiaUnavailableMessage": "No se pudo cargar la función de dibujo.\nInténtalo de nuevo o reinicia la app.",
+    "skiaLoading": "Cargando superficie de dibujo…",
+    "skiaRetry": "Intentar de nuevo"
+  },
+  "common": {
+    "yes": "Sí",
+    "no": "No",
+    "cancel": "Cancelar",
+    "ok": "OK",
+    "close": "Cerrar",
+    "back": "Atrás",
+    "settings": "Ajustes"
+  },
+  "parentalGate": {
+    "title": "Control parental",
+    "message": "Este enlace lleva fuera de la app. Resuelve el reto para continuar:",
+    "placeholder": "Escribe la respuesta",
+    "confirm": "Abrir",
+    "wrongAnswer": "Respuesta incorrecta. Inténtalo de nuevo."
+  },
+  "onboarding": {
+    "skip": "Omitir",
+    "next": "Siguiente",
+    "start": "¡Vamos!",
+    "step1": {
+      "title": "Memoriza",
+      "desc": "Mira la imagen con atención durante unos segundos."
+    },
+    "step2": {
+      "title": "Dibuja",
+      "desc": "Intenta dibujarla de memoria."
+    },
+    "step3": {
+      "title": "Estrellas",
+      "desc": "Compara tu dibujo y gana estrellas."
+    },
+    "welcomeTitle": "¿Listo para jugar?",
+    "welcomeDesc": "Memoriza una imagen y luego dibújala de memoria. ¡Te guiaremos en la primera ronda!",
+    "startButton": "¡Jugar!"
+  },
+  "parentDashboard": {
+    "menuLabel": "Área de padres",
+    "title": "Panel de padres",
+    "subtitle": "Uso del juego en las últimas 4 semanas",
+    "privacyHint": "Todos los datos permanecen en este dispositivo.",
+    "loading": "Cargando estadísticas…",
+    "empty": "Todavía no hay sesiones de juego registradas.",
+    "totalSessions": "Sesiones",
+    "totalTime": "Tiempo total",
+    "avgStars": "Media de estrellas",
+    "streak": "Racha (actual/mejor)",
+    "favoriteLevels": "Niveles favoritos",
+    "dailyBreakdown": "Por día (últimos 14)",
+    "levelLine": "Nivel {{level}} · jugado {{count}}×"
+  },
+  "achievements": {
+    "title": "Trofeos",
+    "menuLabel": "Ver trofeos",
+    "unlocked": "¡Nuevo trofeo!",
+    "progress": "{{unlocked}} de {{total}} desbloqueados",
+    "first_5_stars": {
+      "title": "Primeras 5 estrellas",
+      "desc": "Consigue 5 estrellas en un nivel por primera vez."
+    },
+    "gallery_10": {
+      "title": "Artista de galería",
+      "desc": "Guarda 10 dibujos en tu galería."
+    },
+    "streak_7": {
+      "title": "Racha de 7 días",
+      "desc": "Juega 7 días seguidos."
+    },
+    "all_levels_done": {
+      "title": "Todos los niveles",
+      "desc": "Completa los 10 niveles base."
+    },
+    "daily_5": {
+      "title": "Campeón diario",
+      "desc": "Supera el reto diario 5 veces."
+    },
+    "all_difficulties": {
+      "title": "Todoterreno",
+      "desc": "Juega cada nivel de dificultad al menos una vez."
+    }
+  },
+  "tutorial": {
+    "memorize": "Mira la imagen con atención — ¡solo tienes unos segundos!",
+    "draw": "Dibuja lo que has visto de memoria. ¡Sin estrés! 😊",
+    "result": "Toca las estrellas — ¿qué tal lo hiciste?",
+    "tap": "Toca para continuar",
+    "step": "Paso {{current}} de {{total}}",
+    "badgeMemorize": "Memoriza",
+    "badgeDraw": "Dibuja",
+    "badgeResult": "Puntúa"
+  }
+}

--- a/locales/fr/translations.json
+++ b/locales/fr/translations.json
@@ -1,0 +1,263 @@
+{
+  "app": {
+    "name": "Mémorise et Dessine"
+  },
+  "home": {
+    "title": "Mémorise et Dessine",
+    "subtitle": "Entraîne ta mémoire !",
+    "startButton": "Commencer",
+    "continueButton": "Continuer",
+    "levelsButton": "Choisir un niveau",
+    "galleryButton": "Ma galerie",
+    "creativeButton": "Créatif",
+    "settingsButton": "Réglages",
+    "streakBadge": "🔥 {{count}}",
+    "stats": {
+      "stars": "Étoiles",
+      "streak": "Série",
+      "levels": "Niveaux",
+      "streakDay": "jour",
+      "streakDays": "jours",
+      "levelOf": "sur {{total}}"
+    }
+  },
+  "levels": {
+    "title": "Choisir un niveau",
+    "level": "Niveau {{number}}",
+    "difficulty": "Difficulté : {{diff}}",
+    "displayTime": "{{seconds}}s d'affichage",
+    "stars": "{{count}} étoiles",
+    "locked": "Verrouillé",
+    "unlockHint": "Termine le niveau {{prev}}",
+    "variant": {
+      "title": "Mode de jeu",
+      "normal": "Normal",
+      "outline": "Contour seulement",
+      "mirror": "Image miroir"
+    }
+  },
+  "game": {
+    "memorize": {
+      "title": "Mémorise l'image !",
+      "timeLeft": "{{seconds}}s",
+      "imageInfo": "Niveau {{level}} • {{strokeCount}} traits"
+    },
+    "draw": {
+      "title": "Dessine l'image !",
+      "hint": "Utilise les couleurs et dessine ce dont tu te souviens",
+      "tool": "Outil",
+      "toolBrush": "🖊️ Pinceau",
+      "toolFill": "💧 Remplir",
+      "strokeWidth": "Épaisseur du trait",
+      "strokeWidthThin": "Fin",
+      "strokeWidthNormal": "Normal",
+      "strokeWidthThick": "Épais",
+      "color": "Couleur",
+      "selectColor": "Choisir une couleur",
+      "undo": "Annuler",
+      "clear": "Tout effacer",
+      "clearConfirm": "Vraiment tout effacer ?",
+      "done": "Terminé",
+      "hintButton": "👁 1x",
+      "hintUsed": "Indice utilisé",
+      "hintModalTitle": "Référence",
+      "drawFromMemory": "Dessine le",
+      "referenceLabel": "Voir la référence"
+    },
+    "tabs": {
+      "draw": "Dessiner",
+      "result": "Résultat"
+    },
+    "result": {
+      "title": "Note-toi :",
+      "howWell": "Comment as-tu réussi ?",
+      "tapStars": "Touche les étoiles pour te noter !",
+      "starAccessibilityLabel": "{{rating}} étoile{{plural}}",
+      "template": "Référence",
+      "feedback5": "Parfait ! Tu es un maître de la mémoire !",
+      "feedback4": "Très bien ! Presque parfait !",
+      "feedback3": "Bien joué ! Continue comme ça !",
+      "feedback1": "C'était déjà mieux qu'avant, veux-tu quand même réessayer ?",
+      "yourDrawing": "Ton dessin",
+      "original": "Original",
+      "rating": "Ta note",
+      "retry": "Encore",
+      "nextLevel": "Suivant",
+      "backToMenu": "Menu",
+      "allLevelsComplete": "Tous les niveaux terminés !",
+      "allLevelsCompleteMessage": "Tu as maîtrisé les 20 niveaux. Tu es un vrai champion de la mémoire !",
+      "playAgain": "Recommencer",
+      "replay": "▶ Rejouer",
+      "replayStop": "⏹ Arrêter"
+    }
+  },
+  "settings": {
+    "title": "Réglages",
+    "appearance": "Apparence",
+    "theme": "Thème",
+    "themeLight": "Clair",
+    "themeDark": "Sombre",
+    "themeSystem": "Système",
+    "language": "Langue",
+    "sound": "Effets sonores",
+    "soundOn": "Activé",
+    "soundOff": "Désactivé",
+    "music": "Musique de fond",
+    "dataSection": "Données",
+    "resetProgress": "Réinitialiser la progression",
+    "resetConfirm": "Vraiment supprimer toute la progression ?",
+    "resetConfirmMessage": "Veux-tu vraiment réinitialiser ta progression ? Cette action est irréversible.",
+    "resetSuccess": "Progression réinitialisée",
+    "resetSuccessMessage": "Ta progression de jeu a bien été réinitialisée.",
+    "languageChanged": "Langue modifiée",
+    "languageChangedMessage": "La langue a été changée en français. Redémarre l'application pour que les changements s'appliquent partout.",
+    "feedbackEmailSubject": "Retour : Mémorise et Dessine",
+    "feedbackEmailBody": "Bonjour,\n\nJ'ai un retour à propos de Mémorise et Dessine :\n\n",
+    "feedbackEmailError": "Impossible d'ouvrir le client e-mail. Merci d'envoyer ton retour à : devsven@posteo.de",
+    "browserError": "Impossible d'ouvrir le navigateur. Visite : https://ko-fi.com/s540d",
+    "browserErrorGeneric": "Impossible d'ouvrir le navigateur.",
+    "shareMessage": "Découvre cette super appli d'entraînement de la mémoire : Mémorise et Dessine ! https://github.com/S540d/DrawFromMemory",
+    "aboutSupport": "À propos et support",
+    "feedback": "Retour",
+    "support": "Soutien",
+    "share": "Partager",
+    "aboutButton": "À propos",
+    "aboutTitle": "À propos de Mémorise et Dessine",
+    "versionLabel": "Version",
+    "licenseLabel": "Licence",
+    "error": "Erreur",
+    "about": "À propos de l'app",
+    "version": "Version",
+    "personalize": "Personnaliser",
+    "celebration": "Moment de fête (confettis et son)"
+  },
+  "difficulty": {
+    "1": "Très facile",
+    "2": "Facile",
+    "3": "Moyen",
+    "4": "Difficile",
+    "5": "Très difficile"
+  },
+  "gallery": {
+    "title": "Ma galerie",
+    "empty": "Aucun dessin enregistré pour l'instant. Dessine une image et touche « Enregistrer » !",
+    "save": "Enregistrer dans la galerie",
+    "saved": "Enregistré !",
+    "delete": "Supprimer",
+    "deleteTitle": "Supprimer le dessin",
+    "deleteConfirm": "Veux-tu vraiment supprimer ce dessin ?",
+    "dailyChallengeLabel": "Défi du jour",
+    "creativeLabel": "Dessin libre",
+    "share": "Partager",
+    "shareError": "Le partage a échoué."
+  },
+  "creative": {
+    "title": "Dessin libre",
+    "imageName": "Dessin créatif"
+  },
+  "dailyChallenge": {
+    "title": "Défi du jour",
+    "subtitle": "Image du jour",
+    "start": "Commencer le défi",
+    "completed": "Terminé pour aujourd'hui ✓",
+    "countdown": "Nouveau dans {{hours}}h {{minutes}}m",
+    "level": "Niveau {{number}}"
+  },
+  "errors": {
+    "skiaUnavailableTitle": "Surface de dessin indisponible",
+    "skiaUnavailableMessage": "La fonction de dessin n'a pas pu être chargée.\nRéessaie ou redémarre l'application.",
+    "skiaLoading": "Chargement de la surface de dessin…",
+    "skiaRetry": "Réessayer"
+  },
+  "common": {
+    "yes": "Oui",
+    "no": "Non",
+    "cancel": "Annuler",
+    "ok": "OK",
+    "close": "Fermer",
+    "back": "Retour",
+    "settings": "Réglages"
+  },
+  "parentalGate": {
+    "title": "Contrôle parental",
+    "message": "Ce lien mène en dehors de l'application. Résous le défi pour continuer :",
+    "placeholder": "Saisis la réponse",
+    "confirm": "Ouvrir",
+    "wrongAnswer": "Mauvaise réponse. Réessaie."
+  },
+  "onboarding": {
+    "skip": "Passer",
+    "next": "Suivant",
+    "start": "C'est parti !",
+    "step1": {
+      "title": "Mémorise",
+      "desc": "Regarde bien l'image pendant quelques secondes."
+    },
+    "step2": {
+      "title": "Dessine",
+      "desc": "Essaie de la dessiner de mémoire."
+    },
+    "step3": {
+      "title": "Étoiles",
+      "desc": "Compare ton dessin et gagne des étoiles."
+    },
+    "welcomeTitle": "Prêt à jouer ?",
+    "welcomeDesc": "Mémorise une image, puis dessine-la de mémoire. On te guide pour la première partie !",
+    "startButton": "Jouer !"
+  },
+  "parentDashboard": {
+    "menuLabel": "Espace parents",
+    "title": "Tableau de bord parents",
+    "subtitle": "Utilisation du jeu sur les 4 dernières semaines",
+    "privacyHint": "Toutes les données restent sur cet appareil.",
+    "loading": "Chargement des statistiques…",
+    "empty": "Aucune session de jeu enregistrée pour l'instant.",
+    "totalSessions": "Sessions",
+    "totalTime": "Temps total",
+    "avgStars": "Moy. étoiles",
+    "streak": "Série (actuelle/meilleure)",
+    "favoriteLevels": "Niveaux favoris",
+    "dailyBreakdown": "Par jour (14 derniers)",
+    "levelLine": "Niveau {{level}} · joué {{count}}×"
+  },
+  "achievements": {
+    "title": "Trophées",
+    "menuLabel": "Voir les trophées",
+    "unlocked": "Nouveau trophée !",
+    "progress": "{{unlocked}} sur {{total}} débloqués",
+    "first_5_stars": {
+      "title": "Premières 5 étoiles",
+      "desc": "Obtiens 5 étoiles sur un niveau pour la première fois."
+    },
+    "gallery_10": {
+      "title": "Artiste de galerie",
+      "desc": "Enregistre 10 dessins dans ta galerie."
+    },
+    "streak_7": {
+      "title": "Série de 7 jours",
+      "desc": "Joue 7 jours de suite."
+    },
+    "all_levels_done": {
+      "title": "Tous les niveaux",
+      "desc": "Termine les 10 niveaux de base."
+    },
+    "daily_5": {
+      "title": "Champion quotidien",
+      "desc": "Réussis le défi du jour 5 fois."
+    },
+    "all_difficulties": {
+      "title": "Touche-à-tout",
+      "desc": "Joue chaque niveau de difficulté au moins une fois."
+    }
+  },
+  "tutorial": {
+    "memorize": "Regarde bien l'image — tu n'as que quelques secondes !",
+    "draw": "Dessine ce que tu as vu de mémoire. Pas de stress ! 😊",
+    "result": "Touche les étoiles — comment as-tu réussi ?",
+    "tap": "Touche pour continuer",
+    "step": "Étape {{current}} sur {{total}}",
+    "badgeMemorize": "Mémorise",
+    "badgeDraw": "Dessine",
+    "badgeResult": "Note"
+  }
+}

--- a/locales/it/translations.json
+++ b/locales/it/translations.json
@@ -1,0 +1,263 @@
+{
+  "app": {
+    "name": "Ricorda e Disegna"
+  },
+  "home": {
+    "title": "Ricorda e Disegna",
+    "subtitle": "Allena la tua memoria!",
+    "startButton": "Inizia a giocare",
+    "continueButton": "Continua",
+    "levelsButton": "Scegli livello",
+    "galleryButton": "La mia galleria",
+    "creativeButton": "Creativo",
+    "settingsButton": "Impostazioni",
+    "streakBadge": "🔥 {{count}}",
+    "stats": {
+      "stars": "Stelle",
+      "streak": "Serie",
+      "levels": "Livelli",
+      "streakDay": "giorno",
+      "streakDays": "giorni",
+      "levelOf": "di {{total}}"
+    }
+  },
+  "levels": {
+    "title": "Scegli livello",
+    "level": "Livello {{number}}",
+    "difficulty": "Difficoltà: {{diff}}",
+    "displayTime": "{{seconds}}s di visualizzazione",
+    "stars": "{{count}} stelle",
+    "locked": "Bloccato",
+    "unlockHint": "Completa il livello {{prev}}",
+    "variant": {
+      "title": "Modalità di gioco",
+      "normal": "Normale",
+      "outline": "Solo contorno",
+      "mirror": "Immagine speculare"
+    }
+  },
+  "game": {
+    "memorize": {
+      "title": "Memorizza l'immagine!",
+      "timeLeft": "{{seconds}}s",
+      "imageInfo": "Livello {{level}} • {{strokeCount}} tratti"
+    },
+    "draw": {
+      "title": "Disegna l'immagine!",
+      "hint": "Usa i colori e disegna ciò che ricordi",
+      "tool": "Strumento",
+      "toolBrush": "🖊️ Pennello",
+      "toolFill": "💧 Riempi",
+      "strokeWidth": "Spessore tratto",
+      "strokeWidthThin": "Sottile",
+      "strokeWidthNormal": "Normale",
+      "strokeWidthThick": "Spesso",
+      "color": "Colore",
+      "selectColor": "Scegli colore",
+      "undo": "Annulla",
+      "clear": "Cancella tutto",
+      "clearConfirm": "Vuoi davvero cancellare tutto?",
+      "done": "Fatto",
+      "hintButton": "👁 1x",
+      "hintUsed": "Suggerimento usato",
+      "hintModalTitle": "Riferimento",
+      "drawFromMemory": "Disegna il",
+      "referenceLabel": "Vedi riferimento"
+    },
+    "tabs": {
+      "draw": "Disegna",
+      "result": "Risultato"
+    },
+    "result": {
+      "title": "Valutati:",
+      "howWell": "Quanto sei andato bene?",
+      "tapStars": "Tocca le stelle per valutarti!",
+      "starAccessibilityLabel": "{{rating}} stella{{plural}}",
+      "template": "Riferimento",
+      "feedback5": "Perfetto! Sei un maestro della memoria!",
+      "feedback4": "Molto bene! Quasi perfetto!",
+      "feedback3": "Ben fatto! Continua così!",
+      "feedback1": "È andata già meglio di prima, vuoi comunque riprovare?",
+      "yourDrawing": "Il tuo disegno",
+      "original": "Originale",
+      "rating": "La tua valutazione",
+      "retry": "Ancora",
+      "nextLevel": "Avanti",
+      "backToMenu": "Menu",
+      "allLevelsComplete": "Tutti i livelli completati!",
+      "allLevelsCompleteMessage": "Hai completato tutti i 20 livelli. Sei un vero campione della memoria!",
+      "playAgain": "Ricomincia",
+      "replay": "▶ Riproduci",
+      "replayStop": "⏹ Ferma"
+    }
+  },
+  "settings": {
+    "title": "Impostazioni",
+    "appearance": "Aspetto",
+    "theme": "Tema",
+    "themeLight": "Chiaro",
+    "themeDark": "Scuro",
+    "themeSystem": "Sistema",
+    "language": "Lingua",
+    "sound": "Effetti sonori",
+    "soundOn": "Attivo",
+    "soundOff": "Disattivo",
+    "music": "Musica di sottofondo",
+    "dataSection": "Dati",
+    "resetProgress": "Ripristina progressi",
+    "resetConfirm": "Vuoi davvero cancellare tutti i progressi?",
+    "resetConfirmMessage": "Vuoi davvero ripristinare i tuoi progressi? Questa azione non può essere annullata.",
+    "resetSuccess": "Progressi ripristinati",
+    "resetSuccessMessage": "I tuoi progressi di gioco sono stati ripristinati con successo.",
+    "languageChanged": "Lingua cambiata",
+    "languageChangedMessage": "La lingua è stata cambiata in italiano. Riavvia l'app affinché le modifiche abbiano effetto ovunque.",
+    "feedbackEmailSubject": "Feedback: Ricorda e Disegna",
+    "feedbackEmailBody": "Ciao,\n\nHo un feedback su Ricorda e Disegna:\n\n",
+    "feedbackEmailError": "Impossibile aprire il client email. Invia il tuo feedback a: devsven@posteo.de",
+    "browserError": "Impossibile aprire il browser. Visita: https://ko-fi.com/s540d",
+    "browserErrorGeneric": "Impossibile aprire il browser.",
+    "shareMessage": "Prova questa fantastica app per allenare la memoria: Ricorda e Disegna! https://github.com/S540d/DrawFromMemory",
+    "aboutSupport": "Informazioni e supporto",
+    "feedback": "Feedback",
+    "support": "Supporto",
+    "share": "Condividi",
+    "aboutButton": "Informazioni",
+    "aboutTitle": "Informazioni su Ricorda e Disegna",
+    "versionLabel": "Versione",
+    "licenseLabel": "Licenza",
+    "error": "Errore",
+    "about": "Informazioni sull'app",
+    "version": "Versione",
+    "personalize": "Personalizza",
+    "celebration": "Momento di festa (coriandoli e suono)"
+  },
+  "difficulty": {
+    "1": "Molto facile",
+    "2": "Facile",
+    "3": "Medio",
+    "4": "Difficile",
+    "5": "Molto difficile"
+  },
+  "gallery": {
+    "title": "La mia galleria",
+    "empty": "Nessun disegno salvato ancora. Disegna un'immagine e tocca \"Salva\"!",
+    "save": "Salva in galleria",
+    "saved": "Salvato!",
+    "delete": "Elimina",
+    "deleteTitle": "Elimina disegno",
+    "deleteConfirm": "Vuoi davvero eliminare questo disegno?",
+    "dailyChallengeLabel": "Sfida giornaliera",
+    "creativeLabel": "Disegno libero",
+    "share": "Condividi",
+    "shareError": "Condivisione non riuscita."
+  },
+  "creative": {
+    "title": "Disegno libero",
+    "imageName": "Disegno creativo"
+  },
+  "dailyChallenge": {
+    "title": "Sfida giornaliera",
+    "subtitle": "Immagine del giorno",
+    "start": "Inizia sfida",
+    "completed": "Completata per oggi ✓",
+    "countdown": "Nuova tra {{hours}}h {{minutes}}m",
+    "level": "Livello {{number}}"
+  },
+  "errors": {
+    "skiaUnavailableTitle": "Superficie di disegno non disponibile",
+    "skiaUnavailableMessage": "Non è stato possibile caricare la funzione di disegno.\nRiprova o riavvia l'app.",
+    "skiaLoading": "Caricamento superficie di disegno…",
+    "skiaRetry": "Riprova"
+  },
+  "common": {
+    "yes": "Sì",
+    "no": "No",
+    "cancel": "Annulla",
+    "ok": "OK",
+    "close": "Chiudi",
+    "back": "Indietro",
+    "settings": "Impostazioni"
+  },
+  "parentalGate": {
+    "title": "Controllo genitori",
+    "message": "Questo link porta fuori dall'app. Risolvi la sfida per continuare:",
+    "placeholder": "Inserisci risposta",
+    "confirm": "Apri",
+    "wrongAnswer": "Risposta sbagliata. Riprova."
+  },
+  "onboarding": {
+    "skip": "Salta",
+    "next": "Avanti",
+    "start": "Si parte!",
+    "step1": {
+      "title": "Memorizza",
+      "desc": "Guarda bene l'immagine per qualche secondo."
+    },
+    "step2": {
+      "title": "Disegna",
+      "desc": "Prova a disegnarla a memoria."
+    },
+    "step3": {
+      "title": "Stelle",
+      "desc": "Confronta il tuo disegno e guadagna stelle."
+    },
+    "welcomeTitle": "Pronto a giocare?",
+    "welcomeDesc": "Memorizza un'immagine, poi disegnala a memoria. Ti guideremo nel primo turno!",
+    "startButton": "Gioca!"
+  },
+  "parentDashboard": {
+    "menuLabel": "Area genitori",
+    "title": "Pannello genitori",
+    "subtitle": "Utilizzo del gioco nelle ultime 4 settimane",
+    "privacyHint": "Tutti i dati restano su questo dispositivo.",
+    "loading": "Caricamento statistiche…",
+    "empty": "Ancora nessuna sessione di gioco registrata.",
+    "totalSessions": "Sessioni",
+    "totalTime": "Tempo totale",
+    "avgStars": "Media stelle",
+    "streak": "Serie (attuale/migliore)",
+    "favoriteLevels": "Livelli preferiti",
+    "dailyBreakdown": "Per giorno (ultimi 14)",
+    "levelLine": "Livello {{level}} · giocato {{count}}×"
+  },
+  "achievements": {
+    "title": "Trofei",
+    "menuLabel": "Mostra trofei",
+    "unlocked": "Nuovo trofeo!",
+    "progress": "{{unlocked}} di {{total}} sbloccati",
+    "first_5_stars": {
+      "title": "Prime 5 stelle",
+      "desc": "Raggiungi 5 stelle in un livello per la prima volta."
+    },
+    "gallery_10": {
+      "title": "Artista di galleria",
+      "desc": "Salva 10 disegni nella tua galleria."
+    },
+    "streak_7": {
+      "title": "Serie di 7 giorni",
+      "desc": "Gioca 7 giorni di fila."
+    },
+    "all_levels_done": {
+      "title": "Tutti i livelli",
+      "desc": "Completa tutti i 10 livelli base."
+    },
+    "daily_5": {
+      "title": "Campione giornaliero",
+      "desc": "Supera la sfida giornaliera 5 volte."
+    },
+    "all_difficulties": {
+      "title": "Tuttofare",
+      "desc": "Gioca ogni livello di difficoltà almeno una volta."
+    }
+  },
+  "tutorial": {
+    "memorize": "Guarda bene l'immagine — hai solo pochi secondi!",
+    "draw": "Disegna ciò che hai visto a memoria. Senza stress! 😊",
+    "result": "Tocca le stelle — quanto sei andato bene?",
+    "tap": "Tocca per continuare",
+    "step": "Passo {{current}} di {{total}}",
+    "badgeMemorize": "Memorizza",
+    "badgeDraw": "Disegna",
+    "badgeResult": "Valuta"
+  }
+}

--- a/locales/nl/translations.json
+++ b/locales/nl/translations.json
@@ -1,0 +1,263 @@
+{
+  "app": {
+    "name": "Onthoud en Teken"
+  },
+  "home": {
+    "title": "Onthoud en Teken",
+    "subtitle": "Train je geheugen!",
+    "startButton": "Spel starten",
+    "continueButton": "Doorgaan",
+    "levelsButton": "Level kiezen",
+    "galleryButton": "Mijn galerij",
+    "creativeButton": "Creatief",
+    "settingsButton": "Instellingen",
+    "streakBadge": "🔥 {{count}}",
+    "stats": {
+      "stars": "Sterren",
+      "streak": "Reeks",
+      "levels": "Levels",
+      "streakDay": "dag",
+      "streakDays": "dagen",
+      "levelOf": "van {{total}}"
+    }
+  },
+  "levels": {
+    "title": "Level kiezen",
+    "level": "Level {{number}}",
+    "difficulty": "Moeilijkheid: {{diff}}",
+    "displayTime": "{{seconds}}s weergavetijd",
+    "stars": "{{count}} sterren",
+    "locked": "Vergrendeld",
+    "unlockHint": "Voltooi level {{prev}}",
+    "variant": {
+      "title": "Spelmodus",
+      "normal": "Normaal",
+      "outline": "Alleen omtrek",
+      "mirror": "Spiegelbeeld"
+    }
+  },
+  "game": {
+    "memorize": {
+      "title": "Onthoud de afbeelding!",
+      "timeLeft": "{{seconds}}s",
+      "imageInfo": "Level {{level}} • {{strokeCount}} lijnen"
+    },
+    "draw": {
+      "title": "Teken de afbeelding!",
+      "hint": "Gebruik de kleuren en teken wat je je herinnert",
+      "tool": "Gereedschap",
+      "toolBrush": "🖊️ Penseel",
+      "toolFill": "💧 Vullen",
+      "strokeWidth": "Lijndikte",
+      "strokeWidthThin": "Dun",
+      "strokeWidthNormal": "Normaal",
+      "strokeWidthThick": "Dik",
+      "color": "Kleur",
+      "selectColor": "Kleur kiezen",
+      "undo": "Ongedaan maken",
+      "clear": "Alles wissen",
+      "clearConfirm": "Echt alles wissen?",
+      "done": "Klaar",
+      "hintButton": "👁 1x",
+      "hintUsed": "Hint gebruikt",
+      "hintModalTitle": "Voorbeeld",
+      "drawFromMemory": "Teken de",
+      "referenceLabel": "Voorbeeld bekijken"
+    },
+    "tabs": {
+      "draw": "Tekenen",
+      "result": "Resultaat"
+    },
+    "result": {
+      "title": "Beoordeel jezelf:",
+      "howWell": "Hoe goed heb je het gedaan?",
+      "tapStars": "Tik op de sterren om jezelf te beoordelen!",
+      "starAccessibilityLabel": "{{rating}} ster{{plural}}",
+      "template": "Voorbeeld",
+      "feedback5": "Perfect! Je bent een geheugenmeester!",
+      "feedback4": "Heel goed! Bijna perfect!",
+      "feedback3": "Goed gedaan! Ga zo door!",
+      "feedback1": "Dat was al beter dan eerst, wil je het toch nog eens proberen?",
+      "yourDrawing": "Jouw tekening",
+      "original": "Origineel",
+      "rating": "Jouw beoordeling",
+      "retry": "Opnieuw",
+      "nextLevel": "Volgende",
+      "backToMenu": "Menu",
+      "allLevelsComplete": "Alle levels voltooid!",
+      "allLevelsCompleteMessage": "Je hebt alle 20 levels onder de knie. Je bent een echte geheugenkampioen!",
+      "playAgain": "Opnieuw beginnen",
+      "replay": "▶ Herhalen",
+      "replayStop": "⏹ Stoppen"
+    }
+  },
+  "settings": {
+    "title": "Instellingen",
+    "appearance": "Weergave",
+    "theme": "Thema",
+    "themeLight": "Licht",
+    "themeDark": "Donker",
+    "themeSystem": "Systeem",
+    "language": "Taal",
+    "sound": "Geluidseffecten",
+    "soundOn": "Aan",
+    "soundOff": "Uit",
+    "music": "Achtergrondmuziek",
+    "dataSection": "Gegevens",
+    "resetProgress": "Voortgang resetten",
+    "resetConfirm": "Echt alle voortgang verwijderen?",
+    "resetConfirmMessage": "Wil je je voortgang echt resetten? Deze actie kan niet ongedaan worden gemaakt.",
+    "resetSuccess": "Voortgang gereset",
+    "resetSuccessMessage": "Je speelvoortgang is succesvol gereset.",
+    "languageChanged": "Taal gewijzigd",
+    "languageChangedMessage": "De taal is gewijzigd naar Nederlands. Start de app opnieuw op zodat de wijzigingen overal doorgevoerd worden.",
+    "feedbackEmailSubject": "Feedback: Onthoud en Teken",
+    "feedbackEmailBody": "Hallo,\n\nIk heb feedback over Onthoud en Teken:\n\n",
+    "feedbackEmailError": "Kon e-mailclient niet openen. Stuur je feedback naar: devsven@posteo.de",
+    "browserError": "Kon browser niet openen. Bezoek: https://ko-fi.com/s540d",
+    "browserErrorGeneric": "Kon browser niet openen.",
+    "shareMessage": "Bekijk deze leuke geheugentraining-app: Onthoud en Teken! https://github.com/S540d/DrawFromMemory",
+    "aboutSupport": "Over & ondersteuning",
+    "feedback": "Feedback",
+    "support": "Ondersteuning",
+    "share": "Delen",
+    "aboutButton": "Over",
+    "aboutTitle": "Over Onthoud en Teken",
+    "versionLabel": "Versie",
+    "licenseLabel": "Licentie",
+    "error": "Fout",
+    "about": "Over de app",
+    "version": "Versie",
+    "personalize": "Personaliseren",
+    "celebration": "Feestmoment (confetti & geluid)"
+  },
+  "difficulty": {
+    "1": "Heel makkelijk",
+    "2": "Makkelijk",
+    "3": "Gemiddeld",
+    "4": "Moeilijk",
+    "5": "Heel moeilijk"
+  },
+  "gallery": {
+    "title": "Mijn galerij",
+    "empty": "Nog geen tekeningen opgeslagen. Teken een afbeelding en tik op \"Opslaan\"!",
+    "save": "Opslaan in galerij",
+    "saved": "Opgeslagen!",
+    "delete": "Verwijderen",
+    "deleteTitle": "Tekening verwijderen",
+    "deleteConfirm": "Wil je deze tekening echt verwijderen?",
+    "dailyChallengeLabel": "Dagelijkse uitdaging",
+    "creativeLabel": "Vrij tekenen",
+    "share": "Delen",
+    "shareError": "Delen is mislukt."
+  },
+  "creative": {
+    "title": "Vrij tekenen",
+    "imageName": "Creatieve tekening"
+  },
+  "dailyChallenge": {
+    "title": "Dagelijkse uitdaging",
+    "subtitle": "Afbeelding van de dag",
+    "start": "Uitdaging starten",
+    "completed": "Vandaag voltooid ✓",
+    "countdown": "Nieuw over {{hours}}u {{minutes}}m",
+    "level": "Level {{number}}"
+  },
+  "errors": {
+    "skiaUnavailableTitle": "Tekenoppervlak niet beschikbaar",
+    "skiaUnavailableMessage": "De tekenfunctie kon niet worden geladen.\nProbeer het opnieuw of start de app opnieuw op.",
+    "skiaLoading": "Tekenoppervlak laden…",
+    "skiaRetry": "Opnieuw proberen"
+  },
+  "common": {
+    "yes": "Ja",
+    "no": "Nee",
+    "cancel": "Annuleren",
+    "ok": "OK",
+    "close": "Sluiten",
+    "back": "Terug",
+    "settings": "Instellingen"
+  },
+  "parentalGate": {
+    "title": "Ouderlijk slot",
+    "message": "Deze link leidt buiten de app. Los de opdracht op om verder te gaan:",
+    "placeholder": "Antwoord invoeren",
+    "confirm": "Openen",
+    "wrongAnswer": "Fout antwoord. Probeer het opnieuw."
+  },
+  "onboarding": {
+    "skip": "Overslaan",
+    "next": "Volgende",
+    "start": "Laten we beginnen!",
+    "step1": {
+      "title": "Onthouden",
+      "desc": "Bekijk de afbeelding een paar seconden goed."
+    },
+    "step2": {
+      "title": "Tekenen",
+      "desc": "Probeer het uit je geheugen na te tekenen."
+    },
+    "step3": {
+      "title": "Sterren",
+      "desc": "Vergelijk je tekening en verdien sterren."
+    },
+    "welcomeTitle": "Klaar om te spelen?",
+    "welcomeDesc": "Onthoud een afbeelding en teken deze daarna uit je geheugen. We begeleiden je door de eerste ronde!",
+    "startButton": "Spelen!"
+  },
+  "parentDashboard": {
+    "menuLabel": "Ouderzone",
+    "title": "Ouderdashboard",
+    "subtitle": "Spelgebruik van de afgelopen 4 weken",
+    "privacyHint": "Alle gegevens blijven lokaal op dit apparaat.",
+    "loading": "Statistieken laden…",
+    "empty": "Nog geen spelsessies geregistreerd.",
+    "totalSessions": "Sessies",
+    "totalTime": "Totale tijd",
+    "avgStars": "Gem. sterren",
+    "streak": "Reeks (huidig/best)",
+    "favoriteLevels": "Favoriete levels",
+    "dailyBreakdown": "Per dag (laatste 14)",
+    "levelLine": "Level {{level}} · {{count}}× gespeeld"
+  },
+  "achievements": {
+    "title": "Trofeeën",
+    "menuLabel": "Trofeeën tonen",
+    "unlocked": "Nieuwe trofee!",
+    "progress": "{{unlocked}} van {{total}} ontgrendeld",
+    "first_5_stars": {
+      "title": "Eerste 5 sterren",
+      "desc": "Behaal voor het eerst 5 sterren in een level."
+    },
+    "gallery_10": {
+      "title": "Galerij-artiest",
+      "desc": "Sla 10 tekeningen op in je galerij."
+    },
+    "streak_7": {
+      "title": "7-daagse reeks",
+      "desc": "Speel 7 dagen achter elkaar."
+    },
+    "all_levels_done": {
+      "title": "Alle levels",
+      "desc": "Voltooi alle 10 basislevels."
+    },
+    "daily_5": {
+      "title": "Dagelijkse kampioen",
+      "desc": "Voltooi de dagelijkse uitdaging 5 keer."
+    },
+    "all_difficulties": {
+      "title": "Allrounder",
+      "desc": "Speel elke moeilijkheidsgraad minstens één keer."
+    }
+  },
+  "tutorial": {
+    "memorize": "Bekijk de afbeelding goed — je hebt maar een paar seconden!",
+    "draw": "Teken wat je uit je geheugen hebt gezien. Geen stress! 😊",
+    "result": "Tik op de sterren — hoe goed heb je het gedaan?",
+    "tap": "Tik om door te gaan",
+    "step": "Stap {{current}} van {{total}}",
+    "badgeMemorize": "Onthouden",
+    "badgeDraw": "Tekenen",
+    "badgeResult": "Beoordelen"
+  }
+}

--- a/locales/pl/translations.json
+++ b/locales/pl/translations.json
@@ -1,0 +1,263 @@
+{
+  "app": {
+    "name": "Zapamiętaj i Rysuj"
+  },
+  "home": {
+    "title": "Zapamiętaj i Rysuj",
+    "subtitle": "Trenuj swoją pamięć!",
+    "startButton": "Rozpocznij grę",
+    "continueButton": "Kontynuuj",
+    "levelsButton": "Wybierz poziom",
+    "galleryButton": "Moja galeria",
+    "creativeButton": "Kreatywny",
+    "settingsButton": "Ustawienia",
+    "streakBadge": "🔥 {{count}}",
+    "stats": {
+      "stars": "Gwiazdki",
+      "streak": "Seria",
+      "levels": "Poziomy",
+      "streakDay": "dzień",
+      "streakDays": "dni",
+      "levelOf": "z {{total}}"
+    }
+  },
+  "levels": {
+    "title": "Wybierz poziom",
+    "level": "Poziom {{number}}",
+    "difficulty": "Trudność: {{diff}}",
+    "displayTime": "{{seconds}}s wyświetlania",
+    "stars": "{{count}} gwiazdek",
+    "locked": "Zablokowany",
+    "unlockHint": "Ukończ poziom {{prev}}",
+    "variant": {
+      "title": "Tryb gry",
+      "normal": "Normalny",
+      "outline": "Tylko kontur",
+      "mirror": "Lustrzane odbicie"
+    }
+  },
+  "game": {
+    "memorize": {
+      "title": "Zapamiętaj obrazek!",
+      "timeLeft": "{{seconds}}s",
+      "imageInfo": "Poziom {{level}} • {{strokeCount}} kresek"
+    },
+    "draw": {
+      "title": "Narysuj obrazek!",
+      "hint": "Użyj kolorów i narysuj to, co zapamiętałeś",
+      "tool": "Narzędzie",
+      "toolBrush": "🖊️ Pędzel",
+      "toolFill": "💧 Wypełnij",
+      "strokeWidth": "Grubość linii",
+      "strokeWidthThin": "Cienka",
+      "strokeWidthNormal": "Normalna",
+      "strokeWidthThick": "Gruba",
+      "color": "Kolor",
+      "selectColor": "Wybierz kolor",
+      "undo": "Cofnij",
+      "clear": "Wyczyść wszystko",
+      "clearConfirm": "Na pewno wyczyścić wszystko?",
+      "done": "Gotowe",
+      "hintButton": "👁 1x",
+      "hintUsed": "Podpowiedź użyta",
+      "hintModalTitle": "Wzór",
+      "drawFromMemory": "Narysuj",
+      "referenceLabel": "Zobacz wzór"
+    },
+    "tabs": {
+      "draw": "Rysuj",
+      "result": "Wynik"
+    },
+    "result": {
+      "title": "Oceń się:",
+      "howWell": "Jak dobrze Ci poszło?",
+      "tapStars": "Dotknij gwiazdek, aby się ocenić!",
+      "starAccessibilityLabel": "{{rating}} gwiazdek{{plural}}",
+      "template": "Wzór",
+      "feedback5": "Idealnie! Jesteś mistrzem pamięci!",
+      "feedback4": "Bardzo dobrze! Prawie idealnie!",
+      "feedback3": "Dobra robota! Tak trzymaj!",
+      "feedback1": "Było już lepiej niż wcześniej, chcesz mimo to spróbować ponownie?",
+      "yourDrawing": "Twój rysunek",
+      "original": "Oryginał",
+      "rating": "Twoja ocena",
+      "retry": "Jeszcze raz",
+      "nextLevel": "Dalej",
+      "backToMenu": "Menu",
+      "allLevelsComplete": "Wszystkie poziomy ukończone!",
+      "allLevelsCompleteMessage": "Opanowałeś wszystkie 20 poziomów. Jesteś prawdziwym mistrzem pamięci!",
+      "playAgain": "Zacznij od nowa",
+      "replay": "▶ Powtórz",
+      "replayStop": "⏹ Zatrzymaj"
+    }
+  },
+  "settings": {
+    "title": "Ustawienia",
+    "appearance": "Wygląd",
+    "theme": "Motyw",
+    "themeLight": "Jasny",
+    "themeDark": "Ciemny",
+    "themeSystem": "Systemowy",
+    "language": "Język",
+    "sound": "Efekty dźwiękowe",
+    "soundOn": "Wł.",
+    "soundOff": "Wył.",
+    "music": "Muzyka w tle",
+    "dataSection": "Dane",
+    "resetProgress": "Resetuj postępy",
+    "resetConfirm": "Na pewno usunąć wszystkie postępy?",
+    "resetConfirmMessage": "Czy na pewno chcesz zresetować swoje postępy? Tej czynności nie można cofnąć.",
+    "resetSuccess": "Postępy zresetowane",
+    "resetSuccessMessage": "Twoje postępy w grze zostały pomyślnie zresetowane.",
+    "languageChanged": "Język zmieniony",
+    "languageChangedMessage": "Język został zmieniony na polski. Uruchom ponownie aplikację, aby zmiany zadziałały wszędzie.",
+    "feedbackEmailSubject": "Opinia: Zapamiętaj i Rysuj",
+    "feedbackEmailBody": "Cześć,\n\nMam opinię na temat Zapamiętaj i Rysuj:\n\n",
+    "feedbackEmailError": "Nie można otworzyć klienta e-mail. Prześlij opinię na adres: devsven@posteo.de",
+    "browserError": "Nie można otworzyć przeglądarki. Odwiedź: https://ko-fi.com/s540d",
+    "browserErrorGeneric": "Nie można otworzyć przeglądarki.",
+    "shareMessage": "Sprawdź tę świetną aplikację do trenowania pamięci: Zapamiętaj i Rysuj! https://github.com/S540d/DrawFromMemory",
+    "aboutSupport": "O aplikacji i wsparcie",
+    "feedback": "Opinia",
+    "support": "Wsparcie",
+    "share": "Udostępnij",
+    "aboutButton": "O aplikacji",
+    "aboutTitle": "O aplikacji Zapamiętaj i Rysuj",
+    "versionLabel": "Wersja",
+    "licenseLabel": "Licencja",
+    "error": "Błąd",
+    "about": "O aplikacji",
+    "version": "Wersja",
+    "personalize": "Personalizuj",
+    "celebration": "Moment świętowania (konfetti i dźwięk)"
+  },
+  "difficulty": {
+    "1": "Bardzo łatwy",
+    "2": "Łatwy",
+    "3": "Średni",
+    "4": "Trudny",
+    "5": "Bardzo trudny"
+  },
+  "gallery": {
+    "title": "Moja galeria",
+    "empty": "Brak zapisanych rysunków. Narysuj obrazek i dotknij \"Zapisz\"!",
+    "save": "Zapisz w galerii",
+    "saved": "Zapisano!",
+    "delete": "Usuń",
+    "deleteTitle": "Usuń rysunek",
+    "deleteConfirm": "Czy na pewno chcesz usunąć ten rysunek?",
+    "dailyChallengeLabel": "Codzienne wyzwanie",
+    "creativeLabel": "Rysowanie dowolne",
+    "share": "Udostępnij",
+    "shareError": "Udostępnianie nie powiodło się."
+  },
+  "creative": {
+    "title": "Rysowanie dowolne",
+    "imageName": "Kreatywny rysunek"
+  },
+  "dailyChallenge": {
+    "title": "Codzienne wyzwanie",
+    "subtitle": "Obrazek dnia",
+    "start": "Rozpocznij wyzwanie",
+    "completed": "Ukończono na dziś ✓",
+    "countdown": "Nowe za {{hours}}h {{minutes}}m",
+    "level": "Poziom {{number}}"
+  },
+  "errors": {
+    "skiaUnavailableTitle": "Powierzchnia rysowania niedostępna",
+    "skiaUnavailableMessage": "Nie udało się załadować funkcji rysowania.\nSpróbuj ponownie lub uruchom aplikację od nowa.",
+    "skiaLoading": "Ładowanie powierzchni rysowania…",
+    "skiaRetry": "Spróbuj ponownie"
+  },
+  "common": {
+    "yes": "Tak",
+    "no": "Nie",
+    "cancel": "Anuluj",
+    "ok": "OK",
+    "close": "Zamknij",
+    "back": "Wstecz",
+    "settings": "Ustawienia"
+  },
+  "parentalGate": {
+    "title": "Blokada rodzicielska",
+    "message": "Ten link prowadzi poza aplikację. Rozwiąż zadanie, aby kontynuować:",
+    "placeholder": "Wpisz odpowiedź",
+    "confirm": "Otwórz",
+    "wrongAnswer": "Błędna odpowiedź. Spróbuj ponownie."
+  },
+  "onboarding": {
+    "skip": "Pomiń",
+    "next": "Dalej",
+    "start": "Zaczynamy!",
+    "step1": {
+      "title": "Zapamiętaj",
+      "desc": "Przyjrzyj się uważnie obrazkowi przez kilka sekund."
+    },
+    "step2": {
+      "title": "Rysuj",
+      "desc": "Spróbuj narysować go z pamięci."
+    },
+    "step3": {
+      "title": "Gwiazdki",
+      "desc": "Porównaj swój rysunek i zdobądź gwiazdki."
+    },
+    "welcomeTitle": "Gotowy do gry?",
+    "welcomeDesc": "Zapamiętaj obrazek, a potem narysuj go z pamięci. Przeprowadzimy Cię przez pierwszą rundę!",
+    "startButton": "Graj!"
+  },
+  "parentDashboard": {
+    "menuLabel": "Strefa rodzica",
+    "title": "Panel rodzica",
+    "subtitle": "Użycie gry w ciągu ostatnich 4 tygodni",
+    "privacyHint": "Wszystkie dane pozostają lokalnie na tym urządzeniu.",
+    "loading": "Ładowanie statystyk…",
+    "empty": "Nie zarejestrowano jeszcze żadnych sesji gry.",
+    "totalSessions": "Sesje",
+    "totalTime": "Całkowity czas",
+    "avgStars": "Śr. gwiazdek",
+    "streak": "Seria (obecna/najlepsza)",
+    "favoriteLevels": "Ulubione poziomy",
+    "dailyBreakdown": "Dziennie (ostatnie 14)",
+    "levelLine": "Poziom {{level}} · zagrano {{count}}×"
+  },
+  "achievements": {
+    "title": "Trofea",
+    "menuLabel": "Pokaż trofea",
+    "unlocked": "Nowe trofeum!",
+    "progress": "{{unlocked}} z {{total}} odblokowanych",
+    "first_5_stars": {
+      "title": "Pierwsze 5 gwiazdek",
+      "desc": "Zdobądź po raz pierwszy 5 gwiazdek w poziomie."
+    },
+    "gallery_10": {
+      "title": "Artysta galerii",
+      "desc": "Zapisz 10 rysunków w swojej galerii."
+    },
+    "streak_7": {
+      "title": "7-dniowa seria",
+      "desc": "Graj 7 dni z rzędu."
+    },
+    "all_levels_done": {
+      "title": "Wszystkie poziomy",
+      "desc": "Ukończ wszystkie 10 podstawowych poziomów."
+    },
+    "daily_5": {
+      "title": "Codzienny mistrz",
+      "desc": "Pokonaj codzienne wyzwanie 5 razy."
+    },
+    "all_difficulties": {
+      "title": "Wszechstronny",
+      "desc": "Zagraj na każdym poziomie trudności przynajmniej raz."
+    }
+  },
+  "tutorial": {
+    "memorize": "Przyjrzyj się dokładnie obrazkowi — masz tylko kilka sekund!",
+    "draw": "Narysuj to, co zobaczyłeś, z pamięci. Bez stresu! 😊",
+    "result": "Dotknij gwiazdek — jak dobrze Ci poszło?",
+    "tap": "Dotknij, aby kontynuować",
+    "step": "Krok {{current}} z {{total}}",
+    "badgeMemorize": "Zapamiętaj",
+    "badgeDraw": "Rysuj",
+    "badgeResult": "Oceń"
+  }
+}

--- a/services/StorageManager.ts
+++ b/services/StorageManager.ts
@@ -96,7 +96,7 @@ export interface AppProgress {
 
 export interface AppSettings {
   theme: 'light' | 'dark' | 'system';
-  language: 'de' | 'en';
+  language: 'de' | 'en' | 'es' | 'fr' | 'it' | 'nl' | 'pl';
   soundEnabled: boolean;
   musicEnabled: boolean;
   extraTimeMode: boolean; // Add 5 seconds to all timers

--- a/services/__tests__/i18n.test.ts
+++ b/services/__tests__/i18n.test.ts
@@ -54,8 +54,21 @@ describe('i18n Service', () => {
       expect(getDeviceLanguage()).toBe('en');
     });
 
-    it('should fallback to English for unsupported locales', () => {
+    it('should detect additional supported locales (es/fr/it/nl/pl)', () => {
       Localization.getLocales.mockReturnValue([{ languageCode: 'fr' }]);
+      expect(getDeviceLanguage()).toBe('fr');
+      Localization.getLocales.mockReturnValue([{ languageCode: 'es' }]);
+      expect(getDeviceLanguage()).toBe('es');
+      Localization.getLocales.mockReturnValue([{ languageCode: 'it' }]);
+      expect(getDeviceLanguage()).toBe('it');
+      Localization.getLocales.mockReturnValue([{ languageCode: 'nl' }]);
+      expect(getDeviceLanguage()).toBe('nl');
+      Localization.getLocales.mockReturnValue([{ languageCode: 'pl' }]);
+      expect(getDeviceLanguage()).toBe('pl');
+    });
+
+    it('should fallback to English for unsupported locales', () => {
+      Localization.getLocales.mockReturnValue([{ languageCode: 'ja' }]);
       expect(getDeviceLanguage()).toBe('en');
     });
 

--- a/services/i18n.ts
+++ b/services/i18n.ts
@@ -5,14 +5,25 @@
 
 import de from '../locales/de/translations.json';
 import en from '../locales/en/translations.json';
+import es from '../locales/es/translations.json';
+import fr from '../locales/fr/translations.json';
+import it from '../locales/it/translations.json';
+import nl from '../locales/nl/translations.json';
+import pl from '../locales/pl/translations.json';
 import storageManager from './StorageManager';
 import * as Localization from 'expo-localization';
 
-type Language = 'de' | 'en';
+export type Language = 'de' | 'en' | 'es' | 'fr' | 'it' | 'nl' | 'pl';
 type TranslationKey = string;
 type LanguageChangeListener = (lang: Language) => void;
 
-const translations = { de, en };
+const SUPPORTED_LANGUAGES: Language[] = ['de', 'en', 'es', 'fr', 'it', 'nl', 'pl'];
+
+function isSupportedLanguage(value: unknown): value is Language {
+  return typeof value === 'string' && (SUPPORTED_LANGUAGES as string[]).includes(value);
+}
+
+const translations = { de, en, es, fr, it, nl, pl };
 let currentLanguage: Language = 'en';
 let isInitialized = false;
 const listeners: Set<LanguageChangeListener> = new Set();
@@ -38,12 +49,12 @@ export function addLanguageChangeListener(fn: LanguageChangeListener): () => voi
  * Detects the device's locale and returns a supported language
  * Falls back to 'en' if the device locale is not supported
  *
- * @returns {Language} The detected language code ('de' or 'en')
+ * @returns {Language} The detected language code (de/en/es/fr/it/nl/pl)
  * @example
  * // Device set to German
  * getDeviceLanguage() // returns 'de'
  *
- * // Device set to French (unsupported)
+ * // Device set to Japanese (unsupported)
  * getDeviceLanguage() // returns 'en' (fallback)
  */
 export function getDeviceLanguage(): Language {
@@ -51,12 +62,12 @@ export function getDeviceLanguage(): Language {
     // Get the device locale (e.g., "en-US", "de-DE", "fr-FR")
     const deviceLocale = Localization.getLocales()[0];
     const languageCode = deviceLocale?.languageCode;
-    
+
     // Check if the language code is supported
-    if (languageCode === 'de' || languageCode === 'en') {
-      return languageCode as Language;
+    if (isSupportedLanguage(languageCode)) {
+      return languageCode;
     }
-    
+
     // Default to English if language is not supported
     return 'en';
   } catch (error) {
@@ -78,7 +89,7 @@ export async function initLanguage(): Promise<void> {
   try {
     const savedLanguage = await storageManager.getSetting('language');
     // Only update if we got a valid language value
-    if (savedLanguage === 'de' || savedLanguage === 'en') {
+    if (isSupportedLanguage(savedLanguage)) {
       currentLanguage = savedLanguage;
     } else {
       // No saved language found, detect device language

--- a/types/index.ts
+++ b/types/index.ts
@@ -43,6 +43,12 @@ export interface RatingFeedback {
 export type GamePhase = 'memorize' | 'draw' | 'result';
 
 /**
+ * Spielvariante: 'normal' (Standard), 'outline' (nur Umriss merken),
+ * 'mirror' (Spiegelbild merken/zeichnen)
+ */
+export type GameVariant = 'normal' | 'outline' | 'mirror';
+
+/**
  * Level-Daten
  */
 export interface Level {
@@ -76,7 +82,7 @@ export interface UserProgress {
  * App-Settings (gespeichert in AsyncStorage)
  */
 export interface AppSettings {
-  language: 'de' | 'en';
+  language: 'de' | 'en' | 'es' | 'fr' | 'it' | 'nl' | 'pl';
   soundEnabled: boolean;
   musicEnabled: boolean;
 }


### PR DESCRIPTION
# Pull Request

## Beschreibung

Setzt drei Punkte aus Issue #247 um (Maßnahmenkatalog "App attraktiver machen"):

- **Spielvarianten**: Auf dem Level-Auswahl-Screen (`app/levels.tsx`) neu wählbar über Chips — "Normal", "Nur Umriss" und "Spiegelbild". Die Wahl wird als `?variant=` Query-Param an `/game` übergeben (`types/index.ts: GameVariant`).
  - `outline`: `LevelImageDisplay` entfernt rekursiv alle Füllfarben aus dem SVG-Baum und zeichnet nur eine einheitliche Kontur — die Erinnerung soll sich auf die Form statt auf Farben stützen.
  - `mirror`: `LevelImageDisplay` spiegelt die Anzeige horizontal (`transform: scaleX(-1)`).
  - Wirkt sowohl in der Memorize-Phase als auch im Hinweis-Modal der Draw-Phase.
- **Weitere Sprachen (ES/FR/IT/NL/PL)**: Vollständige Übersetzungen in `locales/{es,fr,it,nl,pl}/translations.json` (identische Schlüsselstruktur wie `en`, per Skript verifiziert). `i18n.ts` erkennt sie automatisch über `getDeviceLanguage()`/`initLanguage()` (bereits vorhandene Geräte-Spracherkennungs-Infrastruktur wurde nur um die neuen Sprachcodes erweitert) und sind im Sprachen-Umschalter der Einstellungen wählbar.
- **Kreativ-Modus**: War bereits vorhanden (`app/creative.tsx`, PR #255) — keine Änderung nötig, in `CLAUDE.md`-Roadmap nur als erledigt markiert.

`CLAUDE.md` wurde aktualisiert (Roadmap-Status, Datei-Übersicht, neuer Abschnitt "Spielvarianten").

## Art der Änderung

- [ ] Bugfix (non-breaking change)
- [x] Neue Funktion (non-breaking change)
- [ ] Breaking Change (Fix oder Feature das bestehende Funktionalität ändert)
- [x] Dokumentation Update

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Nein — reine Cross-Platform-Komponenten (React Native SVG, i18n, React Router-Navigation), keine `window.*`/`localStorage`-Zugriffe.

## Testing Checklist

- [x] Keine TypeScript Errors (`npx tsc --noEmit`)
- [x] Keine ESLint Warnings (`npm run lint`)
- [x] `npm run validate:svg-counts` erfolgreich
- [x] Vollständige Test-Suite grün (387/387, inkl. 5 neuer Tests für `LevelImageDisplay` outline/mirror-Logik)
- [ ] Manuelles Testen auf Android/iOS-Gerät (in dieser Cloud-Umgebung nicht möglich — nur automatisierte Checks)

## Zusätzliche Notizen

- `i18n.test.ts`: Test "should fallback to English for unsupported locales" nutzte bisher `fr` als Beispiel für eine nicht unterstützte Sprache — durch `ja` ersetzt, da `fr` jetzt unterstützt wird; neuer Test deckt alle 5 neuen Sprachen ab.
- Neue Locale-Dateien wurden automatisiert auf identische Schlüsselstruktur zu `en/translations.json` geprüft (kein fehlender/zusätzlicher Key).

## Reviewer Checklist

- [x] Code folgt den Projekt-Konventionen
- [x] Keine Web APIs ohne Platform-Check
- [x] Keine Hard-coded Values (Config/Env Vars verwenden)
- [x] Error Handling vorhanden
- [x] Keine sensiblen Daten im Code
- [x] Commit Messages sind aussagekräftig


---
_Generated by [Claude Code](https://claude.ai/code/session_012RcTMzZPmfFAGu3Pyg2Q7S)_