### PR TITLE
Release: Themen-Pack-Auswahl + Draw-UX-Fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Spieler sehen ein Bild kurz, zeichnen es aus dem Gedächtnis, vergleichen das Er
 | Theming         | ThemeContext (light / dark / system)                                                                         |
 | Sound           | Web Audio API (web) + `expo-haptics` (native)                                                                |
 | i18n            | Custom `services/i18n.ts` (de/en/es/fr/it/nl/pl), Locales in `locales/`, automatische Geräte-Spracherkennung |
-| Tests           | Jest 29 + jest-expo ~55 (373+ Tests, jsdom-Environment)                                                      |
+| Tests           | Jest 29 + jest-expo ~55 (389+ Tests, jsdom-Environment)                                                      |
 | CI              | GitHub Actions (`.github/workflows/ci-cd.yml`)                                                               |
 | Build (Native)  | EAS Build (`eas.json`)                                                                                       |
 | Crash Reporting | Sentry via `EXPO_PUBLIC_SENTRY_DSN` (optional, no-op on Web)                                                 |
@@ -66,7 +66,7 @@ services/
   FloodFillService.ts        # Flood-Fill-Algorithmus (Scanline, 1-Bit-Palette)
   SoftwareRasterizer.ts      # CPU-Rasterizer für native Fill-Grenzenerkennung
   NativeFillLayerService.ts  # Konvertiert DrawingPath[] → native Skia Rect-Spans
-  ImagePoolManager.ts        # Bilderpool: wählt zufällige Bilder nach Schwierigkeit
+  ImagePoolManager.ts        # Bilderpool: wählt zufällige Bilder nach Schwierigkeit (+ optionaler Pack-Filter)
   LevelManager.ts            # Level-Definitionen (10 Level, Anzeigedauer, Difficulty)
   StorageManager.ts          # AsyncStorage-Wrapper mit In-Memory-Fallback für Web
   RatingManager.ts           # Stern-Bewertungen und rotierende Motivations-Nachrichten
@@ -179,6 +179,12 @@ memorize  →  draw  →  result
 Level-Anzahl: 20 (Difficulty 1–5). Alle Level haben 3 s Anzeigezeit.
 Bilderpool: `ImagePoolManager.ts` wählt zufällig nach Difficulty-Klasse aus. Aktuell **51 Bilder** (inkl. Tiere v1 Pack — 10 Tiere, PR #221 + Fahrzeuge v1 Pack — 10 Fahrzeuge, PR #254).
 
+Fortschrittsanzeige oben im Spielschirm (`app/game.tsx`): proportionaler Balken (`levelNumber / totalLevels`), kein Punkte-Indikator mehr (PR #272 — die vorherigen 5 fest codierten Punkte waren bei 20 Levels irreführend).
+
+### Themen-Pack-Auswahl (PR #271)
+
+Auf dem Level-Auswahl-Screen (`app/levels.tsx`) gibt es neben der Spielvarianten-Auswahl einen zweiten Chip-Filter „Themen-Pack" (Alle / Tiere / Fahrzeuge), sofern der Bilderpool getaggte Packs enthält (`getAvailablePacks()` in `ImagePoolManager.ts`). Die Auswahl wird als `?pack=`-Query-Param an `/game` durchgereicht und schränkt `getRandomImageForLevel()` / `getSeededImageForLevel()` auf Bilder mit passendem `pack`-Tag ein — mit Fallback auf den vollen Schwierigkeitspool, falls ein Pack für ein Level leer ist.
+
 ### Spielvarianten (Issue #247)
 
 Auf dem Level-Auswahl-Screen (`app/levels.tsx`) wählbar (`GameVariant` in `types/index.ts`), wird als `?variant=` Query-Param an `/game` übergeben:
@@ -213,6 +219,10 @@ interface DrawingPath {
   type?: 'stroke' | 'fill'; // default = 'stroke'
 }
 ```
+
+### Werkzeug-Icons in der Draw-Phase (PR #272)
+
+`components/game/ToolIcons.tsx` exportiert `PenIcon`, `FillIcon`, `EyeIcon` — abstrakte, einfarbige SVG-Piktogramme (via `react-native-svg`) für Pinsel/Füllen/Vorlage-ansehen in `DrawPhase.tsx`, statt bunter Emoji (✏️ 🪣 👁). Farbe wird komplett über den `color`-Prop gesteuert (aktiv = weiß, inaktiv = `colors.text.secondary`). Die Strichstärken-Auswahl (klein/mittel/groß) zeigt bei allen drei Punkten einheitlich `drawing.color`; die aktive Größe wird über einen Ring (`borderColor`) markiert, nicht über unterschiedliche Punktfarben.
 
 ---
 
@@ -354,7 +364,7 @@ Niemals `rotation`/`origin`-Props an SVG-Elemente geben, die auch auf Web gerend
 ### Tests
 
 - Test-Dateien liegen bei `services/__tests__/`, `components/__tests__/`, `utils/__tests__/`, `__tests__/`
-- Jest-Umgebung: `jsdom`; Skia wird gemockt via `__mocks__/@shopify/react-native-skia.js`
+- Jest-Umgebung: `jsdom`; Skia wird gemockt via `__mocks__/@shopify/react-native-skia.js`, `react-native-svg` via `__mocks__/react-native-svg.js` (beide global, automatisch für alle Tests aktiv — kein `jest.mock()`-Aufruf nötig)
 - `@testing-library/dom` muss installiert sein (Peer-Dep von `@testing-library/react` v16)
 - `npm test` (kein `--runInBand` nötig, aber stabil)
 
@@ -371,7 +381,7 @@ Niemals `rotation`/`origin`-Props an SVG-Elemente geben, die auch auf Web gerend
 ## Wachstums-Roadmap (Issue #219)
 
 Übergeordneter Plan, um aus der App eine dauerhaft wachsende Kids-App im Play Store zu machen.
-Stand: `main` @ v1.7.0 / versionCode 66 — `testing` synchron. Enthält Fahrzeuge v1, PNG-Export, Mini-Tutorial, Design-System Phase C/D-Polish, Spielvarianten, weitere Sprachen, Sentry-ErrorBoundary (#264) und den transform-origin Web-Fix (#265). **Play Store noch nicht auf v1.7.0** — Release-Aufgabe in Issue #267.
+Stand: `main` @ v1.7.0 / versionCode 66. `testing` liegt voraus: enthält zusätzlich die Themen-Pack-Auswahl-UI (PR #271) und die Draw-UX-Fixes (Icons/Strichstärken-Farbe/Fortschrittsbalken, PR #272) — noch nicht in `main` gemerged. Enthält Fahrzeuge v1, PNG-Export, Mini-Tutorial, Design-System Phase C/D-Polish, Spielvarianten, weitere Sprachen, Sentry-ErrorBoundary (#264) und den transform-origin Web-Fix (#265). **Play Store noch nicht auf v1.7.0** — Release-Aufgabe in Issue #267.
 
 ### P0 — Foundation für Wachstum
 
@@ -389,6 +399,7 @@ Stand: `main` @ v1.7.0 / versionCode 66 — `testing` synchron. Enthält Fahrzeu
 | ------------------------------------------------------------------------ | ------------------- |
 | **Themen-Pack Tiere v1** (10 Bilder, #222)                               | ✅ in main (v1.7.0) |
 | **Themen-Pack Fahrzeuge v1** (10 Bilder, PR #254)                        | ✅ in main (v1.7.0) |
+| **Themen-Pack-Auswahl-UI** (Chip-Filter Alle/Tiere/Fahrzeuge, PR #271)   | ✅ in `testing`     |
 | Themen-Pack Natur / Märchen / weitere                                    | 🔲 offen            |
 | **Spielvarianten** (Nur Umriss merken, Spiegelbild, Kreativ-Modus, #247) | ✅ in main (v1.7.0) |
 | Avatar & Personalisierung                                                | 🔲 offen            |
@@ -404,12 +415,14 @@ Stand: `main` @ v1.7.0 / versionCode 66 — `testing` synchron. Enthält Fahrzeu
 | **Sharing-Feature / PNG-Export** (ShareService, PR #255) | ✅ in main (v1.7.0)                                       |
 | Push-Notifications (opt-in)                              | 🔲 offen                                                  |
 
-### Themen-Pack Architektur (ab PR #221)
+### Themen-Pack Architektur (ab PR #221, Auswahl-UI ab PR #271)
 
 - `LevelImage.pack?: string` — optionaler Tag (z.B. `'tiere-v1'`)
 - Bilder ohne `minLevel` sind ab dem passenden Difficulty-Level verfügbar
 - Neue Packs: einfach neue Cases in `LevelImageDisplay.tsx` + Einträge in `ImagePoolManager.ts` + `IMAGE_ELEMENT_COUNTS`
 - Pflicht nach jedem neuen SVG: `npm run validate:svg-counts` (derzeit 51 Einträge)
+- `getAvailablePacks()` (`ImagePoolManager.ts`) liefert alle im Pool vorkommenden Pack-IDs für die Chip-Filter-UI in `app/levels.tsx`
+- Neue Packs erscheinen automatisch als Filteroption — für ein sprechendes Label in der UI zusätzlich einen Eintrag in `PACK_LABEL_KEYS` (`app/levels.tsx`) sowie `levels.pack.<label>` in allen 7 Locale-Dateien ergänzen
 
 ---
 

--- a/__mocks__/react-native-svg.js
+++ b/__mocks__/react-native-svg.js
@@ -1,0 +1,24 @@
+// Mock for react-native-svg
+// Its Fabric native components aren't available under the jsdom-based Jest
+// environment, so we render plain View stand-ins instead.
+const React = require('react');
+const { View } = require('react-native');
+
+function passthrough(name) {
+  const Comp = props => React.createElement(View, { ...props, testID: name });
+  Comp.displayName = name;
+  return Comp;
+}
+
+module.exports = {
+  __esModule: true,
+  default: passthrough('Svg'),
+  Svg: passthrough('Svg'),
+  Circle: passthrough('Circle'),
+  Ellipse: passthrough('Ellipse'),
+  Rect: passthrough('Rect'),
+  Line: passthrough('Line'),
+  Path: passthrough('Path'),
+  Polygon: passthrough('Polygon'),
+  G: passthrough('G'),
+};

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -70,6 +70,7 @@ export default function GameScreen() {
   const isDailyChallenge = params.daily === '1';
   const variant: GameVariant =
     params.variant === 'outline' || params.variant === 'mirror' ? params.variant : 'normal';
+  const pack = typeof params.pack === 'string' && params.pack !== 'all' ? params.pack : undefined;
   const [isTutorial, setIsTutorial] = useState(params.tutorial === '1');
   const [tutorialHintVisible, setTutorialHintVisible] = useState(true);
 
@@ -97,6 +98,7 @@ export default function GameScreen() {
     drawingPaths: drawing.paths,
     clearCanvas: drawing.clearCanvas,
     isDailyChallenge,
+    pack,
   });
 
   useEffect(() => {

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -234,17 +234,15 @@ export default function GameScreen() {
           </Text>
         </TouchableOpacity>
         <View style={styles.headerRight}>
-          <View style={styles.progressDots}>
-            {Array.from({ length: Math.min(getTotalLevels(), 5) }).map((_, i) => (
-              <View
-                key={i}
-                style={[
-                  styles.progressDot,
-                  i < levelNumber - 1 && styles.progressDotDone,
-                  i === levelNumber - 1 && styles.progressDotCurrent,
-                ]}
-              />
-            ))}
+          <View
+            style={styles.progressBarTrack}
+            accessibilityRole="progressbar"
+            accessibilityValue={{ min: 1, max: totalLevels, now: levelNumber }}
+            accessibilityLabel={t('levels.level', { number: levelNumber })}
+          >
+            <View
+              style={[styles.progressBarFill, { width: `${(levelNumber / totalLevels) * 100}%` }]}
+            />
           </View>
           <TouchableOpacity
             onPress={() => setShowSettings(true)}
@@ -446,28 +444,17 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: Spacing.sm,
   },
-  progressDots: {
-    flexDirection: 'row',
-    gap: 4,
-    alignItems: 'center',
-  },
-  progressDot: {
-    width: 8,
+  progressBarTrack: {
+    width: 60,
     height: 8,
     borderRadius: 4,
     backgroundColor: '#ddd5c8',
+    overflow: 'hidden',
   },
-  progressDotDone: {
+  progressBarFill: {
+    height: '100%',
+    borderRadius: 4,
     backgroundColor: Colors.primary,
-    width: 10,
-    height: 10,
-    borderRadius: 5,
-  },
-  progressDotCurrent: {
-    backgroundColor: Colors.secondary,
-    width: 10,
-    height: 10,
-    borderRadius: 5,
   },
   tabBar: {
     flexDirection: 'row',

--- a/app/levels.tsx
+++ b/app/levels.tsx
@@ -11,6 +11,7 @@ import { useRouter } from 'expo-router';
 import { useTranslation } from '@services/i18n';
 import { useTheme } from '@services/ThemeContext';
 import { getAllLevels } from '@services/LevelManager';
+import { getAvailablePacks } from '@services/ImagePoolManager';
 import storageManager from '@services/StorageManager';
 import Colors from '../constants/Colors';
 import { Spacing, FontSize, FontWeight, FontFamily, BorderRadius } from '../constants/Layout';
@@ -21,9 +22,16 @@ import { ChipGroup } from '@components/Chip';
 import type { GameVariant } from '../types';
 
 // Default card width for SSR (will be recalculated on client)
-const DEFAULT_CARD_WIDTH = 150;
+const DEFAULT_CARD_WIDTH = 100;
+const NUM_COLUMNS = 3;
 
 const VARIANT_KEYS: GameVariant[] = ['normal', 'outline', 'mirror'];
+
+// Themen-Pack-ID (z.B. 'tiere-v1') → kurzer i18n-Key (ohne Versionssuffix)
+const PACK_LABEL_KEYS: Record<string, string> = {
+  'tiere-v1': 'tiere',
+  'fahrzeuge-v1': 'fahrzeuge',
+};
 
 /**
  * Levels Screen - Level-Auswahl
@@ -34,11 +42,16 @@ export default function LevelsScreen() {
   const router = useRouter();
   const { colors, theme } = useTheme();
   const levels = useMemo(() => getAllLevels(), []);
+  const packs = useMemo(() => ['all', ...getAvailablePacks()], []);
   const [ratings, setRatings] = useState<Record<number, number | null>>({});
   const [variant, setVariant] = useState<GameVariant>('normal');
+  const [pack, setPack] = useState<string>('all');
   // Use hook for responsive dimensions (SSR-safe)
   const { width: screenWidth } = useWindowDimensions();
-  const cardWidth = screenWidth > 0 ? (screenWidth - Spacing.lg * 3) / 2 : DEFAULT_CARD_WIDTH;
+  const cardWidth =
+    screenWidth > 0
+      ? (screenWidth - Spacing.lg * (NUM_COLUMNS + 1)) / NUM_COLUMNS
+      : DEFAULT_CARD_WIDTH;
 
   const glassSurface = theme === 'dark' ? Colors.glass.darkSurface : Colors.glass.lightSurface;
   const glassBorder = theme === 'dark' ? Colors.glass.darkBorder : Colors.glass.lightBorder;
@@ -83,7 +96,7 @@ export default function LevelsScreen() {
     return (
       <GlassCard
         index={index}
-        onPress={() => router.push(`/game?level=${item.number}&variant=${variant}`)}
+        onPress={() => router.push(`/game?level=${item.number}&variant=${variant}&pack=${pack}`)}
         accessibilityLabel={`${t('levels.level', { number: item.number })} — ${difficultyText}`}
         style={[
           styles.levelCard,
@@ -138,12 +151,29 @@ export default function LevelsScreen() {
         />
       </View>
 
+      {/* Themen-Pack */}
+      {packs.length > 1 && (
+        <View style={styles.variantSection}>
+          <Text style={[styles.variantLabel, { color: colors.text.secondary }]}>
+            {t('levels.pack.title')}
+          </Text>
+          <ChipGroup
+            options={packs.map(p => t(`levels.pack.${PACK_LABEL_KEYS[p] ?? p}`))}
+            selected={t(`levels.pack.${PACK_LABEL_KEYS[pack] ?? pack}`)}
+            onSelect={label => {
+              const match = packs.find(p => t(`levels.pack.${PACK_LABEL_KEYS[p] ?? p}`) === label);
+              if (match) setPack(match);
+            }}
+          />
+        </View>
+      )}
+
       {/* Level-Grid */}
       <FlatList
         data={levels}
         renderItem={renderLevelCard}
         keyExtractor={item => `level-${item.number}`}
-        numColumns={2}
+        numColumns={NUM_COLUMNS}
         columnWrapperStyle={styles.row}
         contentContainerStyle={styles.listContent}
         showsVerticalScrollIndicator={false}
@@ -187,28 +217,28 @@ const styles = StyleSheet.create({
   },
   row: {
     justifyContent: 'space-between',
-    marginBottom: Spacing.lg,
+    marginBottom: Spacing.sm,
   },
   levelCard: {
-    borderRadius: BorderRadius.xxl,
-    padding: Spacing.md,
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.sm,
     borderWidth: 1.5,
   },
   levelHeader: {
-    marginBottom: Spacing.sm,
+    marginBottom: Spacing.xs,
   },
   levelNumber: {
-    fontSize: FontSize.xl,
+    fontSize: FontSize.md,
     fontWeight: FontWeight.bold,
   },
   difficultyBadge: {
-    marginBottom: Spacing.sm,
+    marginBottom: Spacing.xs,
   },
   starsRow: {
     flexDirection: 'row',
     marginTop: Spacing.xs,
   },
   star: {
-    fontSize: FontSize.lg,
+    fontSize: FontSize.sm,
   },
 });

--- a/components/game/DrawPhase.tsx
+++ b/components/game/DrawPhase.tsx
@@ -4,6 +4,7 @@ import DrawingCanvas from '@components/DrawingCanvas';
 import { ErrorBoundary } from '@components/ErrorBoundary';
 import { DrawingColors } from '../../constants/Colors';
 import Colors from '../../constants/Colors';
+import { PenIcon, FillIcon, EyeIcon } from './ToolIcons';
 import { Spacing, FontSize, FontWeight, BorderRadius } from '../../constants/Layout';
 import type { DrawPhaseProps } from './game.shared';
 import { useTranslation } from '@services/i18n';
@@ -67,9 +68,10 @@ export default function DrawPhase({
           accessibilityLabel={hasUsedHint ? t('game.draw.hintUsed') : t('game.draw.hintButton')}
           accessibilityRole="button"
         >
-          <Text style={[styles.hintButtonIcon, hasUsedHint && styles.hintButtonIconUsed]}>
-            {hasUsedHint ? '👁' : t('game.draw.hintButton')}
-          </Text>
+          <View style={styles.hintButtonContent}>
+            <EyeIcon size={14} color={hasUsedHint ? colors.text.secondary : Colors.drawing.white} />
+            {!hasUsedHint && <Text style={styles.hintButtonIcon}>{t('game.draw.hintButton')}</Text>}
+          </View>
         </TouchableOpacity>
       </View>
 
@@ -127,7 +129,10 @@ export default function DrawPhase({
             accessibilityLabel={t('game.draw.toolBrush')}
             accessibilityRole="button"
           >
-            <Text style={styles.toolToggleIcon}>✏️</Text>
+            <PenIcon
+              size={20}
+              color={drawing.tool === 'brush' ? Colors.drawing.white : colors.text.secondary}
+            />
           </TouchableOpacity>
           <TouchableOpacity
             style={[
@@ -139,40 +144,47 @@ export default function DrawPhase({
             accessibilityLabel={t('game.draw.toolFill')}
             accessibilityRole="button"
           >
-            <Text style={styles.toolToggleIcon}>🪣</Text>
+            <FillIcon
+              size={20}
+              color={drawing.tool === 'fill' ? Colors.drawing.white : colors.text.secondary}
+            />
           </TouchableOpacity>
 
           <View style={[styles.toolRowSeparator, { backgroundColor: colors.border }]} />
 
-          {([2, 3, 5] as const).map(size => (
-            <TouchableOpacity
-              key={size}
-              style={[
-                styles.strokeCircleButton,
-                drawing.tool === 'fill' && styles.strokeCircleDisabled,
-              ]}
-              onPress={() => {
-                if (drawing.tool !== 'fill') drawing.setStrokeWidth(size);
-              }}
-              disabled={drawing.tool === 'fill'}
-              accessibilityLabel={`${t('game.draw.strokeWidth')} ${size}`}
-              accessibilityRole="button"
-            >
-              <View
+          {([2, 3, 5] as const).map(size => {
+            const isSelected = drawing.strokeWidth === size && drawing.tool !== 'fill';
+            // Alle drei Punkte zeigen die aktuell gewählte Pinselfarbe (unterscheiden sich
+            // nur in der Größe). Die Auswahl selbst wird über den Ring (borderColor) angezeigt.
+            const dotColor = drawing.tool !== 'fill' ? drawing.color : colors.text.secondary;
+            return (
+              <TouchableOpacity
+                key={size}
                 style={[
-                  styles.strokeCircle,
-                  {
-                    width: size === 2 ? 10 : size === 3 ? 16 : 22,
-                    height: size === 2 ? 10 : size === 3 ? 16 : 22,
-                    backgroundColor:
-                      drawing.strokeWidth === size && drawing.tool !== 'fill'
-                        ? drawing.color
-                        : colors.text.secondary,
-                  },
+                  styles.strokeCircleButton,
+                  isSelected && styles.strokeCircleButtonSelected,
+                  drawing.tool === 'fill' && styles.strokeCircleDisabled,
                 ]}
-              />
-            </TouchableOpacity>
-          ))}
+                onPress={() => {
+                  if (drawing.tool !== 'fill') drawing.setStrokeWidth(size);
+                }}
+                disabled={drawing.tool === 'fill'}
+                accessibilityLabel={`${t('game.draw.strokeWidth')} ${size}`}
+                accessibilityRole="button"
+              >
+                <View
+                  style={[
+                    styles.strokeCircle,
+                    {
+                      width: size === 2 ? 10 : size === 3 ? 16 : 22,
+                      height: size === 2 ? 10 : size === 3 ? 16 : 22,
+                      backgroundColor: dotColor,
+                    },
+                  ]}
+                />
+              </TouchableOpacity>
+            );
+          })}
         </View>
       </View>
 
@@ -297,13 +309,15 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.border,
     opacity: 0.5,
   },
+  hintButtonContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
   hintButtonIcon: {
     fontSize: 16,
     fontWeight: FontWeight.bold,
     color: '#FFFFFF',
-  },
-  hintButtonIconUsed: {
-    color: Colors.text.secondary,
   },
   canvasContainer: {
     flex: 1,
@@ -370,13 +384,6 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.primary,
     borderColor: Colors.primary,
   },
-  toolToggleIcon: {
-    fontSize: 20,
-    lineHeight: 24,
-    textAlign: 'center',
-    textAlignVertical: 'center',
-    includeFontPadding: false,
-  },
   toolRowSeparator: {
     width: 1,
     height: 28,
@@ -385,8 +392,14 @@ const styles = StyleSheet.create({
   strokeCircleButton: {
     width: 36,
     height: 36,
+    borderRadius: 999,
+    borderWidth: 2,
+    borderColor: 'transparent',
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  strokeCircleButtonSelected: {
+    borderColor: Colors.primary,
   },
   strokeCircle: {
     borderRadius: 999,

--- a/components/game/ToolIcons.tsx
+++ b/components/game/ToolIcons.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import Svg, { Path, Circle } from 'react-native-svg';
+
+interface IconProps {
+  size?: number;
+  color: string;
+}
+
+/**
+ * Abstrakte, einfarbige Werkzeug-Piktogramme für die Zeichen-Toolbar.
+ * Ersetzen die bisherigen Emoji (✏️ 🪣 👁) durch klare Linien-Icons,
+ * deren Farbe komplett vom `color`-Prop (aktiv/inaktiv) gesteuert wird.
+ */
+
+export function PenIcon({ size = 20, color }: IconProps) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+      <Path
+        d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"
+        stroke={color}
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
+  );
+}
+
+export function FillIcon({ size = 20, color }: IconProps) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+      <Path
+        d="M3.5 10.5L10.5 3.5a1 1 0 0 1 1.4 0l5.6 5.6a1 1 0 0 1 0 1.4l-7 7a1 1 0 0 1-1.4 0l-5.6-5.6a1 1 0 0 1 0-1.4z"
+        stroke={color}
+        strokeWidth={1.8}
+        strokeLinejoin="round"
+      />
+      <Path d="M3.5 10.5h13" stroke={color} strokeWidth={1.8} />
+      <Path d="M18.5 13c0 1.1-.9 2-2 2s-2-.9-2-2c0-1.1 2-3.5 2-3.5s2 2.4 2 3.5z" fill={color} />
+    </Svg>
+  );
+}
+
+export function EyeIcon({ size = 16, color }: IconProps) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+      <Path
+        d="M1.5 12S5.5 5 12 5s10.5 7 10.5 7-4 7-10.5 7S1.5 12 1.5 12z"
+        stroke={color}
+        strokeWidth={1.8}
+        strokeLinejoin="round"
+      />
+      <Circle cx="12" cy="12" r="3" stroke={color} strokeWidth={1.8} />
+    </Svg>
+  );
+}

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -64,7 +64,7 @@
       "clear": "Alles löschen",
       "clearConfirm": "Wirklich alles löschen?",
       "done": "Fertig",
-      "hintButton": "👁 1x",
+      "hintButton": "1x",
       "hintUsed": "Joker verbraucht",
       "hintModalTitle": "Vorlage",
       "drawFromMemory": "Male das",

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -34,6 +34,12 @@
       "normal": "Normal",
       "outline": "Nur Umriss",
       "mirror": "Spiegelbild"
+    },
+    "pack": {
+      "title": "Themen-Pack",
+      "all": "Alle",
+      "tiere": "Tiere",
+      "fahrzeuge": "Fahrzeuge"
     }
   },
   "game": {

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -64,7 +64,7 @@
       "clear": "Clear all",
       "clearConfirm": "Really clear everything?",
       "done": "Done",
-      "hintButton": "👁 1x",
+      "hintButton": "1x",
       "hintUsed": "Hint used",
       "hintModalTitle": "Reference",
       "drawFromMemory": "Draw the",

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -34,6 +34,12 @@
       "normal": "Normal",
       "outline": "Outline only",
       "mirror": "Mirror image"
+    },
+    "pack": {
+      "title": "Theme pack",
+      "all": "All",
+      "tiere": "Animals",
+      "fahrzeuge": "Vehicles"
     }
   },
   "game": {

--- a/locales/es/translations.json
+++ b/locales/es/translations.json
@@ -64,7 +64,7 @@
       "clear": "Borrar todo",
       "clearConfirm": "¿Seguro que quieres borrar todo?",
       "done": "Listo",
-      "hintButton": "👁 1x",
+      "hintButton": "1x",
       "hintUsed": "Pista usada",
       "hintModalTitle": "Referencia",
       "drawFromMemory": "Dibuja el",

--- a/locales/es/translations.json
+++ b/locales/es/translations.json
@@ -34,6 +34,12 @@
       "normal": "Normal",
       "outline": "Solo contorno",
       "mirror": "Imagen espejo"
+    },
+    "pack": {
+      "title": "Paquete temático",
+      "all": "Todos",
+      "tiere": "Animales",
+      "fahrzeuge": "Vehículos"
     }
   },
   "game": {

--- a/locales/fr/translations.json
+++ b/locales/fr/translations.json
@@ -64,7 +64,7 @@
       "clear": "Tout effacer",
       "clearConfirm": "Vraiment tout effacer ?",
       "done": "Terminé",
-      "hintButton": "👁 1x",
+      "hintButton": "1x",
       "hintUsed": "Indice utilisé",
       "hintModalTitle": "Référence",
       "drawFromMemory": "Dessine le",

--- a/locales/fr/translations.json
+++ b/locales/fr/translations.json
@@ -34,6 +34,12 @@
       "normal": "Normal",
       "outline": "Contour seulement",
       "mirror": "Image miroir"
+    },
+    "pack": {
+      "title": "Pack thématique",
+      "all": "Tous",
+      "tiere": "Animaux",
+      "fahrzeuge": "Véhicules"
     }
   },
   "game": {

--- a/locales/it/translations.json
+++ b/locales/it/translations.json
@@ -64,7 +64,7 @@
       "clear": "Cancella tutto",
       "clearConfirm": "Vuoi davvero cancellare tutto?",
       "done": "Fatto",
-      "hintButton": "👁 1x",
+      "hintButton": "1x",
       "hintUsed": "Suggerimento usato",
       "hintModalTitle": "Riferimento",
       "drawFromMemory": "Disegna il",

--- a/locales/it/translations.json
+++ b/locales/it/translations.json
@@ -34,6 +34,12 @@
       "normal": "Normale",
       "outline": "Solo contorno",
       "mirror": "Immagine speculare"
+    },
+    "pack": {
+      "title": "Pacchetto tematico",
+      "all": "Tutti",
+      "tiere": "Animali",
+      "fahrzeuge": "Veicoli"
     }
   },
   "game": {

--- a/locales/nl/translations.json
+++ b/locales/nl/translations.json
@@ -34,6 +34,12 @@
       "normal": "Normaal",
       "outline": "Alleen omtrek",
       "mirror": "Spiegelbeeld"
+    },
+    "pack": {
+      "title": "Themapakket",
+      "all": "Alle",
+      "tiere": "Dieren",
+      "fahrzeuge": "Voertuigen"
     }
   },
   "game": {

--- a/locales/nl/translations.json
+++ b/locales/nl/translations.json
@@ -64,7 +64,7 @@
       "clear": "Alles wissen",
       "clearConfirm": "Echt alles wissen?",
       "done": "Klaar",
-      "hintButton": "👁 1x",
+      "hintButton": "1x",
       "hintUsed": "Hint gebruikt",
       "hintModalTitle": "Voorbeeld",
       "drawFromMemory": "Teken de",

--- a/locales/pl/translations.json
+++ b/locales/pl/translations.json
@@ -34,6 +34,12 @@
       "normal": "Normalny",
       "outline": "Tylko kontur",
       "mirror": "Lustrzane odbicie"
+    },
+    "pack": {
+      "title": "Pakiet tematyczny",
+      "all": "Wszystkie",
+      "tiere": "Zwierzęta",
+      "fahrzeuge": "Pojazdy"
     }
   },
   "game": {

--- a/locales/pl/translations.json
+++ b/locales/pl/translations.json
@@ -64,7 +64,7 @@
       "clear": "Wyczyść wszystko",
       "clearConfirm": "Na pewno wyczyścić wszystko?",
       "done": "Gotowe",
-      "hintButton": "👁 1x",
+      "hintButton": "1x",
       "hintUsed": "Podpowiedź użyta",
       "hintModalTitle": "Wzór",
       "drawFromMemory": "Narysuj",

--- a/services/ImagePoolManager.ts
+++ b/services/ImagePoolManager.ts
@@ -488,14 +488,17 @@ let lastShownImages: string[] = [];
 /**
  * Wählt ein zufälliges Bild für ein Level aus
  * @param levelNumber Level-Nummer (1-10)
+ * @param pack Optionale Themen-Pack-Einschränkung (z.B. 'tiere-v1'). 'all' oder undefined = kein Filter.
  * @returns Zufälliges Bild aus dem passenden Schwierigkeitspool
  */
-export function getRandomImageForLevel(levelNumber: number): LevelImage {
+export function getRandomImageForLevel(levelNumber: number, pack?: string): LevelImage {
   const targetDifficulty = getDifficultyForLevel(levelNumber);
-  const isEligible = (img: LevelImage) =>
+  const matchesDifficulty = (img: LevelImage) =>
     img.difficulty === targetDifficulty && (!img.minLevel || img.minLevel <= levelNumber);
+  const matchesPack = (img: LevelImage) => !pack || pack === 'all' || img.pack === pack;
+  const isEligible = (img: LevelImage) => matchesDifficulty(img) && matchesPack(img);
 
-  // Filtere Bilder nach Schwierigkeit, minLevel-Guard UND nicht kürzlich gezeigt
+  // Filtere Bilder nach Schwierigkeit, Pack, minLevel-Guard UND nicht kürzlich gezeigt
   let availableImages = imagePool.filter(
     img => isEligible(img) && !lastShownImages.includes(img.filename),
   );
@@ -504,6 +507,11 @@ export function getRandomImageForLevel(levelNumber: number): LevelImage {
   if (availableImages.length === 0) {
     lastShownImages = [];
     availableImages = imagePool.filter(isEligible);
+  }
+
+  // Falls das gewählte Pack für diese Schwierigkeit keine Bilder hat, Pack-Filter ignorieren
+  if (availableImages.length === 0) {
+    availableImages = imagePool.filter(matchesDifficulty);
   }
 
   // Wähle zufällig aus verfügbaren Bildern
@@ -524,16 +532,38 @@ export function getRandomImageForLevel(levelNumber: number): LevelImage {
  * Wird für die Daily Challenge verwendet, damit das Bild des Tages konstant bleibt.
  * @param levelNumber Level-Nummer
  * @param seed Numerischer Seed (z. B. YYYYMMDD)
+ * @param pack Optionale Themen-Pack-Einschränkung (z.B. 'tiere-v1'). 'all' oder undefined = kein Filter.
  */
-export function getSeededImageForLevel(levelNumber: number, seed: number): LevelImage {
+export function getSeededImageForLevel(
+  levelNumber: number,
+  seed: number,
+  pack?: string,
+): LevelImage {
   const targetDifficulty = getDifficultyForLevel(levelNumber);
-  const available = imagePool.filter(
-    img => img.difficulty === targetDifficulty && (!img.minLevel || img.minLevel <= levelNumber),
-  );
-  if (available.length === 0) return getRandomImageForLevel(levelNumber);
-  if (!Number.isFinite(seed)) return getRandomImageForLevel(levelNumber);
+  const matchesDifficulty = (img: LevelImage) =>
+    img.difficulty === targetDifficulty && (!img.minLevel || img.minLevel <= levelNumber);
+  const matchesPack = (img: LevelImage) => !pack || pack === 'all' || img.pack === pack;
+
+  let available = imagePool.filter(img => matchesDifficulty(img) && matchesPack(img));
+  // Falls das gewählte Pack für diese Schwierigkeit keine Bilder hat, Pack-Filter ignorieren
+  if (available.length === 0) {
+    available = imagePool.filter(matchesDifficulty);
+  }
+  if (available.length === 0) return getRandomImageForLevel(levelNumber, pack);
+  if (!Number.isFinite(seed)) return getRandomImageForLevel(levelNumber, pack);
   const index = Math.abs(Math.floor(seed)) % available.length;
   return available[index];
+}
+
+/**
+ * Gibt alle im Bilderpool vorkommenden Themen-Pack-IDs zurück (z.B. ['fahrzeuge-v1', 'tiere-v1'])
+ */
+export function getAvailablePacks(): string[] {
+  const packs = new Set<string>();
+  imagePool.forEach(img => {
+    if (img.pack) packs.add(img.pack);
+  });
+  return Array.from(packs).sort();
 }
 
 /**

--- a/services/useGamePhase.ts
+++ b/services/useGamePhase.ts
@@ -18,16 +18,21 @@ interface UseGamePhaseOptions {
   drawingPaths: DrawingPath[];
   clearCanvas: () => void;
   isDailyChallenge?: boolean;
+  pack?: string;
 }
 
-function getImageForLevel(levelNumber: number, dailyChallengeLevel: number | null): LevelImage {
+function getImageForLevel(
+  levelNumber: number,
+  dailyChallengeLevel: number | null,
+  pack?: string,
+): LevelImage {
   if (dailyChallengeLevel !== null && levelNumber === dailyChallengeLevel) {
     const dateKey = getDailyChallengeKey();
     const rawSeed = parseInt(dateKey.replace(/-/g, ''), 10);
     const seed = Number.isFinite(rawSeed) ? Math.abs(rawSeed) : 0;
-    return getSeededImageForLevel(levelNumber, seed);
+    return getSeededImageForLevel(levelNumber, seed, pack);
   }
-  return getRandomImageForLevel(levelNumber);
+  return getRandomImageForLevel(levelNumber, pack);
 }
 
 export function useGamePhase({
@@ -35,6 +40,7 @@ export function useGamePhase({
   drawingPaths,
   clearCanvas,
   isDailyChallenge = false,
+  pack,
 }: UseGamePhaseOptions) {
   const router = useRouter();
   // dailyChallengeLevel is fixed at mount; only the initial level counts as the
@@ -86,7 +92,7 @@ export function useGamePhase({
   // For the daily challenge level, use a date-seeded image so it stays consistent all day.
   useEffect(() => {
     try {
-      const image: LevelImage = getImageForLevel(levelNumber, dailyChallengeLevel);
+      const image: LevelImage = getImageForLevel(levelNumber, dailyChallengeLevel, pack);
       currentImageRef.current = image;
       setCurrentImage(image);
       levelStartedAtRef.current = Date.now();
@@ -94,7 +100,7 @@ export function useGamePhase({
       console.error('Error initializing level:', error);
       router.back();
     }
-  }, [levelNumber, dailyChallengeLevel, router]);
+  }, [levelNumber, dailyChallengeLevel, pack, router]);
 
   // Update timer when levelNumber or extraTimeMode changes (separate from image init)
   useEffect(() => {
@@ -237,7 +243,7 @@ export function useGamePhase({
     // Re-trigger level-init useEffect by setting a fresh image + time directly
     // (levelNumber doesn't change, so we init manually here)
     try {
-      const image: LevelImage = getImageForLevel(levelNumber, dailyChallengeLevel);
+      const image: LevelImage = getImageForLevel(levelNumber, dailyChallengeLevel, pack);
       currentImageRef.current = image;
       setCurrentImage(image);
       setTimeRemaining(getDisplayDuration(levelNumber, extraTimeMode));


### PR DESCRIPTION
## Summary
- feat: Themen-Pack-Auswahl (Tiere/Fahrzeuge) auf Level-Screen (#271)
- fix: Zeichen-UX aufräumen (Icons, Strichstärken-Farbe, Fortschrittsbalken) (#272)
- docs: CLAUDE.md mit Themen-Pack-Auswahl + Draw-UX-Fixes synchronisieren (#273)

## Test plan
- [ ] CI/CD grün (Lint, Tests, Web-Build, Versionskonsistenz)
- [ ] Manuelle Freigabe durch Nutzer vor Merge (Projekt-Policy: main nur mit expliziter Zustimmung)