### PR TITLE
feat: Tablet- & Landscape-Layout für die Zeichenfläche (Issue #279, 2.4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,10 @@ components/
   Button.tsx                 # UI-Primitiv: Button (primary = LinearGradient cta, secondary = outlined, ghost = transparent, danger = solid)
   SkeletonLoader.tsx         # Skeleton Placeholder
   WebTrustFooter.tsx         # Nur Web: Play-Store-Link + Datenschutz-Link am Ende der Startseite (Issue #279, 3.4)
+  Mascot.tsx                 # Begleitfigur "Mali" (SVG-Chamäleon), Mood-Varianten, kosmetische Accessoires (Issue #279, 1.1)
+  MascotUnlockToast.tsx      # Toast bei neu freigeschaltetem Mascot-Accessoire (spiegelt BadgeUnlockToast)
+  MascotSparkle.tsx          # Lottie-Sparkle-Effekt neben der Mascot bei 5 Sternen/Unlocks (Issue #279, 2.2)
+  AgeGroupModal.tsx          # Erst-Start-Altersauswahl (3-5/6-8/9+), ersetzt den alten extra_time_mode-Schalter (Issue #279, 1.3)
 
 services/
   FloodFillService.ts        # Flood-Fill-Algorithmus (Scanline, 1-Bit-Palette)
@@ -81,6 +85,8 @@ services/
   ShareService.native.ts     # PNG-Export (Native): Skia Surface → expo-file-system + expo-sharing
   useGamePhase.ts            # Spielphasen-Hook: memorize / draw / result + Replay
   useTimer.ts                # Timer-Hook (Countdown, pause/resume via phase)
+  MascotManager.ts           # Einheitliches Fortschrittssystem: Gesamt-Sterne → Mascot-Accessoire-Unlocks, Mood/Greeting-Logik (Issue #279, 1.1)
+  AgeGroupManager.ts         # Altersstufen-Auswahl (3-5/6-8/9+): Anzeigedauer-Bonus, Standard-Strichstärke, empfohlener Level-Bereich (Issue #279, 1.3)
 
 constants/
   Colors.ts                  # Design-Tokens: Primärfarben, Gradienten, shadow.*, glass.*, Drawing-Farben
@@ -89,7 +95,7 @@ constants/
 
 utils/
   platform.ts                # isWeb/isIOS/isAndroid, safeWebAPI(), Storage-Adapter
-  useScreenLayout.ts         # Responsiver Layout-Hook (xs/sm/md/lg nach nutzbarer Höhe)
+  useScreenLayout.ts         # Responsiver Layout-Hook (xs/sm/md/lg nach nutzbarer Höhe; isLandscape/isTablet + toolbarPosition 'bottom'|'side' — Issue #279, 2.4)
 
 types/
   index.ts                   # Globale TypeScript-Typen (LevelImage, GamePhase, AppSettings, …)
@@ -226,6 +232,16 @@ interface DrawingPath {
 
 `components/game/ToolIcons.tsx` exportiert `PenIcon`, `FillIcon`, `EyeIcon` — abstrakte, einfarbige SVG-Piktogramme (via `react-native-svg`) für Pinsel/Füllen/Vorlage-ansehen in `DrawPhase.tsx`, statt bunter Emoji (✏️ 🪣 👁). Farbe wird komplett über den `color`-Prop gesteuert (aktiv = weiß, inaktiv = `colors.text.secondary`). Die Strichstärken-Auswahl (klein/mittel/groß) zeigt bei allen drei Punkten einheitlich `drawing.color`; die aktive Größe wird über einen Ring (`borderColor`) markiert, nicht über unterschiedliche Punktfarben.
 
+### Tablet-/Landscape-Layout (PR #287, Issue #279, 2.4)
+
+`useScreenLayout()` liefert zusätzlich `isLandscape` (width > height), `isTablet` (kürzere Kante ≥ 600px) und `toolbarPosition` (`'bottom' | 'side'`). Im ausreichend breiten Querformat (`safeWidth >= 480`) wechselt `toolbarPosition` auf `'side'`:
+
+- `DrawPhase.tsx` rendert Zeichenfläche und Werkzeugleiste dann nebeneinander (Farbauswahl/Werkzeuge/Strichstärken vertikal gestapelt in einer schmalen Seitenleiste, Breite `sideToolbarWidth`) statt vertikal gestapelt.
+- Die Zeichenfläche bekommt dadurch mehr Höhe (`canvasUpperLimitBase` 640 statt 320/400, da keine Werkzeugleiste mehr darunter Platz braucht).
+- Die Merke-Phase bekommt ein größeres Vorschaubild (`memorizeImageSize`-Obergrenze an die verfügbare Breite gekoppelt statt fix 280px).
+- Bei zu schmalem Querformat (z.B. Split-Screen) bleibt es beim bisherigen `'bottom'`-Layout.
+- `app.json`s `orientation: "default"` + `android:resizeableActivity="true"` (Android-Manifest-Teil von Issue #278) kamen bereits in PR #281.
+
 ---
 
 ## Flood-Fill Architektur (Native)
@@ -261,11 +277,36 @@ Storage-Keys beginnen mit `@merke_male:`.
 
 Gespeicherte Felder: `progress`, `theme`, `language`, `sound_enabled`, `music_enabled`, `extra_time_mode`, `gallery`.
 
+> `extra_time_mode` bleibt als Feld in `AppSettings`/`StorageManager` erhalten (Rückwärtskompatibilität, `LevelManager.getDisplayDuration()` nutzt es weiterhin als Parameter), steuert aber die tatsächliche Anzeigedauer im Spiel nicht mehr — das übernimmt jetzt die Altersstufe aus `AgeGroupManager` (eigener Storage-Key `@merke_male:age_group`, siehe unten).
+
+---
+
+## Mascot & Altersstufen (Issue #279, 1.1 + 1.3)
+
+**Mascot "Mali"** (`components/Mascot.tsx`, `services/MascotManager.ts`): SVG-Chamäleon-Begleitfigur, kein Lottie-Charakter (siehe `docs/ILLUSTRATION_STYLEGUIDE.md` für den visuellen Stil). Begrüßt auf dem Home-Screen (streak-abhängige Nachricht) und kommentiert die Ergebnis-Phase mit einer `MascotMood` (`neutral`/`happy`/`excited`/`encouraging`, abgeleitet aus der Sterne-Bewertung via `getResultMoodForStars()`).
+
+**Ein Fortschrittssystem statt eines weiteren Parallel-Systems:** Gesamt-Sterne (Summe aller `bestRating`-Werte aus `StorageManager.getProgress()`, `getTotalStars()`) schalten kosmetische Mascot-Accessoires frei — `MASCOT_UNLOCKS` in `MascotManager.ts`:
+
+| Schwelle (Gesamt-Sterne) | Accessoire |
+| --- | --- |
+| 15 | Hut |
+| 40 | Sonnenbrille |
+| 80 | Fliege |
+| 150 | Krone |
+
+Bewusst **kein** separates XP-System, keine zusätzliche Währung — nur diese eine Ressource. `useGamePhase.handleRatingSubmit()` vergleicht Sterne-Stand vor/nach dem Speichern (`getNewlyUnlockedAccessories()`) und zeigt bei neuem Unlock `MascotUnlockToast` (mit `MascotSparkle`-Lottie-Effekt, siehe unten).
+
+**Altersstufen** (`services/AgeGroupManager.ts`, `components/AgeGroupModal.tsx`): ersetzen den früher komplett UI-losen `extra_time_mode`-Schalter durch eine bewusste Auswahl (3-5 / 6-8 / 9+) beim ersten Start, vor dem Onboarding-Tutorial (`app/index.tsx`). Änderbar jederzeit über einen Segment-Control in `SettingsModal.tsx`. Steuert:
+
+- **Anzeigedauer-Bonus**: `getExtraTimeForAgeGroup()` — nur 3-5 bekommt den (weiterhin über `LevelManager.getDisplayDuration(level, extraTimeMode)` berechneten) Zeitbonus.
+- **Standard-Strichstärke**: `getDefaultStrokeWidthForAgeGroup()` — 3-5 dick (5), 6-8 mittel (3), 9+ dünn (2); wird beim Rundenstart in `app/game.tsx` per `drawing.setStrokeWidth()` gesetzt.
+- **Empfohlener Level-Bereich** (Bildkomplexität-Hinweis, **keine harte Sperre**): `getRecommendedLevelRange()` — dezenter Hinweistext auf `app/levels.tsx`, alle Level bleiben für jede Altersstufe spielbar.
+
 ---
 
 ## UI/UX Design System (Issue #176)
 
-Stand `testing`: Phase A, B, C und E abgeschlossen, Phase D (Konfetti + Jubel-Sound, TimerArc, Phasen-Crossfade, Stats-Counter) größtenteils umgesetzt — nur Lottie offen.
+Stand `testing`: Phase A, B, C und E abgeschlossen, Phase D (Konfetti + Jubel-Sound, TimerArc, Phasen-Crossfade, Stats-Counter, Lottie) vollständig umgesetzt (Lottie-Teil PR #286, offen).
 
 ### Phase-Übersicht
 
@@ -274,8 +315,15 @@ Stand `testing`: Phase A, B, C und E abgeschlossen, Phase D (Konfetti + Jubel-So
 | **A: Foundation** — Farbpalette, Dark Mode, Nunito-Font, Typografie         | ✅ in `testing`                                                                                                  | PR merged                            |
 | **B: Components** — Gradient-Buttons, Glassmorphism-Cards, Sterne-Animation | ✅ in `testing`                                                                                                  | PR #178 merged                       |
 | **C: Screens** — Timer-Visualisierung, Phase-Übergänge, Home-Refresh        | ✅ in `testing`                                                                                                  | PR #257 merged                       |
-| **D: Delight** — Lottie, Konfetti, Mikro-Sounds                             | 🔶 größtenteils (Konfetti + Jubel-Sound PR #253, TimerArc/Phasen-Crossfade/Stats-Counter PR #257) — Lottie offen | —                                    |
+| **D: Delight** — Lottie, Konfetti, Mikro-Sounds                             | 🔶 Konfetti + Jubel-Sound PR #253, TimerArc/Phasen-Crossfade/Stats-Counter PR #257, Lottie-Sparkle PR #286 (offen) | —                                    |
 | **E: Onboarding** — First-Run-Tour                                          | ✅ in `testing`                                                                                                  | PR #261 merged (In-Game Coach-Marks) |
+
+### Lottie (PR #286, Issue #279 2.2)
+
+`lottie-react-native` war bereits als Dependency installiert, aber nie verdrahtet — `components/MascotSparkle.tsx` ist die erste echte Nutzung: ein hand-authored Lottie-JSON (`assets/lottie/sparkle.json`) als Twinkle-Effekt neben der Mascot bei 5-Sterne-Ergebnissen und neuen Accessoire-Unlocks. Respektiert `prefers-reduced-motion`.
+
+- **Web-Plattform braucht zusätzlich `@lottiefiles/dotlottie-react`** als Peer-Dependency von `lottie-react-native` — ohne sie bricht `expo export --platform web`, sobald `LottieView` real importiert wird (war vorher nie der Fall, da ungenutzt).
+- **Jest-Mock:** `__mocks__/lottie-react-native.js` (analog zu den Skia-/react-native-svg-Mocks) — die native/Web-Implementierungen laufen nicht unter jsdom.
 
 ### Neue Primitiven (Phase B)
 
@@ -370,7 +418,8 @@ Niemals `rotation`/`origin`-Props an SVG-Elemente geben, die auch auf Web gerend
 ### Tests
 
 - Test-Dateien liegen bei `services/__tests__/`, `components/__tests__/`, `utils/__tests__/`, `__tests__/`
-- Jest-Umgebung: `jsdom`; Skia wird gemockt via `__mocks__/@shopify/react-native-skia.js`, `react-native-svg` via `__mocks__/react-native-svg.js` (beide global, automatisch für alle Tests aktiv — kein `jest.mock()`-Aufruf nötig)
+- Jest-Umgebung: `jsdom`; Skia wird gemockt via `__mocks__/@shopify/react-native-skia.js`, `react-native-svg` via `__mocks__/react-native-svg.js`, `lottie-react-native` via `__mocks__/lottie-react-native.js` (alle global, automatisch für alle Tests aktiv — kein `jest.mock()`-Aufruf nötig)
+- `getByTestId`/`queryByTestId` aus `@testing-library/react-native` matchen `node.props.testID` auf der React-Test-Instance-Ebene — unter der `react-native-web`-Abbildung (`moduleNameMapper` in `jest.config.js`) landet der Prop auf dem finalen Host-Element aber als `data-testid`, nicht mehr als `testID`, wodurch beide Queries nichts finden. Für testID-Prüfungen stattdessen `UNSAFE_getAllByType(View)` + `.props.testID`-Filter verwenden (etabliertes Muster in diesem Repo, siehe z.B. `MascotSparkle.test.tsx`).
 - `@testing-library/dom` muss installiert sein (Peer-Dep von `@testing-library/react` v16)
 - `npm test` (kein `--runInBand` nötig, aber stabil)
 
@@ -408,9 +457,9 @@ Stand: `main` @ v1.7.0 / versionCode 66. `testing` liegt voraus: enthält zusät
 | **Themen-Pack-Auswahl-UI** (Chip-Filter Alle/Tiere/Fahrzeuge, PR #271)   | ✅ in `testing`     |
 | Themen-Pack Natur / Märchen / weitere                                    | 🔲 offen            |
 | **Spielvarianten** (Nur Umriss merken, Spiegelbild, Kreativ-Modus, #247) | ✅ in main (v1.7.0) |
-| Avatar & Personalisierung                                                | 🔲 offen            |
-| XP- & Level-System                                                       | 🔲 offen            |
-| Wöchentliche Challenge                                                   | 🔲 offen            |
+| **Avatar & Personalisierung** (Mascot "Mali", Issue #279 1.1)           | 🟡 PR #284 offen — bewusst ohne separates XP-System, siehe Zeile darunter |
+| ~~XP- & Level-System~~                                                   | ❌ bewusst nicht (Issue #279 Anti-Bloat) — Gesamt-Sterne schalten stattdessen direkt Mascot-Accessoires frei |
+| Wöchentliche Challenge                                                   | ❌ bewusst nicht (Issue #279 Anti-Bloat) — ein Loop (Daily Challenge) statt mehrerer Parallel-Systeme |
 
 ### P2 — Reichweite & Trust
 
@@ -420,6 +469,7 @@ Stand: `main` @ v1.7.0 / versionCode 66. `testing` liegt voraus: enthält zusät
 | **Weitere Sprachen** (ES/FR/IT/NL/PL, #247)              | ✅ in main (v1.7.0) — automatische Geräte-Spracherkennung |
 | **Sharing-Feature / PNG-Export** (ShareService, PR #255) | ✅ in main (v1.7.0)                                       |
 | Push-Notifications (opt-in)                              | 🔲 offen                                                  |
+| **Tablet-/Landscape-Layout** (Issue #279 2.4, deckt #278 UI-seitig ab) | 🟡 PR #287 offen |
 
 ### Themen-Pack Architektur (ab PR #221, Auswahl-UI ab PR #271)
 

--- a/app/game.tsx
+++ b/app/game.tsx
@@ -381,6 +381,8 @@ export default function GameScreen() {
               buttonMinHeight: layout.buttonMinHeight,
               buttonPaddingVertical: layout.buttonPaddingVertical,
               isSmall,
+              toolbarPosition: layout.toolbarPosition,
+              sideToolbarWidth: layout.sideToolbarWidth,
             }}
             onDone={() => {
               SoundManager.playPhaseTransition();

--- a/components/__tests__/GamePhaseComponents.test.tsx
+++ b/components/__tests__/GamePhaseComponents.test.tsx
@@ -232,6 +232,24 @@ describe('DrawPhase', () => {
     expect(texts).toContain('game.draw.undo');
     expect(texts).toContain('game.draw.clear');
   });
+
+  // Issue #279, 2.4 — Querformat: Werkzeugleiste steht neben statt unter der Zeichenfläche
+  it('renders all controls when toolbarPosition is "side" (landscape)', () => {
+    const sideProps = {
+      ...drawProps,
+      layout: {
+        ...drawProps.layout,
+        toolbarPosition: 'side' as const,
+        sideToolbarWidth: 120,
+      },
+    };
+    const { UNSAFE_getAllByType } = render(<DrawPhase {...sideProps} />);
+    const texts = getAllTexts(UNSAFE_getAllByType);
+    expect(texts).toContain('game.draw.done');
+    expect(texts).toContain('game.draw.undo');
+    expect(texts).toContain('game.draw.clear');
+    expect(texts).toContain('game.draw.referenceLabel');
+  });
 });
 
 // ─── ResultPhase ─────────────────────────────────────────────────────────────

--- a/components/game/DrawPhase.tsx
+++ b/components/game/DrawPhase.tsx
@@ -25,6 +25,11 @@ export default function DrawPhase({
 
   const levelName = currentLang === 'en' ? currentImage?.displayNameEn : currentImage?.displayName;
 
+  // Querformat: Werkzeugleiste steht neben statt unter der Zeichenfläche,
+  // damit die Zeichenfläche die verfügbare Höhe voll ausnutzt (Issue #279, 2.4).
+  const isSideToolbar = layout.toolbarPosition === 'side';
+  const sideToolbarWidth = layout.sideToolbarWidth ?? 120;
+
   const dynCanvasContainer = useMemo(
     () => ({
       maxHeight: layout.canvasMaxHeight,
@@ -35,10 +40,183 @@ export default function DrawPhase({
   );
 
   const dynToolbar = useMemo(
-    () => ({
-      marginVertical: layout.toolbarMarginVertical,
-    }),
-    [layout.toolbarMarginVertical],
+    () =>
+      isSideToolbar
+        ? { marginVertical: 0, marginLeft: Spacing.sm, width: sideToolbarWidth }
+        : { marginVertical: layout.toolbarMarginVertical },
+    [isSideToolbar, sideToolbarWidth, layout.toolbarMarginVertical],
+  );
+
+  const colorList = (
+    <FlatList
+      data={DrawingColors}
+      keyExtractor={item => item.hex}
+      horizontal={!isSideToolbar}
+      showsHorizontalScrollIndicator={false}
+      showsVerticalScrollIndicator={false}
+      contentContainerStyle={isSideToolbar ? styles.colorColumnContent : styles.colorRowContent}
+      renderItem={({ item }) => (
+        <TouchableOpacity
+          style={[
+            styles.inlineColorSwatch,
+            { borderColor: item.border ?? colors.border },
+            drawing.color === item.hex && styles.inlineColorSwatchActive,
+          ]}
+          onPress={() => drawing.setColor(item.hex)}
+          accessibilityLabel={currentLang === 'de' ? item.name : item.nameEn}
+          accessibilityRole="button"
+        >
+          <View style={[styles.inlineColorSwatchInner, { backgroundColor: item.hex }]} />
+          {drawing.color === item.hex && <Text style={styles.inlineColorCheckmark}>✓</Text>}
+        </TouchableOpacity>
+      )}
+    />
+  );
+
+  const toolControls = (
+    <View style={[styles.toolRow, isSideToolbar && styles.toolRowWrap]}>
+      <TouchableOpacity
+        style={[
+          styles.toolToggleButton,
+          { backgroundColor: colors.surface, borderColor: colors.border },
+          drawing.tool === 'brush' && styles.toolToggleButtonActive,
+        ]}
+        onPress={() => drawing.setTool('brush')}
+        accessibilityLabel={t('game.draw.toolBrush')}
+        accessibilityRole="button"
+      >
+        <PenIcon
+          size={20}
+          color={drawing.tool === 'brush' ? Colors.drawing.white : colors.text.secondary}
+        />
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={[
+          styles.toolToggleButton,
+          { backgroundColor: colors.surface, borderColor: colors.border },
+          drawing.tool === 'fill' && styles.toolToggleButtonActive,
+        ]}
+        onPress={() => drawing.setTool('fill')}
+        accessibilityLabel={t('game.draw.toolFill')}
+        accessibilityRole="button"
+      >
+        <FillIcon
+          size={20}
+          color={drawing.tool === 'fill' ? Colors.drawing.white : colors.text.secondary}
+        />
+      </TouchableOpacity>
+
+      {!isSideToolbar && (
+        <View style={[styles.toolRowSeparator, { backgroundColor: colors.border }]} />
+      )}
+
+      {([2, 3, 5] as const).map(size => {
+        const isSelected = drawing.strokeWidth === size && drawing.tool !== 'fill';
+        // Alle drei Punkte zeigen die aktuell gewählte Pinselfarbe (unterscheiden sich
+        // nur in der Größe). Die Auswahl selbst wird über den Ring (borderColor) angezeigt.
+        const dotColor = drawing.tool !== 'fill' ? drawing.color : colors.text.secondary;
+        return (
+          <TouchableOpacity
+            key={size}
+            style={[
+              styles.strokeCircleButton,
+              isSelected && styles.strokeCircleButtonSelected,
+              drawing.tool === 'fill' && styles.strokeCircleDisabled,
+            ]}
+            onPress={() => {
+              if (drawing.tool !== 'fill') drawing.setStrokeWidth(size);
+            }}
+            disabled={drawing.tool === 'fill'}
+            accessibilityLabel={`${t('game.draw.strokeWidth')} ${size}`}
+            accessibilityRole="button"
+          >
+            <View
+              style={[
+                styles.strokeCircle,
+                {
+                  width: size === 2 ? 10 : size === 3 ? 16 : 22,
+                  height: size === 2 ? 10 : size === 3 ? 16 : 22,
+                  backgroundColor: dotColor,
+                },
+              ]}
+            />
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+
+  const buttonRow = (
+    <View style={styles.buttonRow}>
+      <TouchableOpacity
+        style={[
+          styles.secondaryButton,
+          { backgroundColor: colors.surface, borderColor: Colors.primary },
+        ]}
+        onPress={drawing.undo}
+        disabled={drawing.paths.length === 0}
+        accessibilityLabel={t('game.draw.undo')}
+        accessibilityRole="button"
+      >
+        <Text
+          style={[styles.secondaryButtonText, layout.isSmall && styles.buttonTextSmall]}
+          numberOfLines={1}
+          adjustsFontSizeToFit
+          minimumFontScale={0.7}
+        >
+          {t('game.draw.undo')}
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={[
+          styles.secondaryButton,
+          { backgroundColor: colors.surface, borderColor: Colors.primary },
+          drawing.paths.length === 0 && styles.buttonDisabled,
+        ]}
+        accessibilityLabel={t('game.draw.clear')}
+        accessibilityRole="button"
+        onPress={() => {
+          if (Platform.OS === 'web') {
+            if (drawing.paths.length > 0 && window.confirm(t('game.draw.clearConfirm'))) {
+              // platform-safe
+              drawing.setPaths([]);
+            }
+          } else {
+            if (drawing.paths.length === 0) return;
+            Alert.alert(t('game.draw.clear'), t('game.draw.clearConfirm'), [
+              { text: t('common.cancel'), style: 'cancel' },
+              {
+                text: t('common.yes'),
+                style: 'destructive',
+                onPress: () => {
+                  drawing.setPaths([]);
+                },
+              },
+            ]);
+          }
+        }}
+        disabled={drawing.paths.length === 0}
+      >
+        <Text
+          style={[styles.secondaryButtonText, layout.isSmall && styles.buttonTextSmall]}
+          numberOfLines={1}
+          adjustsFontSizeToFit
+          minimumFontScale={0.7}
+        >
+          {t('game.draw.clear')}
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.primaryButton} onPress={onDone}>
+        <Text
+          style={[styles.primaryButtonText, layout.isSmall && styles.buttonTextSmall]}
+          numberOfLines={1}
+          adjustsFontSizeToFit
+          minimumFontScale={0.7}
+        >
+          {t('game.draw.done')}
+        </Text>
+      </TouchableOpacity>
+    </View>
   );
 
   return (
@@ -75,190 +253,48 @@ export default function DrawPhase({
         </TouchableOpacity>
       </View>
 
-      {/* Zeichenfläche */}
-      <View style={[styles.canvasContainer, dynCanvasContainer]}>
-        <ErrorBoundary>
-          <DrawingCanvas
-            height={Math.floor(layout.canvasMaxHeight)}
-            strokeColor={drawing.color}
-            strokeWidth={drawing.strokeWidth}
-            tool={drawing.tool}
-            paths={drawing.paths}
-            onDrawingChange={drawing.setPaths}
+      {/* Hauptbereich: Zeichenfläche + Werkzeugleiste — nebeneinander im Querformat (Issue #279, 2.4) */}
+      <View style={[styles.mainArea, isSideToolbar && styles.mainAreaRow]}>
+        <View style={styles.canvasColumn}>
+          {/* Zeichenfläche */}
+          <View style={[styles.canvasContainer, dynCanvasContainer]}>
+            <ErrorBoundary>
+              <DrawingCanvas
+                height={Math.floor(layout.canvasMaxHeight)}
+                strokeColor={drawing.color}
+                strokeWidth={drawing.strokeWidth}
+                tool={drawing.tool}
+                paths={drawing.paths}
+                onDrawingChange={drawing.setPaths}
+              />
+            </ErrorBoundary>
+          </View>
+
+          {isSideToolbar && buttonRow}
+        </View>
+
+        {/* Werkzeugleiste-Gruppe */}
+        <View
+          style={[
+            styles.toolbarGroup,
+            dynToolbar,
+            { backgroundColor: colors.surfaceAlt },
+            isSideToolbar && styles.toolbarGroupSide,
+          ]}
+        >
+          {colorList}
+          <View
+            style={[
+              styles.toolbarDivider,
+              isSideToolbar && styles.toolbarDividerSide,
+              { backgroundColor: colors.border },
+            ]}
           />
-        </ErrorBoundary>
-      </View>
-
-      {/* Toolbar-Gruppe */}
-      <View style={[styles.toolbarGroup, dynToolbar, { backgroundColor: colors.surfaceAlt }]}>
-        {/* Reihe 1: Inline-Farbreihe */}
-        <FlatList
-          data={DrawingColors}
-          keyExtractor={item => item.hex}
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={styles.colorRowContent}
-          renderItem={({ item }) => (
-            <TouchableOpacity
-              style={[
-                styles.inlineColorSwatch,
-                { borderColor: item.border ?? colors.border },
-                drawing.color === item.hex && styles.inlineColorSwatchActive,
-              ]}
-              onPress={() => drawing.setColor(item.hex)}
-              accessibilityLabel={currentLang === 'de' ? item.name : item.nameEn}
-              accessibilityRole="button"
-            >
-              <View style={[styles.inlineColorSwatchInner, { backgroundColor: item.hex }]} />
-              {drawing.color === item.hex && <Text style={styles.inlineColorCheckmark}>✓</Text>}
-            </TouchableOpacity>
-          )}
-        />
-
-        <View style={[styles.toolbarDivider, { backgroundColor: colors.border }]} />
-
-        {/* Reihe 2: Pen/Fill + Strichstärken */}
-        <View style={styles.toolRow}>
-          <TouchableOpacity
-            style={[
-              styles.toolToggleButton,
-              { backgroundColor: colors.surface, borderColor: colors.border },
-              drawing.tool === 'brush' && styles.toolToggleButtonActive,
-            ]}
-            onPress={() => drawing.setTool('brush')}
-            accessibilityLabel={t('game.draw.toolBrush')}
-            accessibilityRole="button"
-          >
-            <PenIcon
-              size={20}
-              color={drawing.tool === 'brush' ? Colors.drawing.white : colors.text.secondary}
-            />
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={[
-              styles.toolToggleButton,
-              { backgroundColor: colors.surface, borderColor: colors.border },
-              drawing.tool === 'fill' && styles.toolToggleButtonActive,
-            ]}
-            onPress={() => drawing.setTool('fill')}
-            accessibilityLabel={t('game.draw.toolFill')}
-            accessibilityRole="button"
-          >
-            <FillIcon
-              size={20}
-              color={drawing.tool === 'fill' ? Colors.drawing.white : colors.text.secondary}
-            />
-          </TouchableOpacity>
-
-          <View style={[styles.toolRowSeparator, { backgroundColor: colors.border }]} />
-
-          {([2, 3, 5] as const).map(size => {
-            const isSelected = drawing.strokeWidth === size && drawing.tool !== 'fill';
-            // Alle drei Punkte zeigen die aktuell gewählte Pinselfarbe (unterscheiden sich
-            // nur in der Größe). Die Auswahl selbst wird über den Ring (borderColor) angezeigt.
-            const dotColor = drawing.tool !== 'fill' ? drawing.color : colors.text.secondary;
-            return (
-              <TouchableOpacity
-                key={size}
-                style={[
-                  styles.strokeCircleButton,
-                  isSelected && styles.strokeCircleButtonSelected,
-                  drawing.tool === 'fill' && styles.strokeCircleDisabled,
-                ]}
-                onPress={() => {
-                  if (drawing.tool !== 'fill') drawing.setStrokeWidth(size);
-                }}
-                disabled={drawing.tool === 'fill'}
-                accessibilityLabel={`${t('game.draw.strokeWidth')} ${size}`}
-                accessibilityRole="button"
-              >
-                <View
-                  style={[
-                    styles.strokeCircle,
-                    {
-                      width: size === 2 ? 10 : size === 3 ? 16 : 22,
-                      height: size === 2 ? 10 : size === 3 ? 16 : 22,
-                      backgroundColor: dotColor,
-                    },
-                  ]}
-                />
-              </TouchableOpacity>
-            );
-          })}
+          {toolControls}
         </View>
       </View>
 
-      {/* Buttons */}
-      <View style={styles.buttonRow}>
-        <TouchableOpacity
-          style={[
-            styles.secondaryButton,
-            { backgroundColor: colors.surface, borderColor: Colors.primary },
-          ]}
-          onPress={drawing.undo}
-          disabled={drawing.paths.length === 0}
-          accessibilityLabel={t('game.draw.undo')}
-          accessibilityRole="button"
-        >
-          <Text
-            style={[styles.secondaryButtonText, layout.isSmall && styles.buttonTextSmall]}
-            numberOfLines={1}
-            adjustsFontSizeToFit
-            minimumFontScale={0.7}
-          >
-            {t('game.draw.undo')}
-          </Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[
-            styles.secondaryButton,
-            { backgroundColor: colors.surface, borderColor: Colors.primary },
-            drawing.paths.length === 0 && styles.buttonDisabled,
-          ]}
-          accessibilityLabel={t('game.draw.clear')}
-          accessibilityRole="button"
-          onPress={() => {
-            if (Platform.OS === 'web') {
-              if (drawing.paths.length > 0 && window.confirm(t('game.draw.clearConfirm'))) {
-                // platform-safe
-                drawing.setPaths([]);
-              }
-            } else {
-              if (drawing.paths.length === 0) return;
-              Alert.alert(t('game.draw.clear'), t('game.draw.clearConfirm'), [
-                { text: t('common.cancel'), style: 'cancel' },
-                {
-                  text: t('common.yes'),
-                  style: 'destructive',
-                  onPress: () => {
-                    drawing.setPaths([]);
-                  },
-                },
-              ]);
-            }
-          }}
-          disabled={drawing.paths.length === 0}
-        >
-          <Text
-            style={[styles.secondaryButtonText, layout.isSmall && styles.buttonTextSmall]}
-            numberOfLines={1}
-            adjustsFontSizeToFit
-            minimumFontScale={0.7}
-          >
-            {t('game.draw.clear')}
-          </Text>
-        </TouchableOpacity>
-        <TouchableOpacity style={styles.primaryButton} onPress={onDone}>
-          <Text
-            style={[styles.primaryButtonText, layout.isSmall && styles.buttonTextSmall]}
-            numberOfLines={1}
-            adjustsFontSizeToFit
-            minimumFontScale={0.7}
-          >
-            {t('game.draw.done')}
-          </Text>
-        </TouchableOpacity>
-      </View>
+      {!isSideToolbar && buttonRow}
     </View>
   );
 }
@@ -319,6 +355,15 @@ const styles = StyleSheet.create({
     fontWeight: FontWeight.bold,
     color: '#FFFFFF',
   },
+  mainArea: {
+    flex: 1,
+  },
+  mainAreaRow: {
+    flexDirection: 'row',
+  },
+  canvasColumn: {
+    flex: 1,
+  },
   canvasContainer: {
     flex: 1,
     justifyContent: 'center',
@@ -330,7 +375,16 @@ const styles = StyleSheet.create({
     marginVertical: Spacing.sm,
     gap: Spacing.xs,
   },
+  toolbarGroupSide: {
+    justifyContent: 'flex-start',
+  },
   colorRowContent: {
+    gap: Spacing.xs,
+    paddingHorizontal: Spacing.xs,
+    paddingVertical: Spacing.xs,
+    alignItems: 'center',
+  },
+  colorColumnContent: {
     gap: Spacing.xs,
     paddingHorizontal: Spacing.xs,
     paddingVertical: Spacing.xs,
@@ -365,12 +419,21 @@ const styles = StyleSheet.create({
     height: 1,
     marginHorizontal: Spacing.xs,
   },
+  toolbarDividerSide: {
+    height: 1,
+    width: '100%',
+    marginHorizontal: 0,
+  },
   toolRow: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: Spacing.sm,
     paddingVertical: Spacing.xs,
     paddingHorizontal: Spacing.xs,
+  },
+  toolRowWrap: {
+    flexWrap: 'wrap',
+    justifyContent: 'center',
   },
   toolToggleButton: {
     width: 40,

--- a/components/game/game.shared.ts
+++ b/components/game/game.shared.ts
@@ -38,6 +38,9 @@ export interface DrawPhaseProps {
     buttonMinHeight: number;
     buttonPaddingVertical: number;
     isSmall: boolean;
+    /** 'side' im Querformat (Werkzeugleiste neben statt unter der Zeichenfläche) — Issue #279, 2.4 */
+    toolbarPosition?: 'bottom' | 'side';
+    sideToolbarWidth?: number;
   };
   onDone: () => void;
 }

--- a/utils/__tests__/useScreenLayout.test.ts
+++ b/utils/__tests__/useScreenLayout.test.ts
@@ -185,6 +185,63 @@ describe('useScreenLayout', () => {
     });
   });
 
+  describe('Querformat / Tablet (Issue #279, 2.4)', () => {
+    it('erkennt Querformat wenn width > height', () => {
+      mockWindowDimensions = { width: 932, height: 430 };
+      mockInsets = { top: 0, bottom: 21, left: 50, right: 50 };
+      const { result } = renderHook(() => useScreenLayout());
+      expect(result.current.isLandscape).toBe(true);
+    });
+
+    it('bleibt im Hochformat, wenn height >= width', () => {
+      mockWindowDimensions = { width: 390, height: 844 };
+      mockInsets = { top: 47, bottom: 34, left: 0, right: 0 };
+      const { result } = renderHook(() => useScreenLayout());
+      expect(result.current.isLandscape).toBe(false);
+      expect(result.current.toolbarPosition).toBe('bottom');
+    });
+
+    it('erkennt Tablets über die kürzere Bildschirmkante (>= 600px)', () => {
+      mockWindowDimensions = { width: 1180, height: 820 };
+      mockInsets = { top: 24, bottom: 20, left: 0, right: 0 };
+      const { result } = renderHook(() => useScreenLayout());
+      expect(result.current.isTablet).toBe(true);
+    });
+
+    it('verschiebt die Werkzeugleiste im breiten Querformat zur Seite', () => {
+      mockWindowDimensions = { width: 932, height: 430 };
+      mockInsets = { top: 0, bottom: 21, left: 50, right: 50 };
+      const { result } = renderHook(() => useScreenLayout());
+      expect(result.current.toolbarPosition).toBe('side');
+      expect(result.current.sideToolbarWidth).toBeGreaterThan(0);
+    });
+
+    it('bleibt bei "bottom", wenn im Querformat zu wenig Breite übrig ist', () => {
+      // Sehr schmales Querformat-Popup (z.B. Split-Screen) — sollte nicht seitlich stapeln
+      mockWindowDimensions = { width: 460, height: 300 };
+      mockInsets = { top: 0, bottom: 0, left: 0, right: 0 };
+      const { result } = renderHook(() => useScreenLayout());
+      expect(result.current.toolbarPosition).toBe('bottom');
+    });
+
+    it('erlaubt der Zeichenfläche im Tablet-Querformat eine größere Obergrenze als im Portrait-Großgerät', () => {
+      // Portrait, großes Gerät: canvasUpperLimitBase = 400 (isLarge)
+      mockWindowDimensions = { width: 430, height: 932 };
+      mockInsets = { top: 50, bottom: 34, left: 0, right: 0 };
+      const { result: portraitResult } = renderHook(() => useScreenLayout());
+
+      // Tablet-Querformat mit viel vertikalem Platz: canvasUpperLimitBase = 640 (toolbarPosition 'side')
+      mockWindowDimensions = { width: 1180, height: 900 };
+      mockInsets = { top: 24, bottom: 20, left: 0, right: 0 };
+      const { result: landscapeResult } = renderHook(() => useScreenLayout());
+
+      expect(landscapeResult.current.toolbarPosition).toBe('side');
+      expect(landscapeResult.current.canvasMaxHeight).toBeGreaterThan(
+        portraitResult.current.canvasMaxHeight,
+      );
+    });
+  });
+
   describe('Header-Padding', () => {
     it('headerPaddingVertical ist auf xs kleiner als auf lg', () => {
       mockWindowDimensions = { width: 320, height: 480 };

--- a/utils/useScreenLayout.ts
+++ b/utils/useScreenLayout.ts
@@ -37,6 +37,16 @@ export interface ScreenLayout {
   isSmall: boolean; // size === 'xs' | 'sm'
   isMedium: boolean; // size === 'md'
   isLarge: boolean; // size === 'lg'
+  /** Breiter als hoch (Tablet/Handy im Querformat) */
+  isLandscape: boolean;
+  /** Kürzere Bildschirmkante ≥ 600 px — grobe Tablet-Erkennung */
+  isTablet: boolean;
+
+  // ── Draw-Phase Layout-Modus (Issue #279, 2.4) ─────────────────────
+  /** 'side' im Querformat (Zeichenfläche + Werkzeugleiste nebeneinander), sonst 'bottom' */
+  toolbarPosition: 'bottom' | 'side';
+  /** Breite der seitlichen Werkzeugleiste, wenn toolbarPosition === 'side' */
+  sideToolbarWidth: number;
 
   // ── Header ──────────────────────────────────────────────────────────
   /** Vertikales Innen-Padding des Headers */
@@ -88,6 +98,10 @@ export function useScreenLayout(): ScreenLayout {
 
   // Nutzbare Höhe ohne Systemelemente
   const safeHeight = height - insets.top - insets.bottom;
+  const safeWidth = width - insets.left - insets.right;
+
+  const isLandscape = width > height;
+  const isTablet = Math.min(width, height) >= 600;
 
   // Größenklasse ermitteln
   const size: ScreenSize =
@@ -97,6 +111,12 @@ export function useScreenLayout(): ScreenLayout {
   const isSmall = size === 'xs' || size === 'sm';
   const isMedium = size === 'md';
   const isLarge = size === 'lg';
+
+  // Werkzeugleiste wandert im Querformat neben die Zeichenfläche, statt
+  // darunter gestapelt zu werden — braucht ausreichend Breite dafür (sonst
+  // bleibt es beim vertikalen Stack, z.B. sehr schmales Querformat-Popup).
+  const toolbarPosition: 'bottom' | 'side' = isLandscape && safeWidth >= 480 ? 'side' : 'bottom';
+  const sideToolbarWidth = isXSmall ? 96 : isSmall ? 108 : 128;
 
   // ── Header ──────────────────────────────────────────────────────────
   const headerPaddingVertical = isXSmall ? 4 : isSmall ? 8 : 24;
@@ -114,9 +134,12 @@ export function useScreenLayout(): ScreenLayout {
   // ── Canvas ───────────────────────────────────────────────────────────
   // Schätzung des Platzes, der von festen Elementen verbraucht wird:
   //   Header + phaseContainer-Padding + Toolbar + Buttons + Gaps
+  // Im Querformat (toolbarPosition === 'side') steht die Werkzeugleiste
+  // neben statt unter der Zeichenfläche — sie kostet dann keine Höhe.
+  const isSideToolbar = toolbarPosition === 'side';
   const headerHeight = headerPaddingVertical * 2 + 44; // content ~44 px
   const phasePadding = (isXSmall ? 8 : 16) * 2;
-  const toolbarHeight = toolbarButtonMinHeight + toolbarMarginVertical * 2;
+  const toolbarHeight = isSideToolbar ? 0 : toolbarButtonMinHeight + toolbarMarginVertical * 2;
   const buttonHeight = buttonMinHeight + buttonPaddingVertical * 2;
   const gapTotal = isXSmall ? 8 : 16;
 
@@ -126,17 +149,25 @@ export function useScreenLayout(): ScreenLayout {
   // Canvas bekommt 95 % des verbleibenden Platzes, aber immer im Bereich [minH, maxH].
   // Min-Höhe und Obergrenze werden zusätzlich auf die tatsächlich verbleibende Höhe begrenzt,
   // damit keine vertikale Überlappung auf sehr kleinen / Split-Screen-Layouts entsteht.
+  // Im Querformat/Tablet darf die Zeichenfläche deutlich größer werden (mehr Bildschirmfläche
+  // durch die seitliche statt gestapelte Werkzeugleiste, siehe Issue #279, 2.4).
   const rawCanvasHeight = remainingHeight * 0.95;
   const baseCanvasMinHeight = isXSmall ? 90 : isSmall ? 120 : 160;
   const canvasMinHeight = Math.min(baseCanvasMinHeight, remainingHeight);
-  const canvasUpperLimit = Math.min(isLarge ? 400 : 320, remainingHeight);
+  const canvasUpperLimitBase = isSideToolbar || isTablet ? 640 : isLarge ? 400 : 320;
+  const canvasUpperLimit = Math.min(canvasUpperLimitBase, remainingHeight);
   const canvasMaxHeight = Math.min(Math.max(rawCanvasHeight, canvasMinHeight), canvasUpperLimit);
   const canvasMarginVertical = isXSmall ? 2 : 4;
 
   // ── Merke-Phase ───────────────────────────────────────────────────
-  // Bild bekommt ~40 % der sicheren Höhe, eingegrenzt auf [140 px, 280 px]
-  const memorizeImageSize = Math.min(Math.max(safeHeight * 0.4, 140), 280);
-  const imagePlaceholderMinSize = Math.min(Math.max(safeHeight * 0.42, 150), 280);
+  // Bild bekommt ~40 % der sicheren Höhe, eingegrenzt auf [140 px, 280 px].
+  // Im Querformat ist die Höhe der begrenzende Faktor, nicht die Breite —
+  // Obergrenze daher an min(Breite, Höhe) koppeln, damit Tablets im
+  // Querformat ein größeres Vorschaubild bekommen statt am Portrait-Limit
+  // von 280px zu kleben (Issue #279, 2.4).
+  const memorizeUpperBound = isLandscape ? Math.min(safeWidth * 0.5, 420) : 280;
+  const memorizeImageSize = Math.min(Math.max(safeHeight * 0.4, 140), memorizeUpperBound);
+  const imagePlaceholderMinSize = Math.min(Math.max(safeHeight * 0.42, 150), memorizeUpperBound);
 
   return {
     screenWidth: width,
@@ -147,6 +178,10 @@ export function useScreenLayout(): ScreenLayout {
     isSmall,
     isMedium,
     isLarge,
+    isLandscape,
+    isTablet,
+    toolbarPosition,
+    sideToolbarWidth,
     headerPaddingVertical,
     headerPaddingHorizontal,
     canvasMaxHeight,


### PR DESCRIPTION
## Beschreibung

Vierte und letzte Teil-PR zu Issue #279 (Aufwertungs-Plan). Setzt **2.4** (Tablet- & Landscape-Layout) um.

**Basiert auf PR #286** (2.2+2.3) — reiner Layout-Diff, keine inhaltliche Abhängigkeit, aber stapelt aus Konsistenzgründen auf der bisherigen PR-Kette. Sobald #286 nach `testing` gemerged ist, retargetet GitHub diesen PR automatisch.

### Was ändert sich

Kinder spielen auf Familien-Tablets; `supportsTablet: true` ist gesetzt, `app.json`s `orientation` war bereits auf `"default"` (PR #281, Issue #278), aber die **UI selbst** war weiterhin portrait-only mit einer unter der Zeichenfläche gestapelten Werkzeugleiste — im Querformat blieb dadurch viel Bildschirmfläche ungenutzt.

- **`utils/useScreenLayout.ts`**: neue Felder `isLandscape`, `isTablet` (kürzere Bildschirmkante ≥ 600px), `toolbarPosition` (`'bottom' | 'side'`), `sideToolbarWidth`.
  - Im ausreichend breiten Querformat (`safeWidth >= 480`) wechselt `toolbarPosition` auf `'side'` — die Zeichenfläche bekommt dadurch spürbar mehr Höhe (kein Platzverbrauch durch die darunter gestapelte Werkzeugleiste mehr, `canvasUpperLimitBase` 640 statt 320/400).
  - Die Merke-Phase bekommt ein größeres Vorschaubild im Querformat (Obergrenze an die verfügbare Breite gekoppelt statt fix 280px).
  - Bei zu schmalem Querformat (z.B. Split-Screen-Popup) bleibt es bewusst beim bisherigen `'bottom'`-Layout.
- **`components/game/DrawPhase.tsx`**: rendert Zeichenfläche + Werkzeugleiste im Querformat nebeneinander (Farbauswahl/Werkzeuge/Strichstärken vertikal gestapelt in einer schmalen Seitenleiste) statt wie bisher immer vertikal gestapelt. Portrait-Verhalten ist unverändert (Standardwert bleibt `'bottom'`).
- **`components/game/game.shared.ts`** / **`app/game.tsx`**: `toolbarPosition`/`sideToolbarWidth` als optionale Felder durchgereicht (Default-Verhalten bei fehlenden Feldern bleibt Portrait/Bottom — bestehende Test-Mocks ohne diese Felder brauchten daher keine Anpassung).

### Bewusst nicht Teil dieses PRs

- Kein erneuter Android-Manifest-Fix (bereits in PR #281 / Issue #278 erledigt).
- Kein Umbau von `MemorizePhase.tsx` selbst — die Komponente nutzt `memorizeImageSize`/`imagePlaceholderMinSize` bereits direkt ohne harte Caps, die Vergrößerung im Querformat kommt automatisch aus dem Hook.

## Art der Änderung

- [x] Neue Funktion (non-breaking change)

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Nein — reines Layout über `useWindowDimensions`/Flexbox, keine Web-APIs.

## Testing Checklist

- [x] `npx tsc --noEmit` — keine neuen Fehler
- [x] `npm run lint` — sauber
- [x] `npm test` — 415/415 Tests grün (6 neue Fälle in `useScreenLayout.test.ts`, 1 neuer Fall in `GamePhaseComponents.test.tsx` für `toolbarPosition: 'side'`)
- [x] `npm run validate:svg-counts` — weiterhin 51/51 gültig
- [ ] Manuelles Testen auf echtem Tablet/Android-Emulator im Querformat (nicht in dieser Umgebung möglich)

## Zusätzliche Notizen

Letzter PR einer Serie von 4 zu Issue #279: 1.1+1.3 (#284) → 2.1 (#285) → 2.2+2.3 (#286) → **2.4 (dieser PR)**.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J9F1NAbCEMJ7y7oaSQFdVH)_