### PR TITLE
CI-Workflows nur noch bei PRs gegen main triggern

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, testing]
   pull_request:
-    branches: [main, testing]
+    branches: [main]
 
 # Security: Explicitly set minimal permissions
 permissions:

--- a/.github/workflows/standards-audit.yml
+++ b/.github/workflows/standards-audit.yml
@@ -11,7 +11,7 @@ name: Standards Audit
 
 on:
   pull_request:
-    branches: [main, testing]
+    branches: [main]
   repository_dispatch:
     types: [weekly-self-audit]
   workflow_dispatch: {}


### PR DESCRIPTION
Beschränkt die CI-Workflows auf PRs gegen `main`.

## Hintergrund

Die required Status Checks wurden repo-übergreifend aus dem `testing`-Gate entfernt. Neue Ruleset-Struktur in allen Repos:

| Ruleset | Branch | Regeln |
|---|---|---|
| `protect-main` | `main` | deletion, non-fast-forward, pull_request, **required status checks** |
| `protect-testing` | `testing` | deletion, non-fast-forward, pull_request (**keine** Checks) |

Da CI-Läufe auf `testing`-PRs damit nicht mehr merge-relevant sind, waren sie reine Ressourcenverschwendung.

## Änderung

```diff
 pull_request:
-    branches: [main, testing]
+    branches: [main]
```

- Betrifft die CI- und Standards-Audit-Workflows
- Der `push`-Trigger bleibt **unverändert**
- Das volle Gate greift weiterhin beim PR `testing` → `main`

## Hinweis

`testing` behält Löschschutz, Force-Push-Schutz und PR-Pflicht — es entfällt ausschließlich das CI-Gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)