### PR TITLE
feat: SEO basics for web landing page

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://s540d.github.io/DrawFromMemory/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://s540d.github.io/DrawFromMemory/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/scripts/post-build.js
+++ b/scripts/post-build.js
@@ -3,6 +3,10 @@ const path = require('path');
 
 const distPath = path.join(__dirname, '..', 'dist');
 const baseUrl = '/DrawFromMemory';
+const siteUrl = 'https://s540d.github.io/DrawFromMemory/';
+const appTitle = 'Merke und Male - Gedächtnistraining für Kinder';
+const appDescription =
+  'Merke und Male: Gedächtnistraining für Kinder. Bild kurz ansehen, aus dem Gedächtnis nachzeichnen und vergleichen — spielerisch lernen, kostenlos und werbefrei.';
 
 console.log('🔧 Starting post-build processing for expo-router + GitHub Pages...');
 
@@ -31,10 +35,39 @@ htmlFiles.forEach(filePath => {
 
   // Fix title if empty (expo-router sometimes generates empty titles)
   if (html.includes('<title data-rh="true"></title>') || html.includes('<title></title>')) {
-    html = html.replace(
-      /<title[^>]*><\/title>/,
-      '<title>Merke und Male - Gedächtnistraining</title>',
-    );
+    html = html.replace(/<title[^>]*><\/title>/, `<title>${appTitle}</title>`);
+  } else {
+    // Ensure a descriptive, SEO-friendly title even when expo-router already set one
+    html = html.replace(/<title>[^<]*<\/title>/, `<title>${appTitle}</title>`);
+  }
+
+  // SEO tags: only for index.html (the actual public landing page) —
+  // avoids duplicate-content signals across expo-router's other generated pages.
+  if (fileName === 'index.html') {
+    const seoTags = [
+      `<meta name="robots" content="index, follow">`,
+      `<meta property="og:title" content="${appTitle}">`,
+      `<meta property="og:description" content="${appDescription}">`,
+      `<meta property="og:type" content="website">`,
+      `<meta property="og:url" content="${siteUrl}">`,
+      `<meta property="og:image" content="${siteUrl}feature-graphic.png">`,
+      `<meta name="twitter:card" content="summary_large_image">`,
+      `<meta name="twitter:title" content="${appTitle}">`,
+      `<meta name="twitter:description" content="${appDescription}">`,
+      `<meta name="twitter:image" content="${siteUrl}feature-graphic.png">`,
+      `<link rel="canonical" href="${siteUrl}">`,
+    ].join('\n');
+
+    if (html.includes('<meta name="description"')) {
+      // Overwrite the description injected from app.json's web.description with the
+      // more detailed SEO copy, and insert the rest of the SEO tags right after it.
+      html = html.replace(
+        /<meta name="description"[^>]*>/,
+        `<meta name="description" content="${appDescription}">\n${seoTags}`,
+      );
+    } else {
+      html = html.replace('</head>', `<meta name="description" content="${appDescription}">\n${seoTags}\n</head>`);
+    }
   }
 
   fs.writeFileSync(filePath, html);

--- a/scripts/post-build.js
+++ b/scripts/post-build.js
@@ -66,7 +66,10 @@ htmlFiles.forEach(filePath => {
         `<meta name="description" content="${appDescription}">\n${seoTags}`,
       );
     } else {
-      html = html.replace('</head>', `<meta name="description" content="${appDescription}">\n${seoTags}\n</head>`);
+      html = html.replace(
+        '</head>',
+        `<meta name="description" content="${appDescription}">\n${seoTags}\n</head>`,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

- Injects `<title>`, meta description, `robots` meta, Open Graph tags (og:title/description/type/url/image), Twitter Card tags, and a canonical link into the deployed `index.html` landing page. Applied only to `index.html` (not the privacy-policy pages) to avoid duplicate-content/og:url conflicts.
- Adds `public/robots.txt` (allow all, points to sitemap) and `public/sitemap.xml` (single root URL entry).
- og:image / twitter:image use the existing `public/feature-graphic.png` (1024x500, already deployed to the site root).

## Why in post-build.js, not app/+html.tsx

`app.json` sets `web.output: "single"` (SPA mode), which means Expo Router's `app/+html.tsx` template is **not used** during export — it only applies to `"output": "static"`. The served `index.html` head is generated purely from `app.json`'s `web` config (name/description/themeColor/favicon), with no template hook available in single-output mode. `scripts/post-build.js` already does post-export HTML rewriting (GitHub Pages subpath fix-up), so the SEO tag injection was added there as a natural extension of the existing pattern.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 415/415 passing
- [x] `npm run format:check` — clean
- [x] `npx expo export --platform web && node scripts/post-build.js` — verified generated `dist/index.html` contains title/description/OG/Twitter/canonical/robots tags with correct GitHub Pages subpath URLs; verified `dist/robots.txt` and `dist/sitemap.xml` are present and correctly copied from `public/`; verified privacy-policy pages did NOT receive the OG/canonical tags (avoids duplicate content signals)

Part of S540d/project-templates#95