### PR TITLE
feat: Mascot + einheitliches Fortschrittssystem, Altersstufen-Auswahl (Issue #279, 1.1 + 1.3)

### DIFF
--- a/app/game.tsx
+++ b/app/game.tsx
@@ -15,6 +15,7 @@ import SettingsModal from '@components/SettingsModal';
 import { ErrorBoundary } from '@components/ErrorBoundary';
 import ConfettiBurst from '@components/ConfettiBurst';
 import BadgeUnlockToast from '@components/BadgeUnlockToast';
+import MascotUnlockToast from '@components/MascotUnlockToast';
 import TutorialOverlay from '@components/TutorialOverlay';
 import { markOnboardingDone } from '@services/OnboardingManager';
 import SoundManager from '@services/SoundManager';
@@ -22,6 +23,7 @@ import { useGamePhase } from '@services/useGamePhase';
 import { checkAndUnlock, type AchievementDef } from '@services/AchievementManager';
 import { getStreakData } from '@services/StreakManager';
 import storageManager from '@services/StorageManager';
+import { getAgeGroup, getDefaultStrokeWidthForAgeGroup } from '@services/AgeGroupManager';
 import MemorizePhase from '@components/game/MemorizePhase';
 import DrawPhase from '@components/game/DrawPhase';
 import ResultPhase from '@components/game/ResultPhase';
@@ -87,6 +89,8 @@ export default function GameScreen() {
     isReplaying,
     setIsReplaying,
     replayPaths,
+    newMascotUnlock,
+    clearMascotUnlock,
     handleRatingSubmit,
     saveToGallery,
     startReplay,
@@ -140,6 +144,14 @@ export default function GameScreen() {
       setCelebrationEnabled(enabled);
     }
     init();
+  }, []);
+
+  // Altersgerechte Standard-Strichstärke beim Rundenstart (Issue #279, 1.3)
+  useEffect(() => {
+    getAgeGroup().then(ageGroup => {
+      drawing.setStrokeWidth(getDefaultStrokeWidthForAgeGroup(ageGroup));
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Reset tutorial hint when phase changes so each phase shows its own hint
@@ -410,6 +422,7 @@ export default function GameScreen() {
         </View>
       )}
       <BadgeUnlockToast achievement={unlockedBadge} onHide={handleBadgeToastHide} />
+      <MascotUnlockToast unlock={newMascotUnlock} onHide={clearMascotUnlock} />
 
       {/* Tutorial Coach Mark */}
       {isTutorial &&

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -19,6 +19,11 @@ import { FloatingStars } from '@components/FloatingStars';
 import OnboardingModal from '@components/OnboardingModal';
 import { isOnboardingDone } from '@services/OnboardingManager';
 import WebTrustFooter from '@components/WebTrustFooter';
+import Mascot from '@components/Mascot';
+import AgeGroupModal from '@components/AgeGroupModal';
+import { isAgeGroupSelected, setAgeGroup } from '@services/AgeGroupManager';
+import { getMascotProgress, getHomeGreetingKey, type MascotUnlock } from '@services/MascotManager';
+import type { AgeGroup } from '../types';
 
 export default function HomeScreen() {
   const { t } = useTranslation();
@@ -27,13 +32,31 @@ export default function HomeScreen() {
   const insets = useSafeAreaInsets();
   const [showSettings, setShowSettings] = useState(false);
   const [showOnboarding, setShowOnboarding] = useState(false);
-  const [dailyCompleted, setDailyCompleted] = useState(false);
+  const [showAgeGroup, setShowAgeGroup] = useState(false);
+  const [mascotNextUnlock, setMascotNextUnlock] = useState<MascotUnlock | null>(null);
+
+  const maybeShowOnboarding = useCallback(async () => {
+    const done = await isOnboardingDone();
+    if (!done) setShowOnboarding(true);
+  }, []);
 
   useEffect(() => {
-    isOnboardingDone().then(done => {
-      if (!done) setShowOnboarding(true);
+    isAgeGroupSelected().then(async selected => {
+      if (!selected) {
+        setShowAgeGroup(true);
+        return;
+      }
+      await maybeShowOnboarding();
     });
-  }, []);
+  }, [maybeShowOnboarding]);
+
+  const handleAgeGroupConfirm = async (ageGroup: AgeGroup) => {
+    await setAgeGroup(ageGroup);
+    setShowAgeGroup(false);
+    await maybeShowOnboarding();
+  };
+
+  const [dailyCompleted, setDailyCompleted] = useState(false);
   const [secondsLeft, setSecondsLeft] = useState(() => getSecondsUntilMidnight());
   const [dailyLevel, setDailyLevel] = useState(() => getDailyChallengeLevel());
   const [currentStreak, setCurrentStreak] = useState(0);
@@ -46,9 +69,14 @@ export default function HomeScreen() {
       const refresh = async () => {
         setSecondsLeft(getSecondsUntilMidnight());
         setDailyLevel(getDailyChallengeLevel());
-        const [completed, streakData] = await Promise.all([isTodayCompleted(), getStreakData()]);
+        const [completed, streakData, mascotProgress] = await Promise.all([
+          isTodayCompleted(),
+          getStreakData(),
+          getMascotProgress(),
+        ]);
         setDailyCompleted(completed);
         setCurrentStreak(streakData.currentStreak);
+        setMascotNextUnlock(mascotProgress.nextUnlock);
       };
       refresh();
 
@@ -97,6 +125,24 @@ export default function HomeScreen() {
             <Text style={[styles.settingsIcon, { color: colors.text.primary }]}>⋮</Text>
           </Pressable>
         </View>
+      </View>
+
+      {/* Mascot-Begrüßung — einheitlicher Fortschritts-Companion (Issue #279, 1.1) */}
+      <View style={styles.mascotRow}>
+        <Mascot
+          size={56}
+          mood={currentStreak >= 2 ? 'happy' : 'neutral'}
+          message={t(getHomeGreetingKey(currentStreak), { count: String(currentStreak) })}
+          testID="home-mascot"
+        />
+        {mascotNextUnlock && (
+          <Text style={[styles.mascotUnlockHint, { color: colors.text.secondary }]}>
+            {t('mascot.nextUnlock', {
+              count: String(mascotNextUnlock.starsRequired),
+              item: t(mascotNextUnlock.labelKey),
+            })}
+          </Text>
+        )}
       </View>
 
       {/* Hero CTA — "Spiel starten" als dominanter zentraler Button */}
@@ -203,6 +249,7 @@ export default function HomeScreen() {
       </View>
 
       <SettingsModal visible={showSettings} onClose={() => setShowSettings(false)} />
+      <AgeGroupModal visible={showAgeGroup} onConfirm={handleAgeGroupConfirm} />
       <OnboardingModal
         visible={showOnboarding}
         onClose={() => setShowOnboarding(false)}
@@ -262,6 +309,14 @@ const styles = StyleSheet.create({
   },
   settingsIcon: {
     fontSize: 24,
+  },
+  mascotRow: {
+    marginTop: Spacing.sm,
+    gap: 2,
+  },
+  mascotUnlockHint: {
+    fontSize: FontSize.xs,
+    marginLeft: 64,
   },
   heroSlot: {
     flex: 1,

--- a/app/levels.tsx
+++ b/app/levels.tsx
@@ -13,6 +13,7 @@ import { useTheme } from '@services/ThemeContext';
 import { getAllLevels } from '@services/LevelManager';
 import { getAvailablePacks } from '@services/ImagePoolManager';
 import storageManager from '@services/StorageManager';
+import { getAgeGroup, getRecommendedLevelRange } from '@services/AgeGroupManager';
 import Colors from '../constants/Colors';
 import { Spacing, FontSize, FontWeight, FontFamily, BorderRadius } from '../constants/Layout';
 import { GlassCard } from '@components/AnimatedPrimitives';
@@ -46,6 +47,7 @@ export default function LevelsScreen() {
   const [ratings, setRatings] = useState<Record<number, number | null>>({});
   const [variant, setVariant] = useState<GameVariant>('normal');
   const [pack, setPack] = useState<string>('all');
+  const [recommendedRange, setRecommendedRange] = useState<[number, number] | null>(null);
   // Use hook for responsive dimensions (SSR-safe)
   const { width: screenWidth } = useWindowDimensions();
   const cardWidth =
@@ -72,6 +74,16 @@ export default function LevelsScreen() {
       mounted = false;
     };
   }, [levels]);
+
+  useEffect(() => {
+    let mounted = true;
+    getAgeGroup().then(ageGroup => {
+      if (mounted && ageGroup) setRecommendedRange(getRecommendedLevelRange(ageGroup));
+    });
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   const renderStars = (rating: number | null, levelNumber: number) => {
     const filled = rating === null ? 0 : Math.ceil(rating / 2);
@@ -134,6 +146,14 @@ export default function LevelsScreen() {
           <Text style={[styles.backButton, { color: colors.primary }]}>← {t('common.back')}</Text>
         </TouchableOpacity>
         <Text style={[styles.title, { color: colors.text.primary }]}>{t('levels.title')}</Text>
+        {recommendedRange && (
+          <Text style={[styles.recommendedHint, { color: colors.text.secondary }]}>
+            {t('ageGroup.recommendedLevels', {
+              from: String(recommendedRange[0]),
+              to: String(recommendedRange[1]),
+            })}
+          </Text>
+        )}
       </View>
 
       {/* Spielvariante */}
@@ -201,6 +221,11 @@ const styles = StyleSheet.create({
     fontSize: FontSize.xxl,
     fontWeight: FontWeight.bold,
     fontFamily: FontFamily.extraBold,
+  },
+  recommendedHint: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.medium,
+    marginTop: 2,
   },
   variantSection: {
     paddingHorizontal: Spacing.lg,

--- a/components/AgeGroupModal.tsx
+++ b/components/AgeGroupModal.tsx
@@ -1,0 +1,152 @@
+import React, { useState } from 'react';
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from '@services/i18n';
+import { useTheme } from '@services/ThemeContext';
+import Mascot from './Mascot';
+import Colors from '../constants/Colors';
+import { BorderRadius, FontSize, FontWeight, FontFamily, Spacing } from '../constants/Layout';
+import type { AgeGroup } from '../types';
+
+interface Props {
+  visible: boolean;
+  onConfirm: (ageGroup: AgeGroup) => void;
+}
+
+const AGE_GROUPS: { id: AgeGroup; labelKey: string }[] = [
+  { id: '3-5', labelKey: 'ageGroup.group3to5' },
+  { id: '6-8', labelKey: 'ageGroup.group6to8' },
+  { id: '9plus', labelKey: 'ageGroup.group9plus' },
+];
+
+/**
+ * Erst-Start-Altersauswahl (Issue #279, 1.3). Ersetzt den früheren
+ * versteckten `extra_time_mode`-Schalter durch eine bewusste Entscheidung
+ * vor dem ersten Spiel — steuert Anzeigedauer, empfohlenen Level-Bereich
+ * und Standard-Strichstärke. Änderbar jederzeit in den Einstellungen.
+ */
+export default function AgeGroupModal({ visible, onConfirm }: Props) {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const [selected, setSelected] = useState<AgeGroup | null>(null);
+
+  return (
+    <Modal visible={visible} animationType="fade" testID="age-group-modal">
+      <View style={[styles.container, { backgroundColor: colors.background }]}>
+        <View style={styles.heroSection}>
+          <Mascot size={96} mood="happy" testID="age-group-mascot" />
+          <Text style={[styles.title, { color: colors.text.primary }]}>{t('ageGroup.title')}</Text>
+          <Text style={[styles.subtitle, { color: colors.text.secondary }]}>
+            {t('ageGroup.subtitle')}
+          </Text>
+        </View>
+
+        <View style={styles.optionsList}>
+          {AGE_GROUPS.map(group => {
+            const active = selected === group.id;
+            return (
+              <Pressable
+                key={group.id}
+                onPress={() => setSelected(group.id)}
+                style={[
+                  styles.optionCard,
+                  {
+                    backgroundColor: active ? Colors.primary : colors.surface,
+                    borderColor: active ? Colors.primary : colors.border,
+                  },
+                ]}
+                accessibilityRole="button"
+                accessibilityState={{ selected: active }}
+                testID={`age-group-option-${group.id}`}
+              >
+                <Text
+                  style={[
+                    styles.optionText,
+                    { color: active ? Colors.drawing.white : colors.text.primary },
+                  ]}
+                >
+                  {t(group.labelKey)}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        <Text style={[styles.changeLater, { color: colors.text.light }]}>
+          {t('ageGroup.changeLater')}
+        </Text>
+
+        <Pressable
+          onPress={() => selected && onConfirm(selected)}
+          disabled={!selected}
+          style={[styles.confirmButton, !selected && styles.confirmButtonDisabled]}
+          accessibilityRole="button"
+          testID="age-group-confirm"
+        >
+          <Text style={styles.confirmButtonText}>{t('ageGroup.confirm')}</Text>
+        </Pressable>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: Spacing.xxl,
+    paddingBottom: Spacing.xl,
+    paddingHorizontal: Spacing.xl,
+    justifyContent: 'space-between',
+  },
+  heroSection: {
+    alignItems: 'center',
+    gap: Spacing.sm,
+  },
+  title: {
+    fontSize: FontSize.xl,
+    fontWeight: FontWeight.bold,
+    fontFamily: FontFamily.bold,
+    textAlign: 'center',
+    marginTop: Spacing.sm,
+  },
+  subtitle: {
+    fontSize: FontSize.md,
+    textAlign: 'center',
+    lineHeight: FontSize.md * 1.4,
+    maxWidth: 300,
+  },
+  optionsList: {
+    gap: Spacing.sm,
+  },
+  optionCard: {
+    borderRadius: BorderRadius.lg,
+    borderWidth: 2,
+    paddingVertical: Spacing.md,
+    alignItems: 'center',
+    ...Colors.shadow.small,
+  },
+  optionText: {
+    fontSize: FontSize.lg,
+    fontWeight: FontWeight.bold,
+  },
+  changeLater: {
+    fontSize: FontSize.xs,
+    textAlign: 'center',
+  },
+  confirmButton: {
+    backgroundColor: Colors.primary,
+    borderRadius: BorderRadius.round,
+    paddingVertical: Spacing.lg,
+    alignItems: 'center',
+    ...Colors.shadow.large,
+  },
+  confirmButtonDisabled: {
+    opacity: 0.4,
+  },
+  confirmButtonText: {
+    color: '#fff',
+    fontSize: FontSize.lg,
+    fontWeight: FontWeight.bold,
+    fontFamily: FontFamily.bold,
+    letterSpacing: 0.4,
+  },
+});

--- a/components/Mascot.tsx
+++ b/components/Mascot.tsx
@@ -1,0 +1,193 @@
+import React from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import Svg, { Circle, Ellipse, Path, Polygon } from 'react-native-svg';
+import Colors from '../constants/Colors';
+import { BorderRadius, FontSize, FontWeight, Spacing } from '../constants/Layout';
+import type { MascotMood } from '@services/MascotManager';
+
+export type MascotAccessory = 'hat' | 'glasses' | 'bowtie' | 'crown';
+
+interface MascotProps {
+  message?: string;
+  mood?: MascotMood;
+  size?: number;
+  accessory?: MascotAccessory | null;
+  onPress?: () => void;
+  testID?: string;
+  accessibilityLabel?: string;
+}
+
+const MOOD_COLORS: Record<MascotMood, { body: string; blush: boolean }> = {
+  neutral: { body: '#4ECDC4', blush: false },
+  happy: { body: '#44CF6C', blush: true },
+  excited: { body: '#2ECC71', blush: true },
+  encouraging: { body: '#7FD8CE', blush: false },
+};
+
+/**
+ * Chamäleon-Begleitfigur ("Mali") — begrüßt, kommentiert Fortschritt und
+ * trägt kosmetische Unlocks (Issue #279, 1.1). Reine SVG-Zeichnung (kein
+ * Lottie-Asset — siehe docs/ILLUSTRATION_STYLEGUIDE.md), damit sie ohne
+ * externe Design-Assets in beide Plattformen (Native/Web) rendert.
+ */
+export default function Mascot({
+  message,
+  mood = 'neutral',
+  size = 72,
+  accessory = null,
+  onPress,
+  testID = 'mascot',
+  accessibilityLabel,
+}: MascotProps) {
+  const { body } = MOOD_COLORS[mood];
+  const eyeOffsetY = mood === 'excited' ? -2 : 0;
+
+  const svg = (
+    <Svg width={size} height={size} viewBox="0 0 100 100" testID={`${testID}-svg`}>
+      {/* Schwanz */}
+      <Path
+        d="M28 70 C 10 70, 8 50, 22 46 C 12 44, 12 30, 24 32"
+        stroke={body}
+        strokeWidth={7}
+        strokeLinecap="round"
+        fill="none"
+      />
+      {/* Füße */}
+      <Ellipse cx={38} cy={88} rx={8} ry={5} fill={body} />
+      <Ellipse cx={62} cy={88} rx={8} ry={5} fill={body} />
+      {/* Körper */}
+      <Ellipse cx={50} cy={64} rx={26} ry={22} fill={body} />
+      {/* Kopf */}
+      <Circle cx={50} cy={36} r={19} fill={body} />
+      {/* Augenhöcker */}
+      <Circle cx={39} cy={22} r={9} fill={body} />
+      <Circle cx={61} cy={22} r={9} fill={body} />
+      {/* Augen (weiß + Pupille) */}
+      <Circle cx={39} cy={22 + eyeOffsetY} r={5.5} fill={Colors.drawing.white} />
+      <Circle cx={61} cy={22 + eyeOffsetY} r={5.5} fill={Colors.drawing.white} />
+      <Circle cx={40} cy={21 + eyeOffsetY} r={2.6} fill={Colors.drawing.black} />
+      <Circle cx={62} cy={21 + eyeOffsetY} r={2.6} fill={Colors.drawing.black} />
+      {/* Wangen-Blush bei fröhlicher Stimmung */}
+      {MOOD_COLORS[mood].blush && (
+        <>
+          <Circle cx={37} cy={40} r={4} fill={Colors.drawing.pink} opacity={0.55} />
+          <Circle cx={63} cy={40} r={4} fill={Colors.drawing.pink} opacity={0.55} />
+        </>
+      )}
+      {/* Mund */}
+      {mood === 'encouraging' ? (
+        <Path
+          d="M42 45 Q50 42 58 45"
+          stroke={Colors.drawing.black}
+          strokeWidth={2}
+          strokeLinecap="round"
+          fill="none"
+        />
+      ) : (
+        <Path
+          d="M40 44 Q50 52 60 44"
+          stroke={Colors.drawing.black}
+          strokeWidth={2}
+          strokeLinecap="round"
+          fill="none"
+        />
+      )}
+
+      {/* Accessoires (kosmetische Unlocks) */}
+      {accessory === 'hat' && (
+        <>
+          <Polygon points="38,15 62,15 50,-4" fill={Colors.accentWarm} />
+          <Ellipse cx={50} cy={15} rx={16} ry={3} fill={Colors.accentWarm} />
+        </>
+      )}
+      {accessory === 'glasses' && (
+        <>
+          <Circle
+            cx={39}
+            cy={22 + eyeOffsetY}
+            r={8}
+            fill="none"
+            stroke={Colors.text.primary}
+            strokeWidth={2.5}
+          />
+          <Circle
+            cx={61}
+            cy={22 + eyeOffsetY}
+            r={8}
+            fill="none"
+            stroke={Colors.text.primary}
+            strokeWidth={2.5}
+          />
+          <Path
+            d={`M47 ${22 + eyeOffsetY} L53 ${22 + eyeOffsetY}`}
+            stroke={Colors.text.primary}
+            strokeWidth={2.5}
+          />
+        </>
+      )}
+      {accessory === 'bowtie' && (
+        <Polygon
+          points="42,55 50,60 42,65 42,60 58,60 58,65 50,60 58,55 58,60"
+          fill={Colors.secondary}
+        />
+      )}
+      {accessory === 'crown' && (
+        <Polygon
+          points="36,16 40,2 46,14 50,0 54,14 60,2 64,16"
+          fill={Colors.stars.filled}
+          stroke={Colors.accentWarm}
+          strokeWidth={1}
+        />
+      )}
+    </Svg>
+  );
+
+  const content = (
+    <View style={styles.row}>
+      <View style={{ width: size, height: size }}>{svg}</View>
+      {message ? (
+        <View style={[styles.bubble, { backgroundColor: Colors.surface }]}>
+          <Text style={[styles.bubbleText, { color: Colors.text.primary }]}>{message}</Text>
+        </View>
+      ) : null}
+    </View>
+  );
+
+  if (!onPress) {
+    return (
+      <View testID={testID} accessibilityLabel={accessibilityLabel}>
+        {content}
+      </View>
+    );
+  }
+
+  return (
+    <Pressable
+      testID={testID}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+    >
+      {content}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+  },
+  bubble: {
+    flexShrink: 1,
+    borderRadius: BorderRadius.lg,
+    paddingVertical: Spacing.xs,
+    paddingHorizontal: Spacing.sm,
+    ...Colors.shadow.small,
+  },
+  bubbleText: {
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.semibold,
+  },
+});

--- a/components/MascotUnlockToast.tsx
+++ b/components/MascotUnlockToast.tsx
@@ -1,0 +1,126 @@
+import React, { useEffect } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { useReduceMotion } from '../utils/useReduceMotion';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+import { useTranslation } from '@services/i18n';
+import Colors from '../constants/Colors';
+import { BorderRadius, FontSize, FontWeight, Spacing } from '../constants/Layout';
+import type { MascotUnlock } from '@services/MascotManager';
+
+interface Props {
+  unlock: MascotUnlock | null;
+  onHide: () => void;
+}
+
+const VISIBLE_MS = 2800;
+const FADE_MS = 280;
+
+/**
+ * Slide-in Toast für neu freigeschaltete Mascot-Accessoires (Issue #279, 1.1).
+ * Spiegelt BadgeUnlockToast, aber für das einheitliche Fortschrittssystem
+ * (Gesamt-Sterne → kosmetische Mascot-Unlocks) statt Achievements.
+ */
+export default function MascotUnlockToast({ unlock, onHide }: Props) {
+  const { t } = useTranslation();
+  const reduceMotion = useReduceMotion();
+  const translateY = useSharedValue(-80);
+  const opacity = useSharedValue(0);
+
+  useEffect(() => {
+    if (!unlock) return;
+
+    if (reduceMotion) {
+      translateY.value = 0;
+    } else {
+      translateY.value = withSequence(
+        withTiming(0, { duration: FADE_MS, easing: Easing.out(Easing.ease) }),
+        withDelay(
+          VISIBLE_MS,
+          withTiming(-80, { duration: FADE_MS, easing: Easing.in(Easing.ease) }),
+        ),
+      );
+    }
+    opacity.value = withSequence(
+      withTiming(1, { duration: FADE_MS }),
+      withDelay(VISIBLE_MS, withTiming(0, { duration: FADE_MS })),
+    );
+
+    const timer = setTimeout(onHide, VISIBLE_MS + FADE_MS * 2 + 50);
+    return () => clearTimeout(timer);
+  }, [unlock, reduceMotion, translateY, opacity, onHide]);
+
+  const animStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }],
+    opacity: opacity.value,
+  }));
+
+  if (!unlock) return null;
+
+  return (
+    <Animated.View
+      style={[styles.toast, animStyle]}
+      pointerEvents="none"
+      testID="mascot-unlock-toast"
+    >
+      <Text style={styles.emoji}>🦎</Text>
+      <View style={styles.textCol}>
+        <Text style={styles.title} numberOfLines={1}>
+          {t('mascot.unlockToast.title')}
+        </Text>
+        <Text style={styles.subtitle} numberOfLines={1}>
+          {t('mascot.unlockToast.subtitle', { item: t(unlock.labelKey) })}
+        </Text>
+      </View>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  toast: {
+    position: 'absolute',
+    top: Spacing.lg,
+    left: Spacing.md,
+    right: Spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.lg,
+    backgroundColor: Colors.surface,
+    borderRadius: BorderRadius.xl,
+    borderWidth: 1.5,
+    borderColor: Colors.accent,
+    shadowColor: Colors.accent,
+    shadowOpacity: 0.25,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 6,
+    zIndex: 1000,
+  },
+  emoji: {
+    fontSize: 32,
+    marginRight: Spacing.md,
+  },
+  textCol: {
+    flex: 1,
+  },
+  title: {
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.bold,
+    color: Colors.accent,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
+  subtitle: {
+    fontSize: FontSize.md,
+    fontWeight: FontWeight.semibold,
+    color: Colors.text.primary,
+    marginTop: 2,
+  },
+});

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -15,12 +15,14 @@ import { useTranslation, getLanguage, setLanguage, type Language } from '@servic
 import { useTheme } from '@services/ThemeContext';
 import storageManager from '@services/StorageManager';
 import SoundManager from '@services/SoundManager';
+import { getAgeGroup, setAgeGroup } from '@services/AgeGroupManager';
 import Colors from '../constants/Colors';
 import { Spacing, FontSize, FontWeight, BorderRadius } from '../constants/Layout';
 import ParentalGate from './ParentalGate';
 import ParentDashboard from './ParentDashboard';
 import BadgesModal from './BadgesModal';
 import { useParentalGateAction } from './useParentalGateAction';
+import type { AgeGroup } from '../types';
 
 interface SettingsModalProps {
   visible: boolean;
@@ -42,6 +44,7 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
   const [soundEnabled, setSoundEnabled] = useState(true);
   const [celebrationEnabled, setCelebrationEnabled] = useState(true);
   const [showParentDashboard, setShowParentDashboard] = useState(false);
+  const [ageGroup, setCurrentAgeGroup] = useState<AgeGroup | null>(null);
   const parentalGate = useParentalGateAction();
 
   useEffect(() => {
@@ -49,7 +52,13 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
     setCurrentTheme(themeSetting);
     storageManager.getSetting('soundEnabled').then(setSoundEnabled);
     storageManager.getSetting('celebrationEnabled').then(setCelebrationEnabled);
+    getAgeGroup().then(setCurrentAgeGroup);
   }, [visible, themeSetting]);
+
+  const handleAgeGroupChange = async (value: AgeGroup) => {
+    setCurrentAgeGroup(value);
+    await setAgeGroup(value);
+  };
 
   const handleLanguageChange = async (lang: Language) => {
     await setLanguage(lang);
@@ -291,6 +300,18 @@ export default function SettingsModal({ visible, onClose, embedded = false }: Se
         {t('settings.personalize')}
       </Text>
       <View style={[styles.card, { backgroundColor: colors.surface }]}>
+        {renderRow(
+          t('ageGroup.settingsLabel'),
+          renderSegment(
+            [
+              { label: t('ageGroup.group3to5'), value: '3-5' },
+              { label: t('ageGroup.group6to8'), value: '6-8' },
+              { label: t('ageGroup.group9plus'), value: '9plus' },
+            ],
+            ageGroup ?? '',
+            v => handleAgeGroupChange(v as AgeGroup),
+          ),
+        )}
         {renderRow(
           t('settings.celebration'),
           renderSegment(

--- a/components/__tests__/HomeScreen.test.tsx
+++ b/components/__tests__/HomeScreen.test.tsx
@@ -75,6 +75,31 @@ jest.mock('../../services/OnboardingManager', () => ({
   markOnboardingDone: jest.fn(async () => {}),
 }));
 
+jest.mock('../../services/AgeGroupManager', () => ({
+  isAgeGroupSelected: jest.fn(async () => true),
+  setAgeGroup: jest.fn(async () => {}),
+}));
+
+jest.mock('../../services/MascotManager', () => ({
+  getMascotProgress: jest.fn(async () => ({
+    totalStars: 0,
+    currentStreak: 0,
+    unlocked: [],
+    nextUnlock: null,
+  })),
+  getHomeGreetingKey: () => 'mascot.greeting.default',
+}));
+
+jest.mock('../../components/Mascot', () => {
+  const { View } = require('react-native');
+  return { __esModule: true, default: () => <View testID="mascot" /> };
+});
+
+jest.mock('../../components/AgeGroupModal', () => {
+  const { View } = require('react-native');
+  return { __esModule: true, default: () => <View testID="age-group-modal" /> };
+});
+
 jest.mock('../../services/ThemeContext', () => ({
   useTheme: () => ({
     colors: {

--- a/components/game/ResultPhase.tsx
+++ b/components/game/ResultPhase.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView, Modal } from 'react-native';
 import DrawingCanvas from '@components/DrawingCanvas';
 import LevelImageDisplay from '@components/LevelImageDisplay';
+import Mascot from '@components/Mascot';
 import { AnimatedFeedback, AnimatedStar } from '@components/AnimatedPrimitives';
 import Colors from '../../constants/Colors';
 import { Spacing, FontSize, FontWeight, BorderRadius } from '../../constants/Layout';
@@ -10,6 +11,7 @@ import type { ResultPhaseProps } from './game.shared';
 import { useTranslation } from '@services/i18n';
 import { useTheme } from '@services/ThemeContext';
 import { getRatingFeedback } from '@services/RatingManager';
+import { getResultMoodForStars } from '@services/MascotManager';
 import type { StarRating } from '../../types';
 
 export default function ResultPhase({
@@ -210,9 +212,16 @@ export default function ResultPhase({
             ))}
           </View>
           <AnimatedFeedback visible={userRating > 0}>
-            <Text style={[styles.feedbackText, { color: colors.text.secondary }]}>
-              {getFeedbackText(userRating)}
-            </Text>
+            <View style={styles.mascotFeedbackRow}>
+              <Mascot
+                size={48}
+                mood={getResultMoodForStars(userRating)}
+                testID="result-mascot"
+              />
+              <Text style={[styles.feedbackText, { color: colors.text.secondary }]}>
+                {getFeedbackText(userRating)}
+              </Text>
+            </View>
           </AnimatedFeedback>
         </View>
 
@@ -303,10 +312,17 @@ const styles = StyleSheet.create({
     gap: Spacing.sm,
     marginBottom: Spacing.md,
   },
+  mascotFeedbackRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: Spacing.sm,
+    paddingHorizontal: Spacing.md,
+  },
   feedbackText: {
+    flexShrink: 1,
     fontSize: FontSize.md,
-    textAlign: 'center',
-    paddingHorizontal: Spacing.lg,
+    textAlign: 'left',
   },
   completionOverlay: {
     flex: 1,

--- a/locales/de/translations.json
+++ b/locales/de/translations.json
@@ -270,5 +270,34 @@
     "badgeMemorize": "Merken",
     "badgeDraw": "Zeichnen",
     "badgeResult": "Bewerten"
+  },
+  "mascot": {
+    "greeting": {
+      "default": "Hallo! Ich bin Mali. Bereit zu spielen?",
+      "streak": "Schön, dass du wieder da bist! 🔥 {{count}} Tage in Folge!",
+      "streakLong": "Wow, {{count}} Tage in Folge! Du bist unglaublich!"
+    },
+    "nextUnlock": "Noch {{count}} Sterne bis: {{item}}",
+    "accessory": {
+      "hat": "Hut",
+      "glasses": "Sonnenbrille",
+      "bowtie": "Fliege",
+      "crown": "Krone"
+    },
+    "unlockToast": {
+      "title": "Neues Accessoire!",
+      "subtitle": "Mali trägt jetzt: {{item}}"
+    }
+  },
+  "ageGroup": {
+    "title": "Wie alt ist dein Kind?",
+    "subtitle": "Das hilft uns, Anzeigezeit und Schwierigkeit passend einzustellen.",
+    "group3to5": "3–5 Jahre",
+    "group6to8": "6–8 Jahre",
+    "group9plus": "9+ Jahre",
+    "confirm": "Los geht's!",
+    "changeLater": "Du kannst das später jederzeit in den Einstellungen ändern.",
+    "settingsLabel": "Altersstufe",
+    "recommendedLevels": "Empfohlen für dein Kind: Level {{from}}–{{to}}"
   }
 }

--- a/locales/en/translations.json
+++ b/locales/en/translations.json
@@ -270,5 +270,34 @@
     "badgeMemorize": "Remember",
     "badgeDraw": "Draw",
     "badgeResult": "Rate"
+  },
+  "mascot": {
+    "greeting": {
+      "default": "Hi! I'm Mali. Ready to play?",
+      "streak": "Great to see you again! 🔥 {{count}} days in a row!",
+      "streakLong": "Wow, {{count}} days in a row! You're amazing!"
+    },
+    "nextUnlock": "{{count}} more stars until: {{item}}",
+    "accessory": {
+      "hat": "Hat",
+      "glasses": "Sunglasses",
+      "bowtie": "Bow tie",
+      "crown": "Crown"
+    },
+    "unlockToast": {
+      "title": "New accessory!",
+      "subtitle": "Mali is now wearing: {{item}}"
+    }
+  },
+  "ageGroup": {
+    "title": "How old is your child?",
+    "subtitle": "This helps us set the display time and difficulty just right.",
+    "group3to5": "3–5 years",
+    "group6to8": "6–8 years",
+    "group9plus": "9+ years",
+    "confirm": "Let's go!",
+    "changeLater": "You can change this anytime later in settings.",
+    "settingsLabel": "Age group",
+    "recommendedLevels": "Recommended for your child: Level {{from}}–{{to}}"
   }
 }

--- a/locales/es/translations.json
+++ b/locales/es/translations.json
@@ -270,5 +270,34 @@
     "badgeMemorize": "Memoriza",
     "badgeDraw": "Dibuja",
     "badgeResult": "Puntúa"
+  },
+  "mascot": {
+    "greeting": {
+      "default": "¡Hola! Soy Mali. ¿Listo para jugar?",
+      "streak": "¡Qué bien que vuelvas! 🔥 ¡{{count}} días seguidos!",
+      "streakLong": "¡Vaya, {{count}} días seguidos! ¡Eres increíble!"
+    },
+    "nextUnlock": "Faltan {{count}} estrellas para: {{item}}",
+    "accessory": {
+      "hat": "Sombrero",
+      "glasses": "Gafas de sol",
+      "bowtie": "Pajarita",
+      "crown": "Corona"
+    },
+    "unlockToast": {
+      "title": "¡Nuevo accesorio!",
+      "subtitle": "Mali ahora lleva: {{item}}"
+    }
+  },
+  "ageGroup": {
+    "title": "¿Cuántos años tiene tu hijo/a?",
+    "subtitle": "Esto nos ayuda a ajustar el tiempo de visualización y la dificultad.",
+    "group3to5": "3–5 años",
+    "group6to8": "6–8 años",
+    "group9plus": "9+ años",
+    "confirm": "¡Vamos!",
+    "changeLater": "Puedes cambiarlo más tarde en los ajustes.",
+    "settingsLabel": "Grupo de edad",
+    "recommendedLevels": "Recomendado para tu hijo/a: Nivel {{from}}–{{to}}"
   }
 }

--- a/locales/fr/translations.json
+++ b/locales/fr/translations.json
@@ -270,5 +270,34 @@
     "badgeMemorize": "Mémorise",
     "badgeDraw": "Dessine",
     "badgeResult": "Note"
+  },
+  "mascot": {
+    "greeting": {
+      "default": "Salut ! Je suis Mali. Prêt à jouer ?",
+      "streak": "Content de te revoir ! 🔥 {{count}} jours de suite !",
+      "streakLong": "Waouh, {{count}} jours de suite ! Tu es incroyable !"
+    },
+    "nextUnlock": "Encore {{count}} étoiles avant : {{item}}",
+    "accessory": {
+      "hat": "Chapeau",
+      "glasses": "Lunettes de soleil",
+      "bowtie": "Nœud papillon",
+      "crown": "Couronne"
+    },
+    "unlockToast": {
+      "title": "Nouvel accessoire !",
+      "subtitle": "Mali porte maintenant : {{item}}"
+    }
+  },
+  "ageGroup": {
+    "title": "Quel âge a ton enfant ?",
+    "subtitle": "Cela nous aide à adapter le temps d'affichage et la difficulté.",
+    "group3to5": "3–5 ans",
+    "group6to8": "6–8 ans",
+    "group9plus": "9 ans et +",
+    "confirm": "C'est parti !",
+    "changeLater": "Tu peux changer cela plus tard dans les réglages.",
+    "settingsLabel": "Tranche d'âge",
+    "recommendedLevels": "Recommandé pour ton enfant : niveau {{from}}–{{to}}"
   }
 }

--- a/locales/it/translations.json
+++ b/locales/it/translations.json
@@ -270,5 +270,34 @@
     "badgeMemorize": "Memorizza",
     "badgeDraw": "Disegna",
     "badgeResult": "Valuta"
+  },
+  "mascot": {
+    "greeting": {
+      "default": "Ciao! Sono Mali. Pronto a giocare?",
+      "streak": "Che bello rivederti! 🔥 {{count}} giorni di fila!",
+      "streakLong": "Wow, {{count}} giorni di fila! Sei incredibile!"
+    },
+    "nextUnlock": "Ancora {{count}} stelle per: {{item}}",
+    "accessory": {
+      "hat": "Cappello",
+      "glasses": "Occhiali da sole",
+      "bowtie": "Papillon",
+      "crown": "Corona"
+    },
+    "unlockToast": {
+      "title": "Nuovo accessorio!",
+      "subtitle": "Mali ora indossa: {{item}}"
+    }
+  },
+  "ageGroup": {
+    "title": "Quanti anni ha tuo figlio/a?",
+    "subtitle": "Questo ci aiuta a impostare al meglio tempo di visualizzazione e difficoltà.",
+    "group3to5": "3–5 anni",
+    "group6to8": "6–8 anni",
+    "group9plus": "9+ anni",
+    "confirm": "Si comincia!",
+    "changeLater": "Puoi cambiarlo in qualsiasi momento nelle impostazioni.",
+    "settingsLabel": "Fascia d'età",
+    "recommendedLevels": "Consigliato per tuo figlio/a: Livello {{from}}–{{to}}"
   }
 }

--- a/locales/nl/translations.json
+++ b/locales/nl/translations.json
@@ -270,5 +270,34 @@
     "badgeMemorize": "Onthouden",
     "badgeDraw": "Tekenen",
     "badgeResult": "Beoordelen"
+  },
+  "mascot": {
+    "greeting": {
+      "default": "Hoi! Ik ben Mali. Klaar om te spelen?",
+      "streak": "Leuk dat je er weer bent! 🔥 {{count}} dagen op rij!",
+      "streakLong": "Wow, {{count}} dagen op rij! Je bent geweldig!"
+    },
+    "nextUnlock": "Nog {{count}} sterren tot: {{item}}",
+    "accessory": {
+      "hat": "Hoed",
+      "glasses": "Zonnebril",
+      "bowtie": "Vlinderdas",
+      "crown": "Kroon"
+    },
+    "unlockToast": {
+      "title": "Nieuw accessoire!",
+      "subtitle": "Mali draagt nu: {{item}}"
+    }
+  },
+  "ageGroup": {
+    "title": "Hoe oud is je kind?",
+    "subtitle": "Dit helpt ons de weergavetijd en moeilijkheidsgraad goed in te stellen.",
+    "group3to5": "3–5 jaar",
+    "group6to8": "6–8 jaar",
+    "group9plus": "9+ jaar",
+    "confirm": "Laten we beginnen!",
+    "changeLater": "Je kunt dit later altijd wijzigen in de instellingen.",
+    "settingsLabel": "Leeftijdsgroep",
+    "recommendedLevels": "Aanbevolen voor je kind: Level {{from}}–{{to}}"
   }
 }

--- a/locales/pl/translations.json
+++ b/locales/pl/translations.json
@@ -270,5 +270,34 @@
     "badgeMemorize": "Zapamiętaj",
     "badgeDraw": "Rysuj",
     "badgeResult": "Oceń"
+  },
+  "mascot": {
+    "greeting": {
+      "default": "Cześć! Jestem Mali. Gotowy do gry?",
+      "streak": "Miło Cię znów widzieć! 🔥 {{count}} dni z rzędu!",
+      "streakLong": "Wow, {{count}} dni z rzędu! Jesteś niesamowity!"
+    },
+    "nextUnlock": "Jeszcze {{count}} gwiazdek do: {{item}}",
+    "accessory": {
+      "hat": "Kapelusz",
+      "glasses": "Okulary przeciwsłoneczne",
+      "bowtie": "Muszka",
+      "crown": "Korona"
+    },
+    "unlockToast": {
+      "title": "Nowy dodatek!",
+      "subtitle": "Mali nosi teraz: {{item}}"
+    }
+  },
+  "ageGroup": {
+    "title": "Ile lat ma Twoje dziecko?",
+    "subtitle": "To pomaga nam dopasować czas wyświetlania i trudność.",
+    "group3to5": "3–5 lat",
+    "group6to8": "6–8 lat",
+    "group9plus": "9+ lat",
+    "confirm": "Zaczynamy!",
+    "changeLater": "Możesz to później zmienić w ustawieniach.",
+    "settingsLabel": "Grupa wiekowa",
+    "recommendedLevels": "Polecane dla Twojego dziecka: Poziom {{from}}–{{to}}"
   }
 }

--- a/services/AgeGroupManager.ts
+++ b/services/AgeGroupManager.ts
@@ -1,0 +1,92 @@
+/**
+ * AgeGroupManager — Altersstufen-Auswahl (Issue #279, 1.3)
+ * Ersetzt den früheren versteckten `extra_time_mode`-Schalter durch eine
+ * bewusste Altersauswahl (3–5 / 6–8 / 9+) beim ersten Start.
+ * Steuert Anzeigedauer-Bonus, empfohlenen Level-Bereich (Bildkomplexität)
+ * und Standard-Strichstärke.
+ */
+
+import { createPersistedJson } from './storage/persistedJson';
+import type { AgeGroup } from '../types';
+
+interface AgeGroupState {
+  ageGroup: AgeGroup | null;
+}
+
+const DEFAULT_STATE: AgeGroupState = { ageGroup: null };
+
+const VALID_AGE_GROUPS: AgeGroup[] = ['3-5', '6-8', '9plus'];
+
+function isAgeGroupState(v: unknown): v is AgeGroupState {
+  if (typeof v !== 'object' || v === null) return false;
+  const s = v as Record<string, unknown>;
+  return s.ageGroup === null || VALID_AGE_GROUPS.includes(s.ageGroup as AgeGroup);
+}
+
+const store = createPersistedJson<AgeGroupState>({
+  key: '@merke_male:age_group',
+  defaultValue: DEFAULT_STATE,
+  isValid: isAgeGroupState,
+});
+
+/**
+ * Lädt die gewählte Altersstufe. `null` bedeutet: noch nicht ausgewählt
+ * (löst die Erst-Start-Abfrage auf dem Home-Screen aus).
+ */
+export async function getAgeGroup(): Promise<AgeGroup | null> {
+  const state = await store.load();
+  return state.ageGroup;
+}
+
+export async function setAgeGroup(ageGroup: AgeGroup): Promise<void> {
+  await store.save({ ageGroup });
+}
+
+export async function isAgeGroupSelected(): Promise<boolean> {
+  return (await getAgeGroup()) !== null;
+}
+
+export async function resetAgeGroup(): Promise<void> {
+  await store.reset();
+}
+
+/**
+ * Zusätzliche Anzeigezeit (analog zum früheren `extra_time_mode`-Bonus von
+ * +3 s in `LevelManager.getDisplayDuration`) für jüngere Kinder.
+ */
+export function getExtraTimeForAgeGroup(ageGroup: AgeGroup | null): boolean {
+  return ageGroup === '3-5';
+}
+
+/**
+ * Standard-Strichstärke beim Start einer Zeichenrunde je Altersstufe
+ * (Werte passend zu den drei Strichstärken-Optionen in DrawPhase: 2/3/5).
+ */
+export function getDefaultStrokeWidthForAgeGroup(ageGroup: AgeGroup | null): 2 | 3 | 5 {
+  switch (ageGroup) {
+    case '3-5':
+      return 5;
+    case '9plus':
+      return 2;
+    case '6-8':
+    default:
+      return 3;
+  }
+}
+
+/**
+ * Empfohlener Level-Bereich je Altersstufe (Bildkomplexität-Steuerung).
+ * Bewusst keine harte Sperre — bestehende Level bleiben für alle spielbar,
+ * das ist nur eine Empfehlung auf dem Level-Auswahl-Screen.
+ */
+export function getRecommendedLevelRange(ageGroup: AgeGroup | null): [number, number] {
+  switch (ageGroup) {
+    case '3-5':
+      return [1, 8];
+    case '6-8':
+      return [1, 14];
+    case '9plus':
+    default:
+      return [1, 20];
+  }
+}

--- a/services/MascotManager.ts
+++ b/services/MascotManager.ts
@@ -1,0 +1,92 @@
+/**
+ * MascotManager — Begleitfigur + einheitliches Fortschrittssystem (Issue #279, 1.1)
+ *
+ * Konsolidiert bestehende Fortschritts-Signale (Sterne aus StorageManager,
+ * Streak aus StreakManager) hinter EINEM Fortschrittsbegriff: Gesamt-Sterne
+ * schalten kosmetische Mascot-Accessoires frei. Kein separates XP-System,
+ * keine zusätzliche Währung — bewusst nur eine Ressource (Sterne).
+ */
+
+import storageManager, { type AppProgress } from './StorageManager';
+import { getStreakData } from './StreakManager';
+
+export type MascotMood = 'neutral' | 'happy' | 'excited' | 'encouraging';
+
+export interface MascotUnlock {
+  id: string;
+  starsRequired: number;
+  labelKey: string; // i18n key für den Accessoire-Namen
+}
+
+/**
+ * Kosmetische Unlocks, aufsteigend nach Sterne-Schwelle sortiert.
+ * Bewusst nur Mascot-Accessoires (kein Pinselfarben-Unlock in dieser Runde,
+ * um die feste Zeichenfarbpalette — Issue-Kommentar in Colors.ts — nicht
+ * anzutasten).
+ */
+export const MASCOT_UNLOCKS: MascotUnlock[] = [
+  { id: 'hat', starsRequired: 15, labelKey: 'mascot.accessory.hat' },
+  { id: 'glasses', starsRequired: 40, labelKey: 'mascot.accessory.glasses' },
+  { id: 'bowtie', starsRequired: 80, labelKey: 'mascot.accessory.bowtie' },
+  { id: 'crown', starsRequired: 150, labelKey: 'mascot.accessory.crown' },
+];
+
+export function getTotalStars(progress: Pick<AppProgress, 'levels'>): number {
+  return Object.values(progress.levels).reduce((sum, l) => sum + l.bestRating, 0);
+}
+
+export function getUnlockedMascotAccessories(totalStars: number): MascotUnlock[] {
+  return MASCOT_UNLOCKS.filter(u => totalStars >= u.starsRequired);
+}
+
+export function getNextMascotUnlock(totalStars: number): MascotUnlock | null {
+  return MASCOT_UNLOCKS.find(u => totalStars < u.starsRequired) ?? null;
+}
+
+/**
+ * Ermittelt neu freigeschaltete Accessoires zwischen zwei Sterne-Ständen
+ * (z.B. vor/nach dem Speichern einer neuen Bewertung).
+ */
+export function getNewlyUnlockedAccessories(
+  starsBefore: number,
+  starsAfter: number,
+): MascotUnlock[] {
+  return MASCOT_UNLOCKS.filter(u => starsAfter >= u.starsRequired && starsBefore < u.starsRequired);
+}
+
+export interface MascotProgress {
+  totalStars: number;
+  currentStreak: number;
+  unlocked: MascotUnlock[];
+  nextUnlock: MascotUnlock | null;
+}
+
+/**
+ * Lädt den vereinheitlichten Fortschritt, den die Mascot-Komponente
+ * anzeigt: Gesamt-Sterne, aktuelle Streak, freigeschaltete Accessoires.
+ */
+export async function getMascotProgress(): Promise<MascotProgress> {
+  const [progress, streak] = await Promise.all([storageManager.getProgress(), getStreakData()]);
+  const totalStars = getTotalStars(progress);
+  return {
+    totalStars,
+    currentStreak: streak.currentStreak,
+    unlocked: getUnlockedMascotAccessories(totalStars),
+    nextUnlock: getNextMascotUnlock(totalStars),
+  };
+}
+
+/** Begrüßungs-i18n-Key je nach aktueller Streak. */
+export function getHomeGreetingKey(currentStreak: number): string {
+  if (currentStreak >= 7) return 'mascot.greeting.streakLong';
+  if (currentStreak >= 2) return 'mascot.greeting.streak';
+  return 'mascot.greeting.default';
+}
+
+/** Mascot-Stimmung passend zur Sterne-Bewertung einer Runde. */
+export function getResultMoodForStars(stars: number): MascotMood {
+  if (stars >= 5) return 'excited';
+  if (stars >= 4) return 'happy';
+  if (stars >= 3) return 'neutral';
+  return 'encouraging';
+}

--- a/services/__tests__/AgeGroupManager.test.ts
+++ b/services/__tests__/AgeGroupManager.test.ts
@@ -1,0 +1,56 @@
+/**
+ * AgeGroupManager Tests (Issue #279, 1.3)
+ */
+import {
+  getAgeGroup,
+  setAgeGroup,
+  isAgeGroupSelected,
+  resetAgeGroup,
+  getExtraTimeForAgeGroup,
+  getDefaultStrokeWidthForAgeGroup,
+  getRecommendedLevelRange,
+} from '../AgeGroupManager';
+
+describe('AgeGroupManager', () => {
+  beforeEach(async () => {
+    await resetAgeGroup();
+  });
+
+  it('returns null before any age group is selected', async () => {
+    expect(await getAgeGroup()).toBeNull();
+    expect(await isAgeGroupSelected()).toBe(false);
+  });
+
+  it('persists a selected age group', async () => {
+    await setAgeGroup('6-8');
+    expect(await getAgeGroup()).toBe('6-8');
+    expect(await isAgeGroupSelected()).toBe(true);
+  });
+
+  describe('getExtraTimeForAgeGroup', () => {
+    it('grants extra time only for 3-5', () => {
+      expect(getExtraTimeForAgeGroup('3-5')).toBe(true);
+      expect(getExtraTimeForAgeGroup('6-8')).toBe(false);
+      expect(getExtraTimeForAgeGroup('9plus')).toBe(false);
+      expect(getExtraTimeForAgeGroup(null)).toBe(false);
+    });
+  });
+
+  describe('getDefaultStrokeWidthForAgeGroup', () => {
+    it('returns thick strokes for young kids and thin for older kids', () => {
+      expect(getDefaultStrokeWidthForAgeGroup('3-5')).toBe(5);
+      expect(getDefaultStrokeWidthForAgeGroup('6-8')).toBe(3);
+      expect(getDefaultStrokeWidthForAgeGroup('9plus')).toBe(2);
+      expect(getDefaultStrokeWidthForAgeGroup(null)).toBe(3);
+    });
+  });
+
+  describe('getRecommendedLevelRange', () => {
+    it('narrows the range for younger age groups', () => {
+      expect(getRecommendedLevelRange('3-5')).toEqual([1, 8]);
+      expect(getRecommendedLevelRange('6-8')).toEqual([1, 14]);
+      expect(getRecommendedLevelRange('9plus')).toEqual([1, 20]);
+      expect(getRecommendedLevelRange(null)).toEqual([1, 20]);
+    });
+  });
+});

--- a/services/__tests__/MascotManager.test.ts
+++ b/services/__tests__/MascotManager.test.ts
@@ -1,0 +1,74 @@
+/**
+ * MascotManager Tests (Issue #279, 1.1)
+ */
+import {
+  getTotalStars,
+  getUnlockedMascotAccessories,
+  getNextMascotUnlock,
+  getNewlyUnlockedAccessories,
+  getHomeGreetingKey,
+  getResultMoodForStars,
+  MASCOT_UNLOCKS,
+} from '../MascotManager';
+
+describe('MascotManager', () => {
+  describe('getTotalStars', () => {
+    it('sums bestRating across all levels', () => {
+      const progress = {
+        levels: {
+          1: { levelNumber: 1, rating: 4, completedAt: '', bestRating: 4 },
+          2: { levelNumber: 2, rating: 3, completedAt: '', bestRating: 5 },
+        },
+      };
+      expect(getTotalStars(progress)).toBe(9);
+    });
+
+    it('returns 0 for no completed levels', () => {
+      expect(getTotalStars({ levels: {} })).toBe(0);
+    });
+  });
+
+  describe('getUnlockedMascotAccessories / getNextMascotUnlock', () => {
+    it('unlocks nothing below the first threshold', () => {
+      expect(getUnlockedMascotAccessories(5)).toEqual([]);
+      expect(getNextMascotUnlock(5)?.id).toBe(MASCOT_UNLOCKS[0].id);
+    });
+
+    it('unlocks accessories at and above their threshold', () => {
+      const unlocked = getUnlockedMascotAccessories(40);
+      expect(unlocked.map(u => u.id)).toEqual(['hat', 'glasses']);
+    });
+
+    it('returns null next unlock once everything is unlocked', () => {
+      expect(getNextMascotUnlock(9999)).toBeNull();
+    });
+  });
+
+  describe('getNewlyUnlockedAccessories', () => {
+    it('detects accessories crossed between before/after totals', () => {
+      const newly = getNewlyUnlockedAccessories(10, 42);
+      expect(newly.map(u => u.id)).toEqual(['hat', 'glasses']);
+    });
+
+    it('returns empty when no threshold was crossed', () => {
+      expect(getNewlyUnlockedAccessories(20, 25)).toEqual([]);
+    });
+  });
+
+  describe('getHomeGreetingKey', () => {
+    it('escalates the greeting with streak length', () => {
+      expect(getHomeGreetingKey(0)).toBe('mascot.greeting.default');
+      expect(getHomeGreetingKey(3)).toBe('mascot.greeting.streak');
+      expect(getHomeGreetingKey(7)).toBe('mascot.greeting.streakLong');
+    });
+  });
+
+  describe('getResultMoodForStars', () => {
+    it('maps star ratings to a mascot mood', () => {
+      expect(getResultMoodForStars(5)).toBe('excited');
+      expect(getResultMoodForStars(4)).toBe('happy');
+      expect(getResultMoodForStars(3)).toBe('neutral');
+      expect(getResultMoodForStars(1)).toBe('encouraging');
+    });
+  });
+});

--- a/services/__tests__/useGamePhase.test.ts
+++ b/services/__tests__/useGamePhase.test.ts
@@ -40,7 +40,18 @@ jest.mock('../StorageManager', () => ({
     saveLevelProgress: jest.fn().mockResolvedValue(undefined),
     saveToGallery: jest.fn().mockResolvedValue(undefined),
     getSettings: jest.fn().mockResolvedValue({ extraTimeMode: false }),
+    getProgress: jest.fn().mockResolvedValue({
+      levels: {},
+      lastPlayedLevel: 1,
+      totalLevelsCompleted: 0,
+      averageRating: 0,
+    }),
   },
+}));
+
+jest.mock('../AgeGroupManager', () => ({
+  getAgeGroup: jest.fn().mockResolvedValue(null),
+  getExtraTimeForAgeGroup: jest.fn(() => false),
 }));
 
 jest.mock('../SoundManager', () => ({

--- a/services/useGamePhase.ts
+++ b/services/useGamePhase.ts
@@ -10,6 +10,8 @@ import { recordSession } from '@services/SessionTracker';
 import SoundManager from '@services/SoundManager';
 import { requestReviewIfEligible } from '@services/ReviewManager';
 import { useTimer } from '@services/useTimer';
+import { getAgeGroup, getExtraTimeForAgeGroup } from '@services/AgeGroupManager';
+import { getTotalStars, getNewlyUnlockedAccessories, type MascotUnlock } from '@services/MascotManager';
 import type { DrawingPath } from '@components/DrawingCanvas';
 import type { GamePhase, LevelImage } from '../types';
 
@@ -60,6 +62,7 @@ export function useGamePhase({
   const levelStartedAtRef = useRef<number>(Date.now());
 
   const [extraTimeMode, setExtraTimeMode] = useState(false);
+  const [newMascotUnlock, setNewMascotUnlock] = useState<MascotUnlock | null>(null);
 
   const REPLAY_DURATION_MS = 3000;
   const REPLAY_FRAME_MS = 30;
@@ -77,11 +80,12 @@ export function useGamePhase({
     onExpire: handleTimerExpire,
   });
 
-  // Load extraTimeMode setting once on mount with unmount guard
+  // Load extra-time bonus from the selected age group (Issue #279, 1.3 —
+  // replaces the previous hidden extraTimeMode settings toggle).
   useEffect(() => {
     let mounted = true;
-    storageManager.getSettings().then(settings => {
-      if (mounted) setExtraTimeMode(settings.extraTimeMode);
+    getAgeGroup().then(ageGroup => {
+      if (mounted) setExtraTimeMode(getExtraTimeForAgeGroup(ageGroup));
     });
     return () => {
       mounted = false;
@@ -192,7 +196,11 @@ export function useGamePhase({
     try {
       SoundManager.playStarTap(rating);
       setUserRating(rating);
+      const starsBefore = getTotalStars(await storageManager.getProgress());
       await storageManager.saveLevelProgress(levelNumber, rating);
+      const starsAfter = getTotalStars(await storageManager.getProgress());
+      const newlyUnlocked = getNewlyUnlockedAccessories(starsBefore, starsAfter);
+      if (newlyUnlocked.length > 0) setNewMascotUnlock(newlyUnlocked[0]);
       await updateStreakAfterGame();
       await recordSession({
         durationMs: Date.now() - levelStartedAtRef.current,
@@ -296,6 +304,8 @@ export function useGamePhase({
     isReplaying,
     setIsReplaying,
     replayPaths,
+    newMascotUnlock,
+    clearMascotUnlock: () => setNewMascotUnlock(null),
     handleRatingSubmit,
     saveToGallery,
     startReplay,

--- a/types/index.ts
+++ b/types/index.ts
@@ -94,3 +94,11 @@ export interface BrushSettings {
   color: string;
   size: number; // 1 = dünn, 2 = mittel, 3 = dick
 }
+
+/**
+ * Altersstufe des Kindes (Issue #279, 1.3) — ersetzt den früheren
+ * versteckten `extra_time_mode`-Schalter durch eine bewusste Auswahl
+ * beim ersten Start. Steuert Anzeigedauer, empfohlenen Level-Bereich
+ * und Standard-Strichstärke.
+ */
+export type AgeGroup = '3-5' | '6-8' | '9plus';


### PR DESCRIPTION
## Beschreibung

Erste von vier Teil-PRs zu Issue #279 (Aufwertungs-Plan). Setzt **1.1** (Begleitfigur + einheitliches Fortschrittssystem) und **1.3** (Altersstufen statt versteckter Schalter) um.

### 1.1 — Mascot "Mali" + einheitliches Fortschrittssystem

- Neue Begleitfigur **Mali** (SVG-Chamäleon, `components/Mascot.tsx`) — begrüßt auf dem Home-Screen (streak-abhängige Begrüßung) und kommentiert die Ergebnis-Phase je nach Sterne-Bewertung (Mood: `neutral`/`happy`/`excited`/`encouraging`).
- **Ein** Fortschrittssystem statt eines weiteren Parallel-Systems: Gesamt-Sterne (aus dem bestehenden `StorageManager`-Fortschritt) schalten kosmetische Mascot-Accessoires frei (Hut → 15, Sonnenbrille → 40, Fliege → 80, Krone → 150 Sterne). Kein separates XP-System, keine neue Währung (`services/MascotManager.ts`).
- Neuer Unlock-Toast (`components/MascotUnlockToast.tsx`, spiegelt `BadgeUnlockToast`) beim Freischalten.
- Bewusst **kein** Pinselfarben-Unlock in dieser Runde, um die feste Zeichenfarbpalette nicht anzutasten (siehe Kommentar in `Colors.ts`).

### 1.3 — Altersstufen statt versteckter Schalter

- Der bisher komplett UI-lose `extra_time_mode`-Flag wird durch eine bewusste Altersauswahl (3–5 / 6–8 / 9+) beim ersten Start ersetzt (`components/AgeGroupModal.tsx`, `services/AgeGroupManager.ts`), gezeigt bevor das Onboarding-Tutorial startet.
- Steuert: Anzeigedauer-Bonus (ersetzt den alten `extraTimeMode`-Bonus in `useGamePhase`), empfohlenen Level-Bereich (dezenter Hinweis auf dem Level-Screen, **keine harte Sperre** — bestehende Level bleiben für alle spielbar) und die Standard-Strichstärke beim Rundenstart.
- Änderbar jederzeit über einen neuen Segment-Control in den Einstellungen ("Altersstufe").
- `LevelManager.getDisplayDuration()` bleibt unverändert (inkl. Tests) — nur die Quelle des `extraTimeMode`-Booleans in `useGamePhase` wurde von `AppSettings.extraTimeMode` auf die Altersgruppe umgestellt.

## Art der Änderung

- [x] Neue Funktion (non-breaking change)

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Nein — reines React-Native/`react-native-svg` (bereits global gemockt in Tests), keine Web-APIs, Storage läuft über die bestehenden `createPersistedJson`/`AsyncStorage`-Wrapper.

## Testing Checklist

- [x] `npx tsc --noEmit` — keine neuen Fehler (2 vorbestehende Fehler in `ShareService.native.ts`, unverändert)
- [x] `npm run lint` — sauber
- [x] `npm test` — 406/406 Tests grün (inkl. 2 neuer Test-Dateien: `AgeGroupManager.test.ts`, `MascotManager.test.ts`)
- [x] `npm run validate:svg-counts` — 51/51 Einträge gültig
- [ ] Manuelles Testen auf echtem Android/iOS-Gerät (nicht in dieser Umgebung möglich)

## Zusätzliche Notizen

Übersetzungen für Mascot-Texte und Altersauswahl in allen 7 Sprachen (de/en/es/fr/it/nl/pl) ergänzt.

Teil einer Serie von 4 PRs zu Issue #279: 1.1+1.3 (dieser PR) → 2.1 Stilguide → 2.2+2.3 → 2.4.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J9F1NAbCEMJ7y7oaSQFdVH)_