### PR TITLE
feat: Micro-Animationen, klarere First-Run-Führung + TS-Cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ components/
   ParentalGate.tsx           # Eltern-Sperre für Einstellungen
   SettingsModal.tsx          # Einstellungen-Modal (In-Game)
   ErrorBoundary.tsx          # Fehlerbehandlung für Render-Fehler
-  AnimatedPrimitives.tsx     # AnimatedCard, GlassCard, AnimatedButton, AnimatedFeedback, AnimatedStar
+  AnimatedPrimitives.tsx     # AnimatedCard, GlassCard, AnimatedButton, AnimatedFeedback, AnimatedStar, PressableScale, PulseView
   AnimatedSplashScreen.tsx   # Animierter Splash Screen
   Badge.tsx                  # UI-Primitiv: Badge
   Chip.tsx                   # UI-Primitiv: Chip
@@ -330,13 +330,15 @@ Stand `testing`: Phase A, B, C, D und E vollständig abgeschlossen (Lottie-Teil 
 
 **`AnimatedPrimitives.tsx`** exportiert:
 
-| Komponente         | Zweck                                                                                                            |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| `AnimatedCard`     | Fade-in + Slide-up Eingangs-Animation mit Stagger (50 ms/Item)                                                   |
-| `GlassCard`        | Glassmorphism + Eingangs-Animation + optionaler Press-Lift (scale 0.97, Spring) — `prefers-reduced-motion`-aware |
-| `AnimatedButton`   | Scale-Spring bei Press                                                                                           |
-| `AnimatedFeedback` | Scale + Fade beim Erscheinen (z.B. Feedback-Text)                                                                |
-| `AnimatedStar`     | Spring-Bounce-Pop beim Füllen, Stagger 80 ms/Stern, goldener Textglow — `prefers-reduced-motion`-aware           |
+| Komponente         | Zweck                                                                                                                                  |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `AnimatedCard`     | Fade-in + Slide-up Eingangs-Animation mit Stagger (50 ms/Item)                                                                         |
+| `GlassCard`        | Glassmorphism + Eingangs-Animation + optionaler Press-Lift (scale 0.97, Spring) — `prefers-reduced-motion`-aware                       |
+| `AnimatedButton`   | Scale-Spring bei Press — `prefers-reduced-motion`-aware                                                                                |
+| `AnimatedFeedback` | Scale + Fade beim Erscheinen (z.B. Feedback-Text)                                                                                      |
+| `AnimatedStar`     | Spring-Bounce-Pop beim Füllen, Stagger 80 ms/Stern, goldener Textglow — `prefers-reduced-motion`-aware                                 |
+| `PressableScale`   | Generischer Pressable mit Spring-Scale-Down beim Drücken — taktiles Feedback für schmucklose Kacheln, `prefers-reduced-motion`-aware   |
+| `PulseView`        | Sanfter Dauer-Puls (Scale-Oszillation) als Aufmerksamkeits-Hinweis für Primäraktionen; `enabled`-Prop + `prefers-reduced-motion`-aware |
 
 **`GlassCard` verwenden:**
 

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { View, Text, StyleSheet, Pressable, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
+import { AnimatedCard, PressableScale, PulseView } from '@components/AnimatedPrimitives';
 import { useRouter, useFocusEffect } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from '@services/i18n';
@@ -145,102 +146,111 @@ export default function HomeScreen() {
         )}
       </View>
 
-      {/* Hero CTA — "Spiel starten" als dominanter zentraler Button */}
+      {/* Hero CTA — "Spiel starten" als dominanter zentraler Button.
+          Sanfter Dauer-Puls führt das Auge zur Primäraktion (prefers-reduced-motion-aware). */}
       <View style={styles.heroSlot}>
-        <TouchableOpacity
-          onPress={() => router.push('/game')}
-          accessibilityRole="button"
-          accessibilityLabel={t('home.startButton')}
-          style={styles.heroCtaWrapper}
-          activeOpacity={0.85}
-        >
-          <LinearGradient
-            colors={Colors.gradient.cta as [string, string]}
-            start={{ x: 0, y: 0 }}
-            end={{ x: 1, y: 1 }}
-            style={styles.heroCtaPill}
+        <PulseView>
+          <PressableScale
+            onPress={() => router.push('/game')}
+            accessibilityRole="button"
+            accessibilityLabel={t('home.startButton')}
+            style={styles.heroCtaWrapper}
           >
-            <Text style={styles.heroCtaIcon}>▶</Text>
-            <Text style={styles.heroCtaText}>{t('home.startButton')}</Text>
-          </LinearGradient>
-        </TouchableOpacity>
+            <LinearGradient
+              colors={Colors.gradient.cta as [string, string]}
+              start={{ x: 0, y: 0 }}
+              end={{ x: 1, y: 1 }}
+              style={styles.heroCtaPill}
+            >
+              <Text style={styles.heroCtaIcon}>▶</Text>
+              <Text style={styles.heroCtaText}>{t('home.startButton')}</Text>
+            </LinearGradient>
+          </PressableScale>
+        </PulseView>
       </View>
 
-      {/* Bottom section: sekundär-Aktionen + Stats — versetzt, nicht statisch gestapelt */}
+      {/* Bottom section: sekundär-Aktionen + Stats — versetzt, nicht statisch gestapelt.
+          Gestaffelte Eingangs-Animation (AnimatedCard-Index) + Press-Feedback (PressableScale). */}
       <View style={styles.bottomSection}>
         {/* Daily Challenge — breite Karte, abgesetzt von den anderen */}
-        <TouchableOpacity
-          style={[
-            styles.dailyChallengeButton,
-            {
-              backgroundColor: colors.surface,
-              borderColor: dailyCompleted ? colors.text.light : '#F59E0B',
-            },
-            dailyCompleted && styles.dailyChallengeCompleted,
-          ]}
-          onPress={() => !dailyCompleted && router.push(`/game?level=${dailyLevel}&daily=1`)}
-          accessibilityRole="button"
-          disabled={dailyCompleted}
-        >
-          <Text style={styles.dailyChallengeEmoji}>⚡</Text>
-          <View style={styles.dailyChallengeInfo}>
-            <Text
-              style={[
-                styles.dailyChallengeTitle,
-                { color: dailyCompleted ? colors.text.secondary : '#D97706' },
-              ]}
-            >
-              {t('dailyChallenge.title')}
-            </Text>
-            <Text style={[styles.dailyChallengeMeta, { color: colors.text.secondary }]}>
-              {dailyCompleted
-                ? t('dailyChallenge.completed')
-                : `${t('dailyChallenge.level', { number: String(dailyLevel) })} · ${t('dailyChallenge.countdown', { hours: String(countdownHours), minutes: String(countdownMinutes) })}`}
-            </Text>
-          </View>
-        </TouchableOpacity>
+        <AnimatedCard index={0}>
+          <PressableScale
+            style={[
+              styles.dailyChallengeButton,
+              {
+                backgroundColor: colors.surface,
+                borderColor: dailyCompleted ? colors.text.light : '#F59E0B',
+              },
+              dailyCompleted && styles.dailyChallengeCompleted,
+            ]}
+            onPress={() => !dailyCompleted && router.push(`/game?level=${dailyLevel}&daily=1`)}
+            accessibilityRole="button"
+            disabled={dailyCompleted}
+            accessibilityState={{ disabled: dailyCompleted }}
+          >
+            <Text style={styles.dailyChallengeEmoji}>⚡</Text>
+            <View style={styles.dailyChallengeInfo}>
+              <Text
+                style={[
+                  styles.dailyChallengeTitle,
+                  { color: dailyCompleted ? colors.text.secondary : '#D97706' },
+                ]}
+              >
+                {t('dailyChallenge.title')}
+              </Text>
+              <Text style={[styles.dailyChallengeMeta, { color: colors.text.secondary }]}>
+                {dailyCompleted
+                  ? t('dailyChallenge.completed')
+                  : `${t('dailyChallenge.level', { number: String(dailyLevel) })} · ${t('dailyChallenge.countdown', { hours: String(countdownHours), minutes: String(countdownMinutes) })}`}
+              </Text>
+            </View>
+          </PressableScale>
+        </AnimatedCard>
 
         {/* Levels + Galerie + Kreativ — Side-by-Side */}
-        <View style={styles.secondaryRow}>
-          <TouchableOpacity
+        <AnimatedCard index={1} style={styles.secondaryRow}>
+          <PressableScale
             style={[
               styles.secondaryTile,
               { backgroundColor: colors.surface, borderColor: colors.primary },
             ]}
             onPress={() => router.push('/levels')}
             accessibilityRole="button"
+            accessibilityLabel={t('home.levelsButton')}
           >
             <Text style={[styles.secondaryTileText, { color: colors.primary }]}>
               {t('home.levelsButton')}
             </Text>
-          </TouchableOpacity>
+          </PressableScale>
 
-          <TouchableOpacity
+          <PressableScale
             style={[
               styles.secondaryTile,
               { backgroundColor: colors.surface, borderColor: colors.primary },
             ]}
             onPress={() => router.push('/gallery')}
             accessibilityRole="button"
+            accessibilityLabel={t('home.galleryButton')}
           >
             <Text style={[styles.secondaryTileText, { color: colors.primary }]}>
               {t('home.galleryButton')}
             </Text>
-          </TouchableOpacity>
+          </PressableScale>
 
-          <TouchableOpacity
+          <PressableScale
             style={[
               styles.secondaryTile,
               { backgroundColor: colors.surface, borderColor: colors.primary },
             ]}
             onPress={() => router.push('/creative')}
             accessibilityRole="button"
+            accessibilityLabel={t('home.creativeButton')}
           >
             <Text style={[styles.secondaryTileText, { color: colors.primary }]}>
               🎨 {t('home.creativeButton')}
             </Text>
-          </TouchableOpacity>
-        </View>
+          </PressableScale>
+        </AnimatedCard>
 
         {/* Quick Stats — dezent am unteren Rand */}
         <QuickStatsCards />

--- a/components/AnimatedPrimitives.tsx
+++ b/components/AnimatedPrimitives.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { Pressable, Text, TextStyle, ViewStyle } from 'react-native';
+import { Pressable, StyleProp, Text, TextStyle, ViewStyle } from 'react-native';
 import { useReduceMotion } from '../utils/useReduceMotion';
 import Animated, {
   useSharedValue,
@@ -7,6 +7,9 @@ import Animated, {
   withTiming,
   withSpring,
   withDelay,
+  withRepeat,
+  withSequence,
+  cancelAnimation,
   Easing,
 } from 'react-native-reanimated';
 import Colors from '../constants/Colors';
@@ -147,6 +150,7 @@ export function AnimatedButton({
   accessibilityRole?: 'button' | 'link';
   [key: string]: any;
 }) {
+  const reduceMotion = useReduceMotion();
   const scale = useSharedValue(1);
 
   const animatedStyle = useAnimatedStyle(() => ({
@@ -154,10 +158,12 @@ export function AnimatedButton({
   }));
 
   const handlePressIn = () => {
+    if (reduceMotion) return;
     scale.value = withSpring(0.95, { damping: 15, stiffness: 300 });
   };
 
   const handlePressOut = () => {
+    if (reduceMotion) return;
     scale.value = withSpring(1, { damping: 15, stiffness: 300 });
   };
 
@@ -286,6 +292,118 @@ export function AnimatedStar({
   return (
     <Animated.View style={animatedStyle}>
       <Text style={textStyle}>★</Text>
+    </Animated.View>
+  );
+}
+
+/**
+ * Generic pressable with a spring scale-down on press for tactile feedback.
+ * Gives bare tiles/cards the same responsiveness as `Button` without adopting
+ * its full visual style. Respects prefers-reduced-motion.
+ */
+export function PressableScale({
+  onPress,
+  style,
+  disabled,
+  children,
+  activeScale = 0.96,
+  accessibilityLabel,
+  accessibilityRole = 'button',
+  accessibilityState,
+  testID,
+  ...rest
+}: {
+  onPress?: () => void;
+  style?: StyleProp<ViewStyle>;
+  disabled?: boolean;
+  children: React.ReactNode;
+  activeScale?: number;
+  accessibilityLabel?: string;
+  accessibilityRole?: 'button' | 'link';
+  accessibilityState?: { disabled?: boolean; selected?: boolean };
+  testID?: string;
+  [key: string]: any;
+}) {
+  const reduceMotion = useReduceMotion();
+  const scale = useSharedValue(1);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
+
+  const handlePressIn = () => {
+    if (reduceMotion || disabled) return;
+    scale.value = withSpring(activeScale, { damping: 15, stiffness: 300 });
+  };
+
+  const handlePressOut = () => {
+    if (reduceMotion) return;
+    scale.value = withSpring(1, { damping: 15, stiffness: 300 });
+  };
+
+  return (
+    <AnimatedPressable
+      onPress={onPress}
+      onPressIn={handlePressIn}
+      onPressOut={handlePressOut}
+      disabled={disabled}
+      style={[animatedStyle, style]}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole={accessibilityRole}
+      accessibilityState={accessibilityState}
+      testID={testID}
+      {...rest}
+    >
+      {children}
+    </AnimatedPressable>
+  );
+}
+
+/**
+ * Looping "breathing" pulse that draws the eye to a primary action.
+ * Subtle scale oscillation, meant to wrap a CTA. Static (no loop) when
+ * prefers-reduced-motion is on or `enabled` is false.
+ */
+export function PulseView({
+  children,
+  style,
+  enabled = true,
+  maxScale = 1.04,
+  testID,
+}: {
+  children: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+  enabled?: boolean;
+  maxScale?: number;
+  testID?: string;
+}) {
+  const reduceMotion = useReduceMotion();
+  const scale = useSharedValue(1);
+
+  useEffect(() => {
+    if (reduceMotion || !enabled) {
+      cancelAnimation(scale);
+      scale.value = 1;
+      return;
+    }
+    scale.value = withRepeat(
+      withSequence(
+        withTiming(maxScale, { duration: 1100, easing: Easing.inOut(Easing.ease) }),
+        withTiming(1, { duration: 1100, easing: Easing.inOut(Easing.ease) }),
+      ),
+      -1,
+      false,
+    );
+    return () => cancelAnimation(scale);
+  }, [reduceMotion, enabled, maxScale, scale]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
+
+  return (
+    <Animated.View style={[animatedStyle, style]} testID={testID} pointerEvents="box-none">
+      {children}
     </Animated.View>
   );
 }

--- a/components/OnboardingModal.tsx
+++ b/components/OnboardingModal.tsx
@@ -83,7 +83,12 @@ export default function OnboardingModal({ visible, onClose, onStartTutorial }: P
     onClose();
   };
 
-  const handleStart = () => {
+  const handleStart = async () => {
+    // Onboarding gilt als erledigt, sobald der Nutzer bewusst „Spielen!" tippt —
+    // nicht erst nach der ersten Bewertung. Sonst erscheint dieser Vollbild-Modal
+    // bei jedem App-Start erneut, falls die erste Runde abgebrochen wird. Die
+    // In-Game-Coach-Marks (?tutorial=1) führen weiterhin durch diese erste Runde.
+    await markOnboardingDone();
     onStartTutorial();
   };
 

--- a/components/__tests__/AnimatedPrimitivesExtras.test.tsx
+++ b/components/__tests__/AnimatedPrimitivesExtras.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { render, act, fireEvent } from '@testing-library/react-native';
+import { Text, Pressable } from 'react-native';
+
+jest.mock('../../utils/useReduceMotion', () => ({
+  useReduceMotion: jest.fn(() => false),
+}));
+
+jest.mock('react-native-reanimated', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: {
+      View,
+      createAnimatedComponent: (c: any) => c,
+    },
+    cancelAnimation: jest.fn(),
+    useSharedValue: (v: any) => ({ value: v }),
+    useAnimatedStyle: (_fn: any) => ({}),
+    withTiming: (v: any) => v,
+    withSpring: (v: any) => v,
+    withDelay: (_d: any, v: any) => v,
+    withRepeat: jest.fn((v: any) => v),
+    withSequence: (...args: any[]) => args[args.length - 1],
+    Easing: {
+      ease: (t: number) => t,
+      inOut: (fn: any) => fn,
+      out: (fn: any) => fn,
+    },
+  };
+});
+
+const Reanimated = require('react-native-reanimated');
+const withRepeatMock = Reanimated.withRepeat as jest.Mock;
+
+import { PressableScale, PulseView } from '../AnimatedPrimitives';
+
+const getAllTexts = (getAllByType: (t: any) => any[]) =>
+  getAllByType(Text)
+    .map((n: any) => n.props.children)
+    .flat()
+    .map(String);
+
+describe('PressableScale', () => {
+  it('renders its children', () => {
+    const { UNSAFE_getAllByType } = render(
+      <PressableScale onPress={() => {}}>
+        <Text>Los geht&apos;s</Text>
+      </PressableScale>,
+    );
+    expect(getAllTexts(UNSAFE_getAllByType)).toContain("Los geht's");
+  });
+
+  it('calls onPress when pressed', () => {
+    const onPress = jest.fn();
+    const { UNSAFE_getAllByType } = render(
+      <PressableScale onPress={onPress}>
+        <Text>Tap</Text>
+      </PressableScale>,
+    );
+    fireEvent.press(UNSAFE_getAllByType(Pressable)[0]);
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('PulseView', () => {
+  beforeEach(() => {
+    const { useReduceMotion } = require('../../utils/useReduceMotion');
+    (useReduceMotion as jest.Mock).mockReturnValue(false);
+    withRepeatMock.mockClear();
+  });
+
+  it('renders its children', () => {
+    const { UNSAFE_getAllByType } = render(
+      <PulseView>
+        <Text>Pulsing</Text>
+      </PulseView>,
+    );
+    expect(getAllTexts(UNSAFE_getAllByType)).toContain('Pulsing');
+  });
+
+  it('starts a repeating pulse when enabled and motion is allowed', async () => {
+    render(
+      <PulseView>
+        <Text>Pulsing</Text>
+      </PulseView>,
+    );
+    await act(async () => {});
+    expect(withRepeatMock).toHaveBeenCalled();
+  });
+
+  it('does not pulse when disabled', async () => {
+    render(
+      <PulseView enabled={false}>
+        <Text>Static</Text>
+      </PulseView>,
+    );
+    await act(async () => {});
+    expect(withRepeatMock).not.toHaveBeenCalled();
+  });
+
+  it('does not pulse when prefers-reduced-motion is enabled', async () => {
+    const { useReduceMotion } = require('../../utils/useReduceMotion');
+    (useReduceMotion as jest.Mock).mockReturnValue(true);
+
+    render(
+      <PulseView>
+        <Text>Static</Text>
+      </PulseView>,
+    );
+    await act(async () => {});
+    expect(withRepeatMock).not.toHaveBeenCalled();
+  });
+});

--- a/components/__tests__/GamePhaseComponents.test.tsx
+++ b/components/__tests__/GamePhaseComponents.test.tsx
@@ -84,6 +84,19 @@ jest.mock('../../components/AnimatedPrimitives', () => {
         </TouchableOpacity>
       );
     },
+    PulseView: ({ children }: any) => <View>{children}</View>,
+    PressableScale: ({ children, onPress, accessibilityLabel, disabled }: any) => {
+      const { TouchableOpacity } = require('react-native');
+      return (
+        <TouchableOpacity
+          onPress={onPress}
+          accessibilityLabel={accessibilityLabel}
+          disabled={disabled}
+        >
+          {children}
+        </TouchableOpacity>
+      );
+    },
   };
 });
 

--- a/components/__tests__/HomeScreen.test.tsx
+++ b/components/__tests__/HomeScreen.test.tsx
@@ -1,6 +1,30 @@
 import React from 'react';
 import { render, act } from '@testing-library/react-native';
 
+jest.mock('react-native-reanimated', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: {
+      View,
+      createAnimatedComponent: (c: any) => c,
+    },
+    cancelAnimation: jest.fn(),
+    useSharedValue: (v: any) => ({ value: v }),
+    useAnimatedStyle: (_fn: any) => ({}),
+    withTiming: (v: any) => v,
+    withSpring: (v: any) => v,
+    withDelay: (_d: any, v: any) => v,
+    withRepeat: jest.fn((v: any) => v),
+    withSequence: (...args: any[]) => args[args.length - 1],
+    Easing: {
+      ease: (t: number) => t,
+      inOut: (fn: any) => fn,
+      out: (fn: any) => fn,
+    },
+  };
+});
+
 jest.mock('expo-router', () => ({
   useRouter: () => ({ push: jest.fn() }),
   useFocusEffect: (cb: () => (() => void) | void) => {

--- a/components/__tests__/OnboardingModal.test.tsx
+++ b/components/__tests__/OnboardingModal.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { Pressable } from 'react-native';
+
+// Der echte react-native Modal lässt sich unter react-test-renderer/jsdom nicht
+// sichtbar mounten (parentInstance.children.indexOf). Alle anderen Exports bleiben
+// unverändert; nur Modal wird zu einem Passthrough, damit der Inhalt gerendert wird.
+jest.mock('react-native', () => {
+  const RN = jest.requireActual('react-native');
+  const ReactLocal = require('react');
+  return new Proxy(RN, {
+    get(target, prop) {
+      if (prop === 'Modal') {
+        return ({ children, visible = true }: any) =>
+          visible ? ReactLocal.createElement(target.View, null, children) : null;
+      }
+      return target[prop as keyof typeof target];
+    },
+  });
+});
+
+jest.mock('react-native-reanimated', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: {
+      View,
+      createAnimatedComponent: (c: any) => c,
+    },
+    cancelAnimation: jest.fn(),
+    useSharedValue: (v: any) => ({ value: v }),
+    useAnimatedStyle: (_fn: any) => ({}),
+    withTiming: (v: any) => v,
+    withRepeat: jest.fn((v: any) => v),
+    withSequence: (...args: any[]) => args[args.length - 1],
+    Easing: { ease: (t: number) => t, inOut: (fn: any) => fn, out: (fn: any) => fn },
+  };
+});
+
+jest.mock('../../utils/useReduceMotion', () => ({
+  useReduceMotion: jest.fn(() => true),
+}));
+
+jest.mock('../../services/OnboardingManager', () => ({
+  markOnboardingDone: jest.fn(async () => {}),
+}));
+const { markOnboardingDone } = require('../../services/OnboardingManager') as {
+  markOnboardingDone: jest.Mock;
+};
+
+jest.mock('../../services/i18n', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../../services/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      background: '#fff',
+      surface: '#eee',
+      surfaceAlt: '#ddd',
+      text: { primary: '#000', secondary: '#666', light: '#999' },
+    },
+  }),
+}));
+
+import OnboardingModal from '../OnboardingModal';
+
+describe('OnboardingModal', () => {
+  beforeEach(() => {
+    markOnboardingDone.mockClear();
+  });
+
+  // Reihenfolge der Pressables im JSX: [0] = Skip, [1] = Start.
+  const renderModal = () => {
+    const onClose = jest.fn();
+    const onStartTutorial = jest.fn();
+    const utils = render(
+      <OnboardingModal visible onClose={onClose} onStartTutorial={onStartTutorial} />,
+    );
+    return { onClose, onStartTutorial, ...utils };
+  };
+
+  it('marks onboarding done and starts the tutorial when "Spielen!" is tapped', async () => {
+    const { onStartTutorial, UNSAFE_getAllByType } = renderModal();
+    fireEvent.press(UNSAFE_getAllByType(Pressable)[1]);
+    // handleStart ist async: markOnboardingDone läuft vor onStartTutorial
+    await Promise.resolve();
+    expect(markOnboardingDone).toHaveBeenCalledTimes(1);
+    expect(onStartTutorial).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks onboarding done and closes when skipped', async () => {
+    const { onClose, UNSAFE_getAllByType } = renderModal();
+    fireEvent.press(UNSAFE_getAllByType(Pressable)[0]);
+    await Promise.resolve();
+    expect(markOnboardingDone).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/game/DrawPhase.tsx
+++ b/components/game/DrawPhase.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Alert, Platform, FlatList } from 'react-native';
 import DrawingCanvas from '@components/DrawingCanvas';
 import { ErrorBoundary } from '@components/ErrorBoundary';
+import { PressableScale } from '@components/AnimatedPrimitives';
 import { DrawingColors } from '../../constants/Colors';
 import Colors from '../../constants/Colors';
 import { PenIcon, FillIcon, EyeIcon } from './ToolIcons';
@@ -204,7 +205,11 @@ export default function DrawPhase({
           {t('game.draw.clear')}
         </Text>
       </TouchableOpacity>
-      <TouchableOpacity style={styles.primaryButton} onPress={onDone}>
+      <PressableScale
+        style={styles.primaryButton}
+        onPress={onDone}
+        accessibilityLabel={t('game.draw.done')}
+      >
         <Text
           style={[styles.primaryButtonText, layout.isSmall && styles.buttonTextSmall]}
           numberOfLines={1}
@@ -213,7 +218,7 @@ export default function DrawPhase({
         >
           {t('game.draw.done')}
         </Text>
-      </TouchableOpacity>
+      </PressableScale>
     </View>
   );
 

--- a/components/game/ResultPhase.tsx
+++ b/components/game/ResultPhase.tsx
@@ -4,7 +4,12 @@ import DrawingCanvas from '@components/DrawingCanvas';
 import LevelImageDisplay from '@components/LevelImageDisplay';
 import Mascot from '@components/Mascot';
 import MascotSparkle from '@components/MascotSparkle';
-import { AnimatedFeedback, AnimatedStar } from '@components/AnimatedPrimitives';
+import {
+  AnimatedFeedback,
+  AnimatedStar,
+  PressableScale,
+  PulseView,
+} from '@components/AnimatedPrimitives';
 import Colors from '../../constants/Colors';
 import { Spacing, FontSize, FontWeight, BorderRadius } from '../../constants/Layout';
 import { getTotalLevels } from '@services/LevelManager';
@@ -229,23 +234,30 @@ export default function ResultPhase({
           </AnimatedFeedback>
         </View>
 
-        {/* 3. Weiter — prominenter primärer CTA */}
+        {/* 3. Weiter — prominenter primärer CTA. Sanfter Puls (erst nach Bewertung)
+            zieht in die nächste Runde; Press-Feedback via PressableScale. */}
         {levelNumber < getTotalLevels() ? (
-          <TouchableOpacity
-            style={styles.nextLevelButton}
-            onPress={onNextLevel}
-            accessibilityRole="button"
-          >
-            <Text style={styles.nextLevelButtonText}>{t('game.result.nextLevel')} →</Text>
-          </TouchableOpacity>
+          <PulseView enabled={userRating > 0}>
+            <PressableScale
+              style={styles.nextLevelButton}
+              onPress={onNextLevel}
+              accessibilityRole="button"
+              accessibilityLabel={t('game.result.nextLevel')}
+            >
+              <Text style={styles.nextLevelButtonText}>{t('game.result.nextLevel')} →</Text>
+            </PressableScale>
+          </PulseView>
         ) : (
-          <TouchableOpacity
-            style={styles.nextLevelButton}
-            onPress={onRestartFromLevel1}
-            accessibilityRole="button"
-          >
-            <Text style={styles.nextLevelButtonText}>🔄 {t('game.result.playAgain')}</Text>
-          </TouchableOpacity>
+          <PulseView enabled={userRating > 0}>
+            <PressableScale
+              style={styles.nextLevelButton}
+              onPress={onRestartFromLevel1}
+              accessibilityRole="button"
+              accessibilityLabel={t('game.result.playAgain')}
+            >
+              <Text style={styles.nextLevelButtonText}>🔄 {t('game.result.playAgain')}</Text>
+            </PressableScale>
+          </PulseView>
         )}
       </ScrollView>
     </>

--- a/services/ShareService.native.ts
+++ b/services/ShareService.native.ts
@@ -4,7 +4,10 @@
  * via expo-sharing. Metro loads this file on native, ShareService.ts on web.
  */
 import type { DrawingPath } from '@components/DrawingCanvas.shared';
-import * as FileSystem from 'expo-file-system';
+// Expo SDK 54+ verschob die klassische Datei-API (cacheDirectory, writeAsStringAsync,
+// EncodingType) nach `expo-file-system/legacy`. Der Default-Export bietet stattdessen
+// die neue File/Paths-Klassen-API (Issue: TS-Fehler in ShareService.native.ts).
+import * as FileSystem from 'expo-file-system/legacy';
 import * as Sharing from 'expo-sharing';
 import { Skia, ImageFormat, PaintStyle, StrokeCap, StrokeJoin } from '@shopify/react-native-skia';
 import { computeNativeFillLayers } from './NativeFillLayerService';


### PR DESCRIPTION
## Beschreibung

Optische Aufwertung + strukturelle Nutzerführung zur Verbesserung der Retention. Zwei wiederverwendbare, `prefers-reduced-motion`-aware Animations-Primitiven eingeführt und auf den Kern-Screens angewandt; zusätzlich eine konkrete Reibung im First-Run-Flow behoben und offene TypeScript-Fehler bereinigt.

### 1. Micro-Animationen

Neue Primitiven in `AnimatedPrimitives.tsx`:
- `PressableScale` — Spring-Scale-Down beim Drücken; taktiles Feedback für Kacheln, die vorher nur `TouchableOpacity` waren.
- `PulseView` — sanfter Dauer-Puls (Aufmerksamkeits-Hinweis für Primär-CTAs; `enabled`-Prop).
- `AnimatedButton` respektiert jetzt ebenfalls `prefers-reduced-motion`.

Anwendung:
- **Home:** Hero-CTA „Spiel starten" pulsiert dezent + Press-Feedback; Daily-Challenge und Sekundär-Kacheln bekommen Press-Feedback + gestaffelte Eingangs-Animation.
- **Result:** „Weiter"/„Nochmal"-CTA pulsiert nach abgegebener Bewertung (zieht in die nächste Runde) + Press-Feedback.
- **Draw:** primäre „Fertig"-Aktion mit Press-Feedback.

### 2. Klarere First-Run-Führung (Onboarding-Flow)

- `markOnboardingDone()` wird jetzt bereits beim bewussten Tippen auf „Spielen!" gesetzt, nicht erst nach der ersten Sternebewertung. **Vorher** erschien der Vollbild-`OnboardingModal` bei *jedem* App-Start erneut, wenn ein Erst-Nutzer die erste Runde abbrach — eine typische Retention-Reibung. Die In-Game-Coach-Marks (`?tutorial=1`) führen weiterhin durch die erste Runde; der Post-Rating-Aufruf in `game.tsx` bleibt als idempotentes Sicherheitsnetz.

### 3. TypeScript-Cleanup

- `ShareService.native.ts` nutzt jetzt `expo-file-system/legacy` (Expo SDK 54+ verschob `cacheDirectory`/`writeAsStringAsync`/`EncodingType` dorthin). Behebt zwei vorbestehende `tsc`-Fehler **ohne Verhaltensänderung** — `npx tsc --noEmit` ist jetzt vollständig sauber (0 Fehler).

## Art der Änderung

- [x] Neue Funktion (non-breaking change)
- [x] Bugfix (Onboarding-Re-Nag, ShareService-Typen)
- [x] Dokumentation Update (CLAUDE.md: neue Primitiven dokumentiert)

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Ja (nur `ShareService.native.ts` — reiner Import-Pfad-Wechsel innerhalb `expo-file-system`, keine Web-API-Nutzung, keine Verhaltensänderung). Alle Animationen sind `prefers-reduced-motion`-aware.

## Testing Checklist

- [x] Keine TypeScript Errors (`npx tsc --noEmit` sauber, 0 Fehler)
- [x] Keine ESLint Warnings
- [x] Neue Test-Suites: `AnimatedPrimitivesExtras` (PressableScale/PulseView inkl. reduced-motion) + `OnboardingModal` (Start/Skip markieren Onboarding als erledigt) — **alle 423 Tests grün**

## Zusätzliche Notizen

Additive, in sich reversible Änderungen: keine neuen Dependencies, kein neues State-System. Vorhandene Infrastruktur (`useReduceMotion`, `AnimatedCard`) wird wiederverwendet statt dupliziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)