### PR TITLE
chore: project-templates sync (GLOBAL POLICY + commands)

### DIFF
--- a/.claude/commands/aufräumen.md
+++ b/.claude/commands/aufräumen.md
@@ -2,6 +2,36 @@
 
 Führe den täglichen Cleanup-Workflow durch:
 
+## 0. Branch-Übersicht: testing vs. main (alle Repos)
+
+Erstelle zu Beginn eine Tabelle aller Repositories mit dem Stand von `testing` gegenüber `main`:
+
+```bash
+for repo in Eisenhauer 1x1_Trainer DrawFromMemory EnergyPriceGermany Pflanzkalender safe_my_plants CD-to-Spotify-PWA project-templates; do
+  dir="/Users/svenstrohkark/Documents/Programmierung/Projects/$repo"
+  if [ -d "$dir/.git" ]; then
+    cd "$dir"
+    git fetch --all --prune -q 2>/dev/null
+    ab=$(git rev-list --left-right --count origin/main...origin/testing 2>/dev/null)
+    main_ahead=$(echo $ab | awk '{print $1}')
+    test_ahead=$(echo $ab | awk '{print $2}')
+    echo "$repo | testing +$test_ahead | main +$main_ahead"
+  fi
+done
+```
+
+Zeige das Ergebnis als Markdown-Tabelle:
+
+| Projekt | testing ahead | main ahead | Status                                 |
+| ------- | ------------- | ---------- | -------------------------------------- |
+| ...     | ...           | ...        | ✅ OK / ⚠️ Divergiert / 🔴 main voraus |
+
+**Statusregeln:**
+
+- ✅ OK — main_ahead = 0 (testing enthält main vollständig)
+- ⚠️ Leicht divergiert — main_ahead ≤ 3 und nur Auto-Commits (z.B. marketdata)
+- 🔴 main voraus — main_ahead > 0 mit echten Commits → Sync-PR nötig
+
 ## 1. Repository Status prüfen
 
 - Prüfe `git status` für uncommitted changes

--- a/.claude/commands/cache-clean.md
+++ b/.claude/commands/cache-clean.md
@@ -1,0 +1,44 @@
+# Lokaler Cache-Cleanup
+
+Führe den lokalen Cache-Cleanup für alle Projekte aus (Festplattenplatz freigeben).
+
+Dies ist ein manueller, seltener Eingriff (kein automatischer Cron) — nur auf
+explizite Anfrage ausführen.
+
+## 1. Report erzeugen (Dry-Run)
+
+Führe im project-templates-Verzeichnis aus:
+
+```bash
+cd "$(find ~/Documents -maxdepth 4 -type d -name project-templates 2>/dev/null | head -1)"
+./scripts/clean-local-cache.sh --dry-run
+```
+
+Zeige das Ergebnis (Größen pro Projekt, geplante Löschungen) als Übersicht.
+
+## 2. Rückfrage
+
+Frage explizit: "Sollen diese Caches gelöscht werden? (node_modules, dist,
+build, .expo, android/.gradle, android/app/build)"
+
+Bei Zustimmung:
+
+```bash
+./scripts/clean-local-cache.sh --yes
+```
+
+## 3. Optional: globale Caches
+
+Frage separat: "Auch globale Caches leeren? (~/.gradle/caches ~9GB, ~/.npm
+~900MB — betrifft alle Gradle-/Node-Projekte gemeinsam)"
+
+Bei Zustimmung:
+
+```bash
+./scripts/clean-local-cache.sh --yes --global
+```
+
+## 4. Hinweis nach dem Löschen
+
+Erinnere daran, dass beim nächsten Start des jeweiligen Projekts
+`npm install` (und ggf. `npx expo prebuild` / Gradle-Sync) nötig ist.

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -59,21 +59,28 @@ Einen Pull Request gründlich prüfen, Code-Review-Suggestions umsetzen und für
 - Falls neue Features/Breaking Changes: Schlage CHANGELOG-Eintrag vor
 - Prüfe ob README/Docs aktualisiert werden müssen
 
-### 6. Merge-Gate (review-gate) – automatischer Claude-Review + Autofix
+### 6. Merge-Gate (review-gate) + KI-Review
 
-Der Workflow `reusable-pr-review.yml` korrigiert den PR automatisch und reviewt
-den End-Stand, dann setzt er den required Status-Check **`review-gate`** und ein Label:
+**Kostenloses Gate (automatisch, keine API-Kosten):** Der Workflow
+`reusable-mergeability.yml` läuft bei jedem PR, postet einen Sticky-Kommentar
+(Zielbranch, Konflikt-Status, CI-Übersicht, Checkliste) und setzt den required
+Status-Check **`review-gate`**:
 
-1. **Autofix:** Ein Claude-Agent fixt alle umsetzbaren Findings selbst (Commit `[auto]` + Push).
-2. **Review:** bewertet den korrigierten Stand:
-   - **Keine offenen Findings → grün** + Label `ready to merge` → Merge frei.
-   - **Findings übrig → rot** + Inline-Kommentare + Label `needs human review`.
+- **kein Merge-Konflikt → grün** → Merge möglich (sofern auch CI grün ist).
+- **Merge-Konflikt → rot** → Branch aktualisieren.
 
-Bei `needs human review`: Findings lesen, klären/umsetzen, pushen → frischer Lauf.
+**Tiefer KI-Review (primärer Weg, abo-basiert, ohne Pay-per-Token):** Führe das
+Slash-Command `/review` (bzw. `/code-review --comment`) aus Claude Code aus —
+lokal am PC **oder** in einer Web-Session vom Telefon. Das ist durch dein
+Pro/Max-Abo gedeckt und kostet keine metered API-Token. Mit `--comment` werden die
+Findings als PR-Kommentare gepostet, mit `--fix` direkt im Working-Tree umgesetzt.
 
-> ⚠️ Es gibt **kein** manuelles Quittierungs-Label mehr. Den roten Gate öffnet nur
-> ein sauberer Review (alle Findings gelöst). Solange `needs human review` gesetzt
-> ist: **nicht mergen**, bis die offenen Punkte geklärt sind.
+**Optionaler API-Fallback (kostet metered API):** Setze das Label **`ai-review`**
+am PR → `pr-review.yml` postet einen beratenden Claude-Review (Haiku). Dieser
+blockiert den Merge **nicht** — er ergänzt nur das kostenlose Gate.
+
+> ℹ️ Der KI-Review ist beratend; verbindlich für den Merge sind die kostenlosen,
+> deterministischen Checks (CI grün + `review-gate` grün + keine Konflikte).
 
 ### 7. Merge vorbereiten
 
@@ -145,7 +152,7 @@ Bei `needs human review`: Findings lesen, klären/umsetzen, pushen → frischer 
 
 - ❌ CI/CD Tests fehlgeschlagen
 - ❌ Merge Conflicts vorhanden
-- ❌ `review-gate` ist rot bzw. Label `needs human review` gesetzt (offene Findings erst klären)
+- ❌ `review-gate` ist rot (Merge-Konflikt – erst Branch aktualisieren)
 - ❌ Target-Branch ist `main` oder `production` (extra Vorsicht, nur mit Freigabe + `--admin`)
 
 **Immer fragen vor:**

--- a/.claude/commands/security-review.md
+++ b/.claude/commands/security-review.md
@@ -1,0 +1,65 @@
+# Security Review (Cross-Project)
+
+Globaler Security-Scan über alle lokalen Projekte mit konsolidiertem Report (Issue #7).
+
+> **Ablageort:** global unter `~/.claude/commands/security-review.md`, nicht pro Projekt.
+> Begründung: scannt projektübergreifend, gehört nicht in ein einzelnes Repo.
+
+## Ziel
+
+Alle lokalen Projekt-Repositories auf Secrets, Fingerprints, getrackte sensible Dateien
+und Gitignore-Lücken prüfen – ein zusammengefasster Bericht statt sieben Einzelläufe.
+
+## Workflow
+
+### 1. Projekte ermitteln
+
+- Bestimme die zu prüfenden Repos (Standard: alle App-Projekte im Workspace).
+- Pro Repo: ist es ein Git-Repo? Aktueller Branch? Uncommitted Changes?
+
+### 2. Pro Projekt scannen
+
+Für jedes Repo dieselben Checks (entsprechen `reusable-security-scan.yml`):
+
+- **Signing-Fingerprints** (SHA1/SHA256 Colon-Hex):
+  ```bash
+  git -C "$repo" grep -nE '([0-9A-Fa-f]{2}:){15,}[0-9A-Fa-f]{2}' -- . ':!*.lock'
+  ```
+- **Hardcodierte API-Keys / Tokens:**
+  ```bash
+  git -C "$repo" grep -niE '(api[_-]?key|secret[_-]?key|auth[_-]?token|access[_-]?token)["'\'' ]*[:=]["'\'' ]*[A-Za-z0-9_-]{16,}' -- . ':!*.lock'
+  ```
+- **Getrackte sensible Dateien:** (nur konventionell-geheime .env – nicht committete `.env.<environment>`-Config)
+  ```bash
+  git -C "$repo" ls-files | grep -E '(credentials\.json$|\.jks$|\.keystore$|\.p12$|\.p8$|(^|/)\.env(\.local)?$|(^|/)\.env\.[^/]*\.local$)'
+  ```
+- **Gitignore-Pflichteinträge** vorhanden? (`.env`, `.env.local`, `credentials.json`, `*.jks`, `*.keystore`, `*.p12`, `*.p8`, `docs/private/`) – deckungsgleich mit `reusable-gitignore-audit.yml`. `.env.<environment>` mit reiner Public-Config ist erlaubt.
+- **`docs/private/` nicht getrackt?**
+- **`npm audit`** (falls `package.json` vorhanden) – Vulnerabilities zählen.
+
+### 3. Befunde einordnen
+
+- Bekannte False Positives kennzeichnen (z.B. CrUX-Demo-Key in `@react-native/debugger-frontend`).
+- Severity zuordnen: 🔴 Secret/Fingerprint getrackt · 🟡 Gitignore-Lücke · 🟢 nur Hinweis.
+
+### 4. Konsolidierter Report
+
+Tabelle über alle Projekte:
+
+| Projekt | Fingerprints | Secrets | Sensible Dateien | Gitignore | npm audit |
+| ------- | ------------ | ------- | ---------------- | --------- | --------- |
+| ...     | ✅/❌        | ✅/❌   | ✅/❌            | ✅/⚠️     | 0 / N     |
+
+- Anschließend priorisierte Handlungsempfehlungen (kritischste zuerst).
+- Nichts automatisch ändern – nur berichten und Fixes vorschlagen.
+
+## Sicherheitschecks
+
+- **Niemals** gefundene Secrets im Klartext in Commits/Issues/Logs ausgeben – nur Datei + Zeile.
+- Bei echtem Leak: sofort als kritisch markieren, Rotation + History-Bereinigung empfehlen.
+
+## Best Practices
+
+✅ Regelmäßig laufen lassen (z.B. wöchentlich, ergänzend zu `weekly-audit.yml`).
+✅ Public-Repos strenger behandeln (alle Workspace-Projekte sind öffentlich).
+❌ Keine destruktiven Aktionen ohne Rückfrage (kein `git filter-repo` etc. automatisch).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,12 +328,12 @@ Colors.glass.darkShadow; // { boxShadow, elevation } — dunkel
 
 Alle `EXPO_PUBLIC_*`-Flags sind zur Build-Zeit eingefroren (Expo bündelt sie statisch).
 
-| Env-Var                            | Default | Bedeutung                                                                                                       |
-| ---------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------- |
-| `EXPO_PUBLIC_SENTRY_DSN`           | —       | Sentry-Reporting aktivieren (leer = no-op)                                                                      |
-| `EXPO_PUBLIC_ENABLE_IN_APP_REVIEW` | `false` | In-App-Review-Prompt via `expo-store-review` — **deaktiviert bis Play-Store-Listing auditiert** (Issue #219 P0) |
-| `EXPO_PUBLIC_PLAUSIBLE_DOMAIN`     | —       | Privacy-freundliches, cookie-loses Web-Analytics (Plausible-kompatibel) — leer = no-op (Issue #279, 3.4)        |
-| `EXPO_PUBLIC_PLAUSIBLE_SCRIPT_SRC` | Plausible-Cloud-URL | Überschreibt die Script-Quelle für self-hosted Plausible/Umami-kompatible Instanzen                  |
+| Env-Var                            | Default             | Bedeutung                                                                                                       |
+| ---------------------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `EXPO_PUBLIC_SENTRY_DSN`           | —                   | Sentry-Reporting aktivieren (leer = no-op)                                                                      |
+| `EXPO_PUBLIC_ENABLE_IN_APP_REVIEW` | `false`             | In-App-Review-Prompt via `expo-store-review` — **deaktiviert bis Play-Store-Listing auditiert** (Issue #219 P0) |
+| `EXPO_PUBLIC_PLAUSIBLE_DOMAIN`     | —                   | Privacy-freundliches, cookie-loses Web-Analytics (Plausible-kompatibel) — leer = no-op (Issue #279, 3.4)        |
+| `EXPO_PUBLIC_PLAUSIBLE_SCRIPT_SRC` | Plausible-Cloud-URL | Überschreibt die Script-Quelle für self-hosted Plausible/Umami-kompatible Instanzen                             |
 
 > **Aktivieren:** In `.env` oder EAS-Build-Profil `EXPO_PUBLIC_ENABLE_IN_APP_REVIEW=true` setzen.  
 > Der Flag wird in `services/ReviewManager.ts` ausgewertet; kein Code-Change nötig.
@@ -438,3 +438,33 @@ Stand: `main` @ v1.7.0 / versionCode 66. `testing` liegt voraus: enthält zusät
 - **Nexus 6**: EOL — `minSdkVersion` = 26; Nexus 6 endet bei API 25 (geschlossen via Issue #172)
 - **iOS**: Nicht primär getestet (Fokus auf Web + Android)
 - **iOS App Store**: Bundle ID `com.s540d.merkeundmale`, App Store URL noch TBD
+
+<!-- GLOBAL POLICY:START -->
+
+## [GLOBAL POLICY]
+
+> Automatisch synchronisiert aus project-templates (Issue #7). Nicht manuell editieren –
+> Änderungen hier werden beim nächsten Sync überschrieben. Quelle anpassen statt lokal.
+
+- PRs immer gegen `testing`, nie direkt gegen `staging` oder `main`
+- Merge auf `main` nur mit expliziter schriftlicher Freigabe
+- `--delete-branch` nur für Feature-Branches (nie staging/testing)
+- **Lokales Branch-Cleanup:** `main` und `testing` NIE löschen — auch nicht beim Bulk-Delete verwaister `[gone]`-Branches. Ein fehlender `origin/main`/`origin/testing` ist ein **wiederherzustellender Defekt** (lokal behalten, nach origin zurückpushen), kein Aufräum-Signal.
+- `--no-verify` nur auf explizite Bitte
+- **Vor jedem Push: lokale Tests ausführen** (`npm test` bzw. projektspezifischer Test-Befehl) – kein Push ohne grüne lokale Tests
+- **Kein Merge bei CI-Fail** – Branch Protection erzwingt das technisch; nie mit `--admin` umgehen außer auf explizite Bitte
+
+## [ANDROID BUILD – PFLICHTREGELN]
+
+- **Git-Tag** nach jedem Play-Store-Upload setzen: `git tag vX.Y.Z && git push origin vX.Y.Z` – der Tag markiert den tatsächlich veröffentlichten Stand und dient als Changelog-Baseline für den nächsten Build
+- **EAS Local Build (DrawFromMemory):** Workingdir vor jedem Build leeren: `rm -rf ~/tmp/eas-build && mkdir -p ~/tmp/eas-build` – ein nicht-leeres Verzeichnis bricht den Build sofort ab
+- **Disk-Check vor EAS Build:** Skia-Libraries benötigen ~5–8 GB. Bei < 5 GB frei: `npm cache clean --force && rm -rf ~/.npm/_npx` (~13 GB, sicher löschbar)
+- **JAVA_HOME** für EAS/Expo-Builds explizit auf Android Studio JBR setzen: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`
+- **Gradle-Lock nach Absturz:** Bei "Cannot lock file hash cache"-Fehler Daemons stoppen: `pkill -f GradleDaemon`, dann Workingdir leeren und neu starten
+- **AAB-Archiv:** Gebaute Release-AABs in einem **gitignored** `aab-archive/`-Verzeichnis im Repo-Root ablegen (in `.gitignore` aufnehmen – AABs sind 3–110 MB und gehören nie in die Git-History). Benennung: `<Projekt>-vX.Y.Z-vc<versionCode>-YYYY-MM-DD.aab`. **Retention: max. 2 Dateien** (aktuelles Release + ein Vorgänger für schnelles Rollback); ältere AABs löschen. Der Git-Tag `vX.Y.Z` ist die eigentliche Release-Baseline – ältere AABs lassen sich daraus jederzeit neu bauen.
+
+## [CI – CACHE-CLEANUP]
+
+- **Cache-Cleanup-Workflow** (`.github/workflows/cache-cleanup.yml`) in jedem Repo mit GitHub-Actions-Caches: löscht wöchentlich (So 03:00 UTC) bzw. on-demand alle Action-Caches älter als der jeweils letzte Lauf. GitHub-Limit ist 10 GB pro Repo – ohne Cleanup laufen Build-Caches (node_modules, Gradle, Expo) voll und verdrängen frische Einträge. Vorlage: `cache-cleanup.yml` in project-templates.
+
+<!-- GLOBAL POLICY:END -->

--- a/components/WebTrustFooter.tsx
+++ b/components/WebTrustFooter.tsx
@@ -26,18 +26,14 @@ export default function WebTrustFooter() {
 
   return (
     <View style={styles.container}>
-      <Text style={[styles.tagline, { color: colors.text.secondary }]}>
-        {t('footer.tagline')}
-      </Text>
+      <Text style={[styles.tagline, { color: colors.text.secondary }]}>{t('footer.tagline')}</Text>
       <View style={styles.linkRow}>
         <TouchableOpacity onPress={() => openUrl(PLAY_STORE_URL)} accessibilityRole="link">
           <Text style={[styles.link, { color: colors.primary }]}>{t('footer.playStore')}</Text>
         </TouchableOpacity>
         <Text style={[styles.separator, { color: colors.text.light }]}>·</Text>
         <TouchableOpacity onPress={() => openUrl(PRIVACY_POLICY_URL)} accessibilityRole="link">
-          <Text style={[styles.link, { color: colors.primary }]}>
-            {t('footer.privacyPolicy')}
-          </Text>
+          <Text style={[styles.link, { color: colors.primary }]}>{t('footer.privacyPolicy')}</Text>
         </TouchableOpacity>
       </View>
     </View>

--- a/docs/PLAY_STORE_LISTING.md
+++ b/docs/PLAY_STORE_LISTING.md
@@ -9,10 +9,10 @@ Quelle: Issue [#243](https://github.com/S540d/DrawFromMemory/issues/243) (Store-
 
 ## 1. Titel (max. 30 Zeichen)
 
-| Sprache | Titel                | Zeichen |
-| ------- | -------------------- | ------- |
-| DE      | Merke und Male       | 14      |
-| EN      | Merke und Male       | 14      |
+| Sprache | Titel          | Zeichen |
+| ------- | -------------- | ------- |
+| DE      | Merke und Male | 14      |
+| EN      | Merke und Male | 14      |
 
 > Der App-Name bleibt in allen Sprachen identisch (Markenname, entspricht `app.json` / Package `com.s540d.merkeundmale`). Keyword-Ergänzungen im Titel (z. B. „– Memory für Kinder") sind möglich, aber bewusst weggelassen: Der Titel bleibt kurz und einprägsam, Keywords stehen in Kurz- und Langbeschreibung.
 


### PR DESCRIPTION
## Was

Synchronisiert `.claude/commands/` und den `CLAUDE.md` GLOBAL POLICY Block aus project-templates.

Zusätzlich mit Prettier korrigiert: `components/WebTrustFooter.tsx`, `docs/PLAY_STORE_LISTING.md` (vorbestehend unformatiert, blockierten den pre-push Hook, der das ganze Repo prüft).

## Tests

- `npm test`: 392/392 grün
- `npm run format:check`: sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)