### PR TITLE
chore: Version 1.7.2 / versionCode 68

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Merke und Male",
     "slug": "merke-und-male",
-    "version": "1.7.0",
+    "version": "1.7.2",
     "platforms": ["ios", "android", "web"],
     "orientation": "portrait",
     "icon": "./assets/icons/app-icon.png",
@@ -37,7 +37,7 @@
       },
       "package": "com.s540d.merkeundmale",
       "permissions": [],
-      "versionCode": 66,
+      "versionCode": 68,
       "minSdkVersion": 26,
       "newArchEnabled": false,
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.s540d.merkeundmale",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merke-und-male",
-  "version": "1.7.0",
+  "version": "1.7.2",
   "main": "expo-router/entry",
   "homepage": "https://s540d.github.io/DrawFromMemory/",
   "repository": {


### PR DESCRIPTION
## Summary
Version-Bump für den nächsten Play-Store-Release (AAB-Build folgt nach Merge).

- `version`: 1.7.0 → **1.7.2**
- `android.versionCode`: 66 → **68**
- package.json version synchronisiert

## Warum 1.7.2 / vc 68 (nicht 1.7.1 / 67)
Der Play Store hat bereits **1.7.1 (versionCode 67)** — dieser Bump wurde damals nur als Tag `v1.7.1` (Commit `d2c518a`) gebaut & hochgeladen, **nie nach main/testing gemergt**. `main` stand daher auf 1.7.0/66. Neuer versionCode muss > 67 sein (→ 68), und der Versionsname 1.7.1 ist im Store schon belegt (→ 1.7.2).

## Test plan
- [ ] CI/CD grün (Versionskonsistenz package.json == app.json)
- [ ] Nach Merge: EAS production Build (versionCode 68 > 67 ✅)