### PR TITLE
feat: Themen-Pack-Auswahl (Tiere/Fahrzeuge) auf Level-Screen

### DIFF
--- a/app/game.tsx
+++ b/app/game.tsx
@@ -70,6 +70,7 @@ export default function GameScreen() {
   const isDailyChallenge = params.daily === '1';
   const variant: GameVariant =
     params.variant === 'outline' || params.variant === 'mirror' ? params.variant : 'normal';
+  const pack = typeof params.pack === 'string' && params.pack !== 'all' ? params.pack : undefined;
   const [isTutorial, setIsTutorial] = useState(params.tutorial === '1');
   const [tutorialHintVisible, setTutorialHintVisible] = useState(true);
 
@@ -97,6 +98,7 @@ export default function GameScreen() {
     drawingPaths: drawing.paths,
     clearCanvas: drawing.clearCanvas,
     isDailyChallenge,
+    pack,
   });
 
   useEffect(() => {

--- a/app/levels.tsx
+++ b/app/levels.tsx
@@ -11,6 +11,7 @@ import { useRouter } from 'expo-router';
 import { useTranslation } from '@services/i18n';
 import { useTheme } from '@services/ThemeContext';
 import { getAllLevels } from '@services/LevelManager';
+import { getAvailablePacks } from '@services/ImagePoolManager';
 import storageManager from '@services/StorageManager';
 import Colors from '../constants/Colors';
 import { Spacing, FontSize, FontWeight, FontFamily, BorderRadius } from '../constants/Layout';
@@ -21,9 +22,16 @@ import { ChipGroup } from '@components/Chip';
 import type { GameVariant } from '../types';
 
 // Default card width for SSR (will be recalculated on client)
-const DEFAULT_CARD_WIDTH = 150;
+const DEFAULT_CARD_WIDTH = 100;
+const NUM_COLUMNS = 3;
 
 const VARIANT_KEYS: GameVariant[] = ['normal', 'outline', 'mirror'];
+
+// Themen-Pack-ID (z.B. 'tiere-v1') → kurzer i18n-Key (ohne Versionssuffix)
+const PACK_LABEL_KEYS: Record<string, string> = {
+  'tiere-v1': 'tiere',
+  'fahrzeuge-v1': 'fahrzeuge',
+};
 
 /**
  * Levels Screen - Level-Auswahl
@@ -34,11 +42,16 @@ export default function LevelsScreen() {
   const router = useRouter();
   const { colors, theme } = useTheme();
   const levels = useMemo(() => getAllLevels(), []);
+  const packs = useMemo(() => ['all', ...getAvailablePacks()], []);
   const [ratings, setRatings] = useState<Record<number, number | null>>({});
   const [variant, setVariant] = useState<GameVariant>('normal');
+  const [pack, setPack] = useState<string>('all');
   // Use hook for responsive dimensions (SSR-safe)
   const { width: screenWidth } = useWindowDimensions();
-  const cardWidth = screenWidth > 0 ? (screenWidth - Spacing.lg * 3) / 2 : DEFAULT_CARD_WIDTH;
+  const cardWidth =
+    screenWidth > 0
+      ? (screenWidth - Spacing.lg * (NUM_COLUMNS + 1)) / NUM_COLUMNS
+      : DEFAULT_CARD_WIDTH;
 
   const glassSurface = theme === 'dark' ? Colors.glass.darkSurface : Colors.glass.lightSurface;
   const glassBorder = theme === 'dark' ? Colors.glass.darkBorder : Colors.glass.lightBorder;
@@ -83,7 +96,7 @@ export default function LevelsScreen() {
     return (
       <GlassCard
         index={index}
-        onPress={() => router.push(`/game?level=${item.number}&variant=${variant}`)}
+        onPress={() => router.push(`/game?level=${item.number}&variant=${variant}&pack=${pack}`)}
         accessibilityLabel={`${t('levels.level', { number: item.number })} — ${difficultyText}`}
         style={[
           styles.levelCard,
@@ -138,12 +151,29 @@ export default function LevelsScreen() {
         />
       </View>
 
+      {/* Themen-Pack */}
+      {packs.length > 1 && (
+        <View style={styles.variantSection}>
+          <Text style={[styles.variantLabel, { color: colors.text.secondary }]}>
+            {t('levels.pack.title')}
+          </Text>
+          <ChipGroup
+            options={packs.map(p => t(`levels.pack.${PACK_LABEL_KEYS[p] ?? p}`))}
+            selected={t(`levels.pack.${PACK_LABEL_KEYS[pack] ?? pack}`)}
+            onSelect={label => {
+              const match = packs.find(p => t(`levels.pack.${PACK_LABEL_KEYS[p] ?? p}`) === label);
+              if (match) setPack(match);
+            }}
+          />
+        </View>
+      )}
+
       {/* Level-Grid */}
       <FlatList
         data={levels}
         renderItem={renderLevelCard}
         keyExtractor={item => `level-${item.number}`}
-        numColumns={2}
+        numColumns={NUM_COLUMNS}
         columnWrapperStyle={styles.row}
         contentContainerStyle={styles.listContent}
         showsVerticalScrollIndicator={false}
@@ -187,28 +217,28 @@ const styles = StyleSheet.create({
   },
   row: {
     justifyContent: 'space-between',
-    marginBottom: Spacing.lg,
+    marginBottom: Spacing.sm,
   },
   levelCard: {
-    borderRadius: BorderRadius.xxl,
-    padding: Spacing.md,
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.sm,
     borderWidth: 1.5,
   },
   levelHeader: {
-    marginBottom: Spacing.sm,
+    marginBottom: Spacing.xs,
   },
   levelNumber: {
-    fontSize: FontSize.xl,
+    fontSize: FontSize.md,
     fontWeight: FontWeight.bold,
   },
   difficultyBadge: {
-    marginBottom: Spacing.sm,
+    marginBottom: Spacing.xs,
   },
   starsRow: {
     flexDirection: 'row',
     marginTop: Spacing.xs,
   },
   star: {
-    fontSize: FontSize.lg,
+    fontSize: FontSize.sm,
   },
 });

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -34,6 +34,12 @@
       "normal": "Normal",
       "outline": "Nur Umriss",
       "mirror": "Spiegelbild"
+    },
+    "pack": {
+      "title": "Themen-Pack",
+      "all": "Alle",
+      "tiere": "Tiere",
+      "fahrzeuge": "Fahrzeuge"
     }
   },
   "game": {

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -34,6 +34,12 @@
       "normal": "Normal",
       "outline": "Outline only",
       "mirror": "Mirror image"
+    },
+    "pack": {
+      "title": "Theme pack",
+      "all": "All",
+      "tiere": "Animals",
+      "fahrzeuge": "Vehicles"
     }
   },
   "game": {

--- a/locales/es/translations.json
+++ b/locales/es/translations.json
@@ -34,6 +34,12 @@
       "normal": "Normal",
       "outline": "Solo contorno",
       "mirror": "Imagen espejo"
+    },
+    "pack": {
+      "title": "Paquete temático",
+      "all": "Todos",
+      "tiere": "Animales",
+      "fahrzeuge": "Vehículos"
     }
   },
   "game": {

--- a/locales/fr/translations.json
+++ b/locales/fr/translations.json
@@ -34,6 +34,12 @@
       "normal": "Normal",
       "outline": "Contour seulement",
       "mirror": "Image miroir"
+    },
+    "pack": {
+      "title": "Pack thématique",
+      "all": "Tous",
+      "tiere": "Animaux",
+      "fahrzeuge": "Véhicules"
     }
   },
   "game": {

--- a/locales/it/translations.json
+++ b/locales/it/translations.json
@@ -34,6 +34,12 @@
       "normal": "Normale",
       "outline": "Solo contorno",
       "mirror": "Immagine speculare"
+    },
+    "pack": {
+      "title": "Pacchetto tematico",
+      "all": "Tutti",
+      "tiere": "Animali",
+      "fahrzeuge": "Veicoli"
     }
   },
   "game": {

--- a/locales/nl/translations.json
+++ b/locales/nl/translations.json
@@ -34,6 +34,12 @@
       "normal": "Normaal",
       "outline": "Alleen omtrek",
       "mirror": "Spiegelbeeld"
+    },
+    "pack": {
+      "title": "Themapakket",
+      "all": "Alle",
+      "tiere": "Dieren",
+      "fahrzeuge": "Voertuigen"
     }
   },
   "game": {

--- a/locales/pl/translations.json
+++ b/locales/pl/translations.json
@@ -34,6 +34,12 @@
       "normal": "Normalny",
       "outline": "Tylko kontur",
       "mirror": "Lustrzane odbicie"
+    },
+    "pack": {
+      "title": "Pakiet tematyczny",
+      "all": "Wszystkie",
+      "tiere": "Zwierzęta",
+      "fahrzeuge": "Pojazdy"
     }
   },
   "game": {

--- a/services/ImagePoolManager.ts
+++ b/services/ImagePoolManager.ts
@@ -488,14 +488,17 @@ let lastShownImages: string[] = [];
 /**
  * Wählt ein zufälliges Bild für ein Level aus
  * @param levelNumber Level-Nummer (1-10)
+ * @param pack Optionale Themen-Pack-Einschränkung (z.B. 'tiere-v1'). 'all' oder undefined = kein Filter.
  * @returns Zufälliges Bild aus dem passenden Schwierigkeitspool
  */
-export function getRandomImageForLevel(levelNumber: number): LevelImage {
+export function getRandomImageForLevel(levelNumber: number, pack?: string): LevelImage {
   const targetDifficulty = getDifficultyForLevel(levelNumber);
-  const isEligible = (img: LevelImage) =>
+  const matchesDifficulty = (img: LevelImage) =>
     img.difficulty === targetDifficulty && (!img.minLevel || img.minLevel <= levelNumber);
+  const matchesPack = (img: LevelImage) => !pack || pack === 'all' || img.pack === pack;
+  const isEligible = (img: LevelImage) => matchesDifficulty(img) && matchesPack(img);
 
-  // Filtere Bilder nach Schwierigkeit, minLevel-Guard UND nicht kürzlich gezeigt
+  // Filtere Bilder nach Schwierigkeit, Pack, minLevel-Guard UND nicht kürzlich gezeigt
   let availableImages = imagePool.filter(
     img => isEligible(img) && !lastShownImages.includes(img.filename),
   );
@@ -504,6 +507,11 @@ export function getRandomImageForLevel(levelNumber: number): LevelImage {
   if (availableImages.length === 0) {
     lastShownImages = [];
     availableImages = imagePool.filter(isEligible);
+  }
+
+  // Falls das gewählte Pack für diese Schwierigkeit keine Bilder hat, Pack-Filter ignorieren
+  if (availableImages.length === 0) {
+    availableImages = imagePool.filter(matchesDifficulty);
   }
 
   // Wähle zufällig aus verfügbaren Bildern
@@ -524,16 +532,38 @@ export function getRandomImageForLevel(levelNumber: number): LevelImage {
  * Wird für die Daily Challenge verwendet, damit das Bild des Tages konstant bleibt.
  * @param levelNumber Level-Nummer
  * @param seed Numerischer Seed (z. B. YYYYMMDD)
+ * @param pack Optionale Themen-Pack-Einschränkung (z.B. 'tiere-v1'). 'all' oder undefined = kein Filter.
  */
-export function getSeededImageForLevel(levelNumber: number, seed: number): LevelImage {
+export function getSeededImageForLevel(
+  levelNumber: number,
+  seed: number,
+  pack?: string,
+): LevelImage {
   const targetDifficulty = getDifficultyForLevel(levelNumber);
-  const available = imagePool.filter(
-    img => img.difficulty === targetDifficulty && (!img.minLevel || img.minLevel <= levelNumber),
-  );
-  if (available.length === 0) return getRandomImageForLevel(levelNumber);
-  if (!Number.isFinite(seed)) return getRandomImageForLevel(levelNumber);
+  const matchesDifficulty = (img: LevelImage) =>
+    img.difficulty === targetDifficulty && (!img.minLevel || img.minLevel <= levelNumber);
+  const matchesPack = (img: LevelImage) => !pack || pack === 'all' || img.pack === pack;
+
+  let available = imagePool.filter(img => matchesDifficulty(img) && matchesPack(img));
+  // Falls das gewählte Pack für diese Schwierigkeit keine Bilder hat, Pack-Filter ignorieren
+  if (available.length === 0) {
+    available = imagePool.filter(matchesDifficulty);
+  }
+  if (available.length === 0) return getRandomImageForLevel(levelNumber, pack);
+  if (!Number.isFinite(seed)) return getRandomImageForLevel(levelNumber, pack);
   const index = Math.abs(Math.floor(seed)) % available.length;
   return available[index];
+}
+
+/**
+ * Gibt alle im Bilderpool vorkommenden Themen-Pack-IDs zurück (z.B. ['fahrzeuge-v1', 'tiere-v1'])
+ */
+export function getAvailablePacks(): string[] {
+  const packs = new Set<string>();
+  imagePool.forEach(img => {
+    if (img.pack) packs.add(img.pack);
+  });
+  return Array.from(packs).sort();
 }
 
 /**

--- a/services/useGamePhase.ts
+++ b/services/useGamePhase.ts
@@ -18,16 +18,21 @@ interface UseGamePhaseOptions {
   drawingPaths: DrawingPath[];
   clearCanvas: () => void;
   isDailyChallenge?: boolean;
+  pack?: string;
 }
 
-function getImageForLevel(levelNumber: number, dailyChallengeLevel: number | null): LevelImage {
+function getImageForLevel(
+  levelNumber: number,
+  dailyChallengeLevel: number | null,
+  pack?: string,
+): LevelImage {
   if (dailyChallengeLevel !== null && levelNumber === dailyChallengeLevel) {
     const dateKey = getDailyChallengeKey();
     const rawSeed = parseInt(dateKey.replace(/-/g, ''), 10);
     const seed = Number.isFinite(rawSeed) ? Math.abs(rawSeed) : 0;
-    return getSeededImageForLevel(levelNumber, seed);
+    return getSeededImageForLevel(levelNumber, seed, pack);
   }
-  return getRandomImageForLevel(levelNumber);
+  return getRandomImageForLevel(levelNumber, pack);
 }
 
 export function useGamePhase({
@@ -35,6 +40,7 @@ export function useGamePhase({
   drawingPaths,
   clearCanvas,
   isDailyChallenge = false,
+  pack,
 }: UseGamePhaseOptions) {
   const router = useRouter();
   // dailyChallengeLevel is fixed at mount; only the initial level counts as the
@@ -86,7 +92,7 @@ export function useGamePhase({
   // For the daily challenge level, use a date-seeded image so it stays consistent all day.
   useEffect(() => {
     try {
-      const image: LevelImage = getImageForLevel(levelNumber, dailyChallengeLevel);
+      const image: LevelImage = getImageForLevel(levelNumber, dailyChallengeLevel, pack);
       currentImageRef.current = image;
       setCurrentImage(image);
       levelStartedAtRef.current = Date.now();
@@ -94,7 +100,7 @@ export function useGamePhase({
       console.error('Error initializing level:', error);
       router.back();
     }
-  }, [levelNumber, dailyChallengeLevel, router]);
+  }, [levelNumber, dailyChallengeLevel, pack, router]);
 
   // Update timer when levelNumber or extraTimeMode changes (separate from image init)
   useEffect(() => {
@@ -237,7 +243,7 @@ export function useGamePhase({
     // Re-trigger level-init useEffect by setting a fresh image + time directly
     // (levelNumber doesn't change, so we init manually here)
     try {
-      const image: LevelImage = getImageForLevel(levelNumber, dailyChallengeLevel);
+      const image: LevelImage = getImageForLevel(levelNumber, dailyChallengeLevel, pack);
       currentImageRef.current = image;
       setCurrentImage(image);
       setTimeRemaining(getDisplayDuration(levelNumber, extraTimeMode));


### PR DESCRIPTION
## Beschreibung

Tiere-v1 und Fahrzeuge-v1 waren bisher nur interne `pack`-Tags im Bilderpool ohne jede Filterwirkung — die Bilder erschienen rein zufällig innerhalb ihres Schwierigkeitsgrads, ohne dass Spieler:innen gezielt ein Thema auswählen konnten. Dieser PR fügt eine echte Themen-Pack-Auswahl hinzu und macht das Level-Grid kompakter, um Scrollen bei 20 Levels zu reduzieren.

- `services/ImagePoolManager.ts`: `getRandomImageForLevel()` / `getSeededImageForLevel()` filtern jetzt optional nach `pack`, mit Fallback auf den vollen Schwierigkeitspool falls ein Pack für ein Level leer ist. Neue Funktion `getAvailablePacks()`.
- `services/useGamePhase.ts` / `app/game.tsx`: neuer `pack`-Query-Parameter wird durchgereicht.
- `app/levels.tsx`: neuer Chip-Filter „Themen-Pack" (Alle/Tiere/Fahrzeuge) analog zur bestehenden Spielvarianten-Auswahl. Level-Grid von 2 auf 3 Spalten mit kompakteren Karten (weniger Innenabstand, kleinere Schrift) umgestellt.
- Übersetzungen für `levels.pack.*` in allen 7 Sprachen (de/en/es/fr/it/nl/pl) ergänzt.

## Art der Änderung

- [x] Neue Funktion (non-breaking change)

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Nein — reine React-Native-Komponenten/Business-Logik, kein Web-API-Zugriff.

## Testing Checklist

- [x] Lokaler Build erfolgreich (`npx tsc --noEmit`)
- [x] Keine TypeScript Errors
- [x] Keine ESLint Warnings
- [x] `npm run validate:svg-counts` (51/51 Einträge)
- [x] Volle Testsuite grün (389/389 Tests)
- [ ] Manuell auf Android/iOS getestet (nicht in dieser Umgebung möglich)

## Zusätzliche Notizen

Branch `testing` existierte nicht mehr im Remote (vermutlich nach letztem Merge gelöscht) und wurde frisch von `main` neu angelegt, um dem in CLAUDE.md dokumentierten Workflow `feature → testing → main` zu folgen.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CModEukkySa6KyHBYZ7Sei)_